### PR TITLE
support rss

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,9 +1,10 @@
 [book]
+title = "Rust精选"
 authors = ["blackanger"]
+description = "The roots aren't deep but the seeds are planted!"
 language = "zh_CN"
 multilingual = false
 src = "src"
-title = "rust-magazine"
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
@@ -23,6 +24,10 @@ copy-js = true
 [output.html.fold]
 enable = true
 level = 0
+
+[preprocessor.rss]
+files-glob = "chapter_*/**/*.md"
+url-base = "https://rustmagazine.github.io/rust_magazine_2021/"
 
 # [output.latex]
 # latex    = true  # default = true

--- a/src/rss.xml
+++ b/src/rss.xml
@@ -1,0 +1,21246 @@
+<?xml version="1.0" encoding="utf-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title>Rust精选</title><link></link><description>The roots aren&apos;t deep but the seeds are planted!</description><generator>mdbook-rss 0.1.0</generator><item><title>本月简报 | Rust官方动态</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/lang.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报：官方动态'>本月简报：官方动态</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>专题编辑：张汉东</li>
+</ul>
+
+<hr><h2 id='rust_1.49_稳定版发布'>Rust 1.49 稳定版发布</h2>
+
+<p>2020年最后一天，Rust 1.49 稳定版发布了。稳定版 Rust 发布周期为六周一次。</p>
+
+<p>值得关注的更新：</p>
+
+<ul>
+<li><code>aarch64-unknown-linux-gnu</code> 升级为<code>Tier 1</code>。</li>
+
+<li><code>aarch64-apple-darwin</code> 和<code>aarch64-pc-windows-msvc</code> 得到<code>Tier 2</code> 级别的支持。</li>
+
+<li>单元测试中线程中的print输出将会被捕获，默认不会在控制台打印出来了。如果不需要捕获，需要添加--nocapture参数。</li>
+
+<li><code>union</code>支持 <code>impl Drop trait</code> 了 支持使用<code>ref</code>关键字让解构的字段不再被move 而是被借用。</li>
+</ul>
+
+<pre><code class="language-`rust,editable">#[derive(Debug)]
+struct Person {
+    name: String,
+    age: u8,
+}
+
+fn main(){
+    let person = Person {
+    name: String::from(&quot;Alice&quot;),
+    age: 20,
+    };
+
+    // `name` is moved out of person, but `age` is referenced.
+    let Person { name, ref age } = person;
+    println!(&quot;{} {}&quot;, name, age);
+}</code></pre>
+
+<p><a href='https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html'>https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html</a></p>
+
+<h2 id='rust_将不再支持_windows_xp'>Rust 将不再支持 Windows XP</h2>
+
+<p>目标i686-pc-windows-msvc和x86_64-pc-windows-msvc是个怪胎。它们对Windows 7+有Tier 1支持，但对Windows XP也有Tier 3支持。这是Firefox需要在XP上运行时的遗留问题。然而在他们放弃XP支持后的几年里，尽管偶尔会有修复，但大多都是任由它过期了。</p>
+
+<p>因此有人建议，正式放弃这个Tier 3支持状态，可以更好地反映出目前对XP的实际支持程度，不再让一个Tier 1目标背负着实际上不支持Tier 3目标的担忧。</p>
+
+<p>只要LLVM和他们的链接器仍然支持XP目标，移除官方的XP支持不会阻止任何人编译到XP（减去std）。</p>
+
+<p>对Windows 7以上的目标的影响将是移除工作区和一个支持XP的运行时兼容性层。此外，还有可能使用更现代的API，而这些API可能曾经因为兼容性问题而被避免。</p>
+
+<p>如果在未来，有人积极支持XP，那么最好的办法是为此创建一个新的目标。这可以从其自身的优点出发，而且它的开发不会影响到一级平台的开发。</p>
+
+<p>官方团队接受了该建议。</p>
+
+<p><a href='https://github.com/rust-lang/compiler-team/issues/378'>https://github.com/rust-lang/compiler-team/issues/378</a></p>
+
+<h2 id='rustup_宣布发布_1.23.0_版本'>Rustup 宣布发布 1.23.0 版本</h2>
+
+<p>官方发布 1.23.0 版本，其中最激动人心的改变就是支持 Apple M1 设备。大家可以安心的买 M1 了！</p>
+
+<p><a href='https://blog.rust-lang.org/2020/11/27/Rustup-1.23.0.html'>原文链接</a></p>
+
+<h2 id='rust_官方知名开发者陆续入职巨头科技公司'>Rust 官方知名开发者陆续入职巨头科技公司</h2>
+
+<p><strong>Niko Matsakis，Esteband K 入职 Amazon</strong></p>
+
+<p>Niko Matsakis 入职 Amazon 担任 Rust 团队的技术主管。</p>
+
+<pre><code class="language-`">Niko的博客链接: https://smallcultfollowing.com/babysteps/blog/2020/12/30/the-more-things-change/</code></pre>
+
+<p>Esteband K 入职 Amazon 研究 Rust 编译器和相关工具。</p>
+
+<pre><code class="language-`">Twitter 链接：https://mobile.twitter.com/ekuber/status/1345218814087053312</code></pre>
+
+<p><strong>Patrick Walton 入职 Facebook</strong></p>
+
+<p>Patrick Walton 将领导 Facebook 的新 Rust 团队，致力于为 Rust 社区改善其编译器和生态。</p>
+
+<pre><code class="language-`">Twitter 链接：https://twitter.com/pcwalton/status/1345094455712333824</code></pre>
+
+<h2 id='futures-rs_0.3.9_发布'>futures-rs 0.3.9 发布</h2>
+
+<ul>
+<li>把<code>pin-project</code>这个<code>crate</code>替换成了<code>pin-project-lite</code>, 在<code>--no-default-features</code>的情况下大幅提高了编译速度.</li>
+
+<li>
+<p>增加了几个新的API方法</p>
+
+<ul>
+<li>stream::repeat_with</li>
+
+<li>StreamExt::unzip</li>
+
+<li>sink::unfold</li>
+
+<li>SinkExt::feed</li>
+</ul>
+</li>
+</ul>
+
+<p>链接：<a href='https://github.com/rust-lang/futures-rs/releases/tag/0.3.9'>https://github.com/rust-lang/futures-rs/releases/tag/0.3.9</a></p>
+
+<h2 id='rust_异常处理小组的工作范围是什么？'>Rust 异常处理小组的工作范围是什么？</h2>
+
+<p>该小组的主要重点是继续进行小组成立前的错误处理相关工作。为此而努力系统地解决与错误处理相关的问题，以及消除阻碍RFC停滞不前的障碍。</p>
+
+<p>在小组成立的最初几次会议上，制定了一些短期和长期目标，这些目标主要围绕下面三个主题：</p>
+
+<ul>
+<li>使 <code>Error</code> trait 在生态中应用更加普及。</li>
+
+<li>提升错误处理的开发体验。</li>
+
+<li>编写更多的关于错误处理的学习资源。</li>
+</ul>
+
+<p>下面具体来说。</p>
+
+<p><strong>建立统一的标准<code>Error</code> trait。</strong></p>
+
+<p><code>Error</code> trait 从 <code>1.0</code>开始就存在了，并暴露了两个方法。<code>Error::description</code>和<code>Error::cause</code>。由于它最初的构造，由于一些原因，它太过拘谨。<code>Failure</code> crate通过导出Fail trait解决了Error trait的许多缺点。</p>
+
+<p>在这一点上，加强<code>std::error::Error</code> trait，使其可以作为<code>Error</code> trait被整个Rust社区采用，自2018年8月RFC 2504被合并以来，一直是一个持续的过程。</p>
+
+<p>这个过程还涉及稳定许多<code>Error</code> trait API和<code>crates</code>，截至本文撰写时，这些API和crates只在Nightly使用。这些包括backtrace和chain方法，这两种方法对于处理错误类型非常有用。如果你有兴趣关注或贡献这项工作，请看一下这个问题。</p>
+
+<p>另一个相关的举措是将<code>Error</code> trait迁移到核心，这样它就可以更广泛地用于不同的场景（比如在FFI或嵌入式上下文中）。</p>
+
+<p><strong>增加通过回溯（backtrace）类型进行迭代的能力</strong></p>
+
+<p>到目前为止，<code>backtrace</code> 类型只实现了<code>Display</code>和<code>Debug</code>特征。这意味着使用回溯类型的唯一方法是打印出来，这不是很理想。一个能够提供迭代堆栈框架的迭代器API将使用户能够控制他们的反向跟踪如何被格式化，这是一个必要的步骤，将<code>std::backtrace::Backtrace</code>支持添加到像<code>color-backtrace</code>这样的箱子中。</p>
+
+<p>在研究了如何解决这个问题的策略后，我们发现回溯箱已经有了一个框架方法，可以很好地实现<code>Iterator</code> API。在std中公开一个相同的方法应该是一个相对简单的考验。</p>
+
+<p>我们已经为此开了一个<code>[PR](https://github.com/rust-lang/rust/pull/78299)</code>，如果有人想看的话，可以去看看。</p>
+
+<p><strong>通用成员访问</strong></p>
+
+<p>目前，当我们想要获取一些与错误相关的额外上下文时，需要调用一些特定的方法来获取该上下文。例如，如果要查看一个错误的回溯，我们会调用回溯方法： <code>let backtrace = some_error.backtrace();</code>。这种方法的问题是，它不可能支持在<code>std</code>之外定义的类型。即使是存在于<code>std</code>内的类型，也需要定义一个方法来访问每个各自的类型，这使得事情变得很麻烦，而且更难维护。</p>
+
+<p>顾名思义，通用成员访问，当它得到实现时，是一种类型无关的方法，可以从<code>Error</code> trait对象中访问不同的上下文。这有个类比示例，当你要把一个字符串解析成一个数字的时候，用这样的方法。</p>
+
+<pre><code class="language-`rust">let ten = &quot;10&quot;.parse::&lt;i32&gt;();</code></pre>
+
+<p>或者通过迭代器来collect生成的内容时：</p>
+
+<pre><code class="language-`rust">use std::collections::HashSet;
+
+let a_to_z_set = (&#8217;a&#8217;..=&#8217;z&#8217;).collect::&lt;HashSet&lt;_&gt;&gt;();</code></pre>
+
+<p>跟上面用法类似，您可以通过指定错误的类型ID来访问某个上下文片段。</p>
+
+<pre><code class="language-`rust">let span_trace = some_error.context::&lt;&amp;SpanTrace&gt;();</code></pre>
+
+<p>这可以用来获取与错误相关的其他上下文，如错误的回溯、错误的来源、状态码、替代的格式化表示（如&amp;dyn Serialize）。</p>
+
+<p>这个功能将使我们计划在以后添加的其他功能成为可能，比如提供一种方法来报告程序中错误来源的所有位置，以及提供一种除了显示和调试之外的更一致的错误报告格式。</p>
+
+<p>Jane在推动这些想法上做了很多工作。你可以查看相关的<a href='https://github.com/rust-lang/rfcs/pull/2895'>RFC</a>。</p>
+
+<p><strong>编写一本<code>Rust</code>错误处理最佳实践的书</strong></p>
+
+<p>最后但并非最不重要的一点是，围绕创作<a href='https://github.com/rust-lang/project-error-handling'>The Rust Error Book</a>的团队引起了很多兴趣。 本书的目的是根据各自的用例来整理和交流不同的错误处理最佳实践。 这可能包括FFI用例，或有关从程序返回错误代码的最佳实践。</p>
+
+<p>这是一项持续不断的工作，在接下来的几周和几个月中将会看到许多进步！</p>
+
+<p><strong>脚注</strong></p>
+
+<ul>
+<li><code>Error::description</code>方法只支持字符串片段，这意味着创建包含附加上下文的动态错误信息是不直接的。这个方法被弃用，改用<code>Display</code>。</li>
+
+<li><code>Error::cause</code>方法，现在被称为<code>Error::source</code>，并没有强制要求错误具有 &quot;静态生命周期&quot;，这意味着 downcasting 错误源是不可能的，这使得使用动态错误处理程序来处理错误变得更加困难。</li>
+</ul>
+
+<h2 id='rustdoc_性能提升'>Rustdoc 性能提升</h2>
+
+<p>有两个PR明确地旨在提高rustdoc的性能：</p>
+
+<ul>
+<li>Rustdoc：缓存已解析的链接<a href='https://github.com/rust-lang/rust/pull/77700'>＃77700</a>。该<code>PR</code>将文档生成的链接的时间缩短了 <code>90%</code>。</li>
+
+<li>不要在文档内链接中寻找覆盖实现（blanket-impls）<a href='https://github.com/rust-lang/rust/pull/79682'>＃79682</a>。因为它从来没有起过作用，并且已经引起了严重的性能问题。</li>
+</ul>
+
+<p>Rustdoc 团队还清理了一些技术债务。比如 <code>jyn514</code> 不久前注意到，Rustdoc中的大部分工作都是重复的: 实际上有三种不同的抽象语法树(ast)！一个用于doctree，一个用于clean，还有一个是编译器使用的原始HIR。Rustdoc花费了大量的时间在它们之间进行转换。大部分的速度改进来自于完全去掉部分AST。</p>
+
+<p>文章里也介绍了Rustdoc的工作原理：</p>
+
+<ul>
+<li>运行编译器的某些部分以获得需要的信息。</li>
+
+<li>删除编译器提供的不需要的信息（例如，如果一个项目是doc(hidden)，就不需要它）。这一部分有很多话要说，也许会再写一篇博文来详细介绍。</li>
+
+<li><code>doctree pass</code>，它在编译器的某些项目上添加了一些<code>rustdoc</code>需要的额外信息。</li>
+
+<li><code>clean pass</code>将编译器类型转换为<code>rustdoc</code>类型：基本上，它将所有内容都转换为 &quot;可打印 &quot;内容。</li>
+
+<li>渲染（render）通证，然后生成所需的输出（HTML 或，在Nightly，JSON）</li>
+</ul>
+
+<p>更多内容： <a href='https://blog.rust-lang.org/inside-rust/2021/01/15/rustdoc-performance-improvements.html'>https://blog.rust-lang.org/inside-rust/2021/01/15/rustdoc-performance-improvements.html</a></p>
+
+<h2 id='nightly的reference已上线const_generics的文档'>Nightly的Reference已上线Const Generics的文档</h2>
+
+<p>Const Generics 计划在1.50版进入stable，官方今天在nightly的Reference上已更新好相关文档。</p>
+
+<p>链接：<a href='https://doc.rust-lang.org/nightly/reference/items/generics.html#const-generics'>https://doc.rust-lang.org/nightly/reference/items/generics.html#const-generics</a></p>
+
+<h2 id='nightly_edition_guide_文档增加了_rust_2021_edition_小节'>Nightly Edition Guide 文档增加了 Rust 2021 Edition 小节</h2>
+
+<p>内容还在逐步更新，可以先关注。</p>
+
+<p>链接： <a href='https://doc.rust-lang.org/nightly/edition-guide/rust-next/index.html'>https://doc.rust-lang.org/nightly/edition-guide/rust-next/index.html</a></p>
+
+<h2 id='rfc_2945_:_"c_unwind"_abi_支持相关情况'>RFC 2945 : &quot;C unwind&quot; ABI 支持相关情况</h2>
+
+<p>官方 FFI-Unwind 项目工作组已经将 RFC 2945 合并了。该 RFC 描述了对 &quot;C unwind&quot; ABI 的支持。</p>
+
+<p>RFC 概要：</p>
+
+<p>&gt; &gt; 引入了一个新的<code>ABI</code>字符串“<code>C-unwind</code>”，以支持从其他语言(如c++)到Rust框架的<code>unwind</code>，以及从<code>Rust</code>到其他语言的<code>unwind</code>。此外，当<code>unwind</code>操作以“non <code>Rust</code>”、“non <code>C-unwind</code>”ABI到达<code>Rust</code>函数边界时，我们为之前未定义的有限几种情况定义了行为。作为该规范的一部分，我们引入了术语“Plain Old Frame”(POF)。POF帧不会挂起析构函数，可以轻松地释放析构函数。这个RFC没有定义被外部异常展开的Rust框架中的catch unwind行为。</p>
+
+<p>引入动机：</p>
+
+<p>&gt; &gt; 有些Rust项目需要跨语言展开以提供所需的功能。 一个主要的例子是<code>Wasm</code>解释器，包括<code>Lucet</code>和<code>Wasmer</code>项目。 &gt; &gt; 还有一些现有的<code>Rust</code> crate（尤其是围绕libpng和libjpeg C库的包装器）会在<code>C</code>帧之间出现混乱。 这种展开的安全性取决于Rust的展开机制与<code>GCC</code>，<code>LLVM</code>和<code>MSVC</code>中的本机异常机制之间的兼容性。 尽管使用了兼容的展开机制，但是当前的<code>rustc</code>实现假定“extern <code>C</code>”函数无法展开，这允许LLVM在这种展开构成未定义行为的前提下进行优化。 &gt; &gt; 之前已经在其他RFC（包括＃2699和＃2753）上讨论了对此功能的需求。</p>
+
+<p>RFC 2945: <a href='https://github.com/rust-lang/rfcs/blob/master/text/2945-c-unwind-abi.md'>https://github.com/rust-lang/rfcs/blob/master/text/2945-c-unwind-abi.md</a></p>
+
+<p>现在 FFI-unwind 工作组正在为<code>C-unwind</code> ABI 指定新的行为（覆盖之前的未定义的行为），<a href='https://github.com/rust-lang/rust/pull/76570'>RFC 2945 实现PR</a>。</p>
+
+<p>然而，在起草 &quot;<code>C unwind</code> &quot; RFC 时，工作组发现围绕<code>longjmp</code>和类似函数的现有保证可以改进。虽然这与<code>unwind</code>并没有严格的关系，但它们有着密切的联系：它们都是 <code>non-local</code> 的控制流机制，防止函数正常返回。由于<code>Rust</code>项目的目标之一是让<code>Rust</code>与现有的<code>C</code>系语言互操作，而这些控制流机制在实践中被广泛使用，工作组认为<code>Rust</code>必须对它们有一定程度的支持。</p>
+
+<p>这篇博文将解释该问题。如果你有兴趣帮助指定这种行为，欢迎参与!</p>
+
+<p>官方博文地址：<a href='https://blog.rust-lang.org/inside-rust/2021/01/26/ffi-unwind-longjmp.html'>https://blog.rust-lang.org/inside-rust/2021/01/26/ffi-unwind-longjmp.html</a></p>
+
+<h2 id='rust_playground_支持_vim_模式'>Rust Playground 支持 vim 模式</h2>
+
+<p>Rust Playground <code>vim</code> 模式，可以通过输入 <code>:w</code> 回车运行编译，非常棒的使用体验。</p>
+]]></content:encoded></item><item><title>本月简报 |社区热点</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/hots.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_社区热点'>本月简报 | 社区热点</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：Rust 日报小组</li>
+</ul>
+
+<h2 id='async-std_v1.9.0_发布'>Async-std v1.9.0 发布</h2>
+
+<p>这个版本发布了稳定的 <code>async_std::channel</code> 子模块，并引入了 tokio v1.0 的功能，同时，移除了不赞成使用的<code>sync::channel</code>类型。</p>
+
+<pre><code class="language-`rust">use async_std::channel;
+
+let (sender, receiver) = channel::unbounded();
+
+assert_eq!(sender.send(&quot;Hello&quot;).await, Ok(()));
+assert_eq!(receiver.recv().await, Ok(&quot;Hello&quot;));</code></pre>
+
+<p>链接，<a href='https://github.com/async-rs/async-std/releases/tag/v1.9.0'>https://github.com/async-rs/async-std/releases/tag/v1.9.0</a></p>
+
+<h2 id='deno_in_2020'>Deno in 2020</h2>
+
+<p>一直很火热的 Deno 官方最近发布了 Deno 的<a href='https://deno.land/posts/deno-in-2020'>大事记表</a>。 其中 1 月份进行了将 libdeno 替换成 rusty<em>v8 的工作。之前是使用 libdeno（C++ 写的） 来进行绑定 V8 的操作。现在替换成 Rust 原生实现的 rusty</em>v8。并且 rusty_v8 是一个单独的 Rust crate。</p>
+
+<h2 id='the_rust_on_raspberry_pi_pico_charity_live_stream'>The Rust on Raspberry Pi Pico Charity Live Stream</h2>
+
+<p>在树莓派上写 Rust 是一种怎样的体验？最近一位国外友人就尝试这么做了，并且进行了直播。具体详情可以<a href='https://www.reddit.com/r/rust/comments/l39jdo/the_rust_on_raspberry_pi_pico_charity_live_stream/'>戳此链接</a>。 Rust 在嵌入式开发领域还是有非常大的潜力的。</p>
+
+<p>想要看更多关于 Rust 的流媒体视频，可以关注这个项目 <a href='https://github.com/jamesmunns/awesome-rust-streaming'>awesome-rust-streaming</a></p>
+
+<h2 id='sequoia_pgp_发布_1.0_版本'>Sequoia PGP 发布 1.0 版本</h2>
+
+<ol type="2">
+<li>年，三位 GnuPG 开发者开始着手开发 Sequoia，这是 OpenPGP 在 Rust 中的实现版本。OpenPGP 是一种非专有协议，为加密消息、签名、私钥和用于交换公钥的证书定义了统一标准。</li>
+</ol>
+
+<p>通过<a href='https://sequoia-pgp.org/blog/2020/12/16/202012-1.0/'>官方博客</a>可以看出团队对当前版本对于安全性的思考和对未来下一步的规划。</p>
+
+<h2 id='firecracker'>Firecracker</h2>
+
+<p>Firecracker 是一种开源虚拟化技术，专门用于创建和管理安全的，多租户容器和基于功能的服务。</p>
+
+<p><a href='https://github.com/firecracker-microvm/firecracker'>项目地址</a></p>
+
+<h2 id='rust_gui_编程介绍'>Rust GUI 编程介绍</h2>
+
+<p>Rust GUI 方面的介绍以及目前 Rust GUI 库的现阶段状况</p>
+
+<p><a href='https://dev.to/davidedelpapa/rust-gui-introduction-a-k-a-the-state-of-rust-gui-libraries-as-of-january-2021-40gl#comments'>原文链接</a></p>
+
+<h2 id='facebook_使用_rust_的简单介绍'>Facebook 使用 Rust 的简单介绍</h2>
+
+<p>该 twitter 快速的介绍了 Rust 在 facebook 中的使用历程:</p>
+
+<ol type="2">
+<li>年开始应用于一个资源控制项目，后来证明性能和稳定性都比 C++好。 之后，更多的工程师开始使用 Rust 在各种项目中，例如 Diem，Hack，Mononoke。 在 dev tools 中证明 Rust 可行之后, 开始在后端和手机应用中使用 Rust 很多工程师来自 python 和 javascript 语言，Rust 的强类型和高性能让这些工程师不再挣扎于运行时的 bug。 为了让 Rust 更广泛的使用，设立了一个专门的 Rust 小组来支持其他的工程师在不同的项目中使用 Rust。 该小组同时在 Rust 社区中也非常活跃，贡献代码。</li>
+</ol>
+
+<p><a href='https://twitter.com/alexvoica/status/1350049393471324161'>原文链接</a></p>
+
+<h2 id='时隔一年_tower_终于发布新版本啦'>时隔一年 tower 终于发布新版本啦</h2>
+
+<p>Tower 是一个模块化和可重用组件库，用于构建健壮的网络客户端和服务器。上一个版本 0.3.1 版本是 2020 年 1 月 17 发布的，新版本 0.4.0 是 2021 年 1 月 7 号发布的，这个版本包含了大量改动，包括使用了 tokio 1.0，将所有的中间件转移到了 tower crate，改造，添加了中间件 API。</p>
+
+<p>不过这次变更并没有核心 Service 或者 Layer trait，所以新版本还是依赖着 tower- service 0.3 和 tower- layer 0.3，因此新版本是兼容使用这两个 crate 的库的。更多发布细节请移步下面的链接。</p>
+
+<p><a href='https://github.com/tower-rs/tower/releases/tag/tower-0.4.0'>原文链接</a></p>
+
+<p><a href='https://crates.io/crates/tower/0.4.0'>项目地址</a></p>
+
+<h2 id='rust_search_extension_1.1.0_发布'>Rust Search Extension 1.1.0 发布</h2>
+
+<p><a href='https://rust.extension.sh/'>Rust Search Extension</a> 发布了最新版，同时也突破了 500 个 star，感谢大家的支持！这个版本主要功能如下：</p>
+
+<ul>
+<li>! 搜索改成了 docs.rs，!! 改成了 crates.io。</li>
+
+<li>给 Rust 仓库的 release 页面增加了目录菜单。</li>
+
+<li>Rust 标准库文档页面和源码页面所有 &quot;since&quot; 和 &quot;issue&quot; 标签分别会链接到仓库的 release 页面对应的版本和 GitHub 对应的 issue 页。</li>
+</ul>
+
+<h2 id='为什么_2021_年将成为系统程序员的_rust_年？'>为什么 2021 年将成为系统程序员的 Rust 年？</h2>
+
+<p>Gartner 今天的一篇博文报道了“Rust”：近年来，Rust 获得了很多粉丝，并且有充分的理由。Rust 旨在成为满足系统编程需求的 C++ 的可靠替代品。</p>
+
+<p><a href='https://blogs.gartner.com/manjunath-bhat/2021/01/03/why-2021-will-be-a-rusty-year-for-system-programmers/'>原文链接</a></p>
+
+<h2 id='open_source_security,_inc.宣布为rust的gcc前端提供资金'>Open Source Security, Inc.宣布为Rust的GCC前端提供资金</h2>
+
+<p>Open Source Security, Inc.宣布为Rust的GCC前端提供资金 开源安全公司（Open Source Security，Inc）自豪地宣布，它为Rust的GCC前端的全职和公共开发工作提供了资金。在此博客文章中，作者将详细介绍我们参与的动机以及公众将因这项努力而获得的利益。</p>
+
+<p>原文链接 : <a href='https://opensrcsec.com/open_source_security_announces_rust_gcc_funding'>https://opensrcsec.com/open_source_security_announces_rust_gcc_funding</a></p>
+
+<h2 id='rust_gui框架的全调研'>Rust GUI框架的全调研</h2>
+
+<p>这篇文章对几乎目前Rust社区较为流行的GUI框架做了整体的调研，druid和iced表现还不错。</p>
+
+<ul>
+<li>原文链接： <a href='https://www.boringcactus.com/2020/08/21/survey-of-rust-gui-libraries.html'>https://www.boringcactus.com/2020/08/21/survey-of-rust-gui-libraries.html</a></li>
+
+<li>AreWeGuiYet 网站也可以看到 GUI 相关信息：<a href='https://www.areweguiyet.com/'>https://www.areweguiyet.com/</a></li>
+
+<li><a href='https://dev.to/davidedelpapa/rust-gui-introduction-a-k-a-the-state-of-rust-gui-libraries-as-of-january-2021-40gl#comments'>另一篇`GUI`调研文章</a></li>
+</ul>
+
+<h2 id='redox_os_最近公布了2020年的财务明细。'>Redox OS 最近公布了2020年的财务明细。</h2>
+
+<p>主要的收入是通过捐赠，包括Patreon网站，paypal,和接收到的一些比特币和以太坊。 《Redox OS Summer of Code》是主要的支出预算，其他网站服务的支出，包括亚马逊的EC2，Jenkins服务器，Gitlab服务。</p>
+
+<p>开源项目的明细能做到公开、明细还是非常值得社区学习的。</p>
+
+<p>原文链接: <a href='https://www.redox-os.org/news/finances-2020/'>https://www.redox-os.org/news/finances-2020/</a></p>
+
+<h2 id='rust_官方团队_wesley_wiser_宣布入职微软'>Rust 官方团队 Wesley Wiser 宣布入职微软</h2>
+
+<p>From Twitter:</p>
+
+<p>&gt; &gt; Wesley Wiser: I&#8217;m very pleased to announce that I will be joining @Microsoftto work on the @rustlang compiler team they are forming!</p>
+
+<p>Wesley Wiser 在 twitter 宣布：加入微软，并且为「微软组织的<code>Rust</code>编译器团队」工作。Wesley Wiser 在 2020 年 12 月刚出任 官方 Rust 编译器团队 co-Leader。</p>
+
+<p>到目前为止，编译器的三大 Leader ：Niko 和 Felix 去了亚马逊，Wesley Wiser 去了微软。之前 Facebook 也在招人组建 Rust 编译器团队，侧面反应出大厂们对 Rust 正在做战略布局。</p>
+
+<p>原文链接：<a href='https://twitter.com/wesleywiser/status/1354896012113022984'>https://twitter.com/wesleywiser/status/1354896012113022984</a></p>
+]]></content:encoded></item><item><title>本月简报 | 推荐项目</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/projects.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_推荐项目'>本月简报 | 推荐项目</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+</ul>
+
+<h2 id='「微软」rust_for_windows'>「微软」Rust for Windows</h2>
+
+<ul>
+<li><a href='https://github.com/microsoft/windows-rs'>仓库链接</a></li>
+
+<li><a href='https://microsoft.github.io/windows-docs-rs/doc/bindings/windows'>文档链接</a></li>
+
+<li><a href='https://crates.io/crates/windows'>crate 链接</a></li>
+</ul>
+
+<p>这个仓库是 1 月 20 日微软发布的官方 Win32 API crate。</p>
+
+<p>过去用 rust 为 Windows 开发应用程序时，若要调用 Win32 API，必须使用 <a href='https://github.com/retep998/winapi-rs'>winapi-rs</a> 这样的 wrapper 库，此类库需要社区去人工维护和 Win32 API 的绑定。 为了改善这点，微软通过 <a href='https://github.com/microsoft/win32metadata'>win32metadata</a> 项目来加强对 C/C++ 以外的编程语言的支持（<a href='https://blogs.windows.com/windowsdeveloper/2021/01/21/making-win32-apis-more-accessible-to-more-languages/'>相关链接</a>）， 其中就包括对 rust 的支持。</p>
+
+<p>现在已经有使用该库实现的<a href='https://github.com/robmikh/minesweeper-rs'>扫雷</a>程序, 除此之外，也有微软工程师发布了一些<a href='https://github.com/kennykerr/samples-rs'>示例项目</a>。</p>
+
+<h2 id='czkawka'>Czkawka</h2>
+
+<ul>
+<li><a href='https://github.com/qarmin/czkawka'>仓库链接</a></li>
+
+<li><a href='https://www.reddit.com/r/linux/comments/kjcbva/czkawka_200_multithread_support_similar_images/'>reddit 讨论</a></li>
+</ul>
+
+<p><em>Czkawka</em> 是一个多平台的空间清理应用，可用于找出系统中的重复的文件、空文件夹、临时文件等。</p>
+
+<p>项目采用 gtk3/gtk-rs 开发 GUI 部分, 同时也提供 CLI 程序。</p>
+
+<p><img src='https://user-images.githubusercontent.com/41945903/103371136-fb9cae80-4ace-11eb-8d72-7b4c8ac44260.png' alt='czkawka' /></p>
+
+<h2 id='artichoke'>Artichoke</h2>
+
+<ul>
+<li><a href='https://www.artichokeruby.org/'>项目主页</a></li>
+
+<li><a href='https://twitter.com/artichokeruby'>推特主页</a></li>
+
+<li><a href='https://github.com/artichoke/artichoke'>仓库链接</a></li>
+
+<li><a href='https://www.youtube.com/watch?v=QMni48MBqFw&amp;list=PLE7tQUdRKcyZDE8nFrKaqkpd-XK4huygU&amp;index=37'>rubyconf 2019 上的相关演讲</a></li>
+</ul>
+
+<p><em>Artichoke</em> 是一个由 rust 开发的 ruby 实现，可以将 ruby 代码编译至 WebAssembly。</p>
+
+<p>当前 Artichoke 依然依赖于 mruby backend，在与 mruby 进行 FFI 交互的同时，改进某些 Kernel 和库函数的实现。例如 <a href='https://github.com/artichoke/artichoke/tree/trunk/artichoke-backend/src/extn/core/regexp'>regex</a> 部分就是由 rust 实现的。</p>
+
+<p>作者表示在未来会开发出一个纯 rust 的实现。</p>
+
+<h2 id='linfa'>linfa</h2>
+
+<ul>
+<li><a href='https://github.com/rust-ml/linfa'>仓库链接</a></li>
+
+<li><a href='https://docs.rs/linfa/0.3.0/linfa/'>文档链接</a></li>
+
+<li><a href='https://www.reddit.com/r/rust/comments/e4wh8c/linfa_taking_ml_to_production_with_rust_a_25x/'>reddit 讨论</a></li>
+</ul>
+
+<p><em>linfa</em> 是一个机器学习的框架和工具集，其设计参照了 python 的 <code>scikit-learn</code> 库。</p>
+
+<p>关于 rust 在机器学习方面的生态系统，可以参考 <a href='http://www.arewelearningyet.com/'>arewelearningyet</a>。</p>
+
+<h2 id='async-trait-static'>async-trait-static</h2>
+
+<ul>
+<li><a href='https://github.com/tiannian/async-trait-static'>仓库链接</a></li>
+
+<li><a href='https://docs.rs/async-trait-static/0.1.4/async_trait_static/'>文档链接</a></li>
+</ul>
+
+<p><em>async-trait-static</em> 是一个用于在 trait 中声明 async 方法的库，可以在 <code>no_std</code> 下使用。</p>
+
+<p>由于 rustc 的限制，<a href='https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/'>要在 trait 中写出 async 方法是很困难的</a>。 针对这个问题，dtolnay 实现了 <a href='https://github.com/dtolnay/async-trait'>async-trait</a>，将 <code>async fn</code> 的返回类型转化为 <code>Pin&lt;Box&lt;dyn Future&gt;&gt;</code>。</p>
+
+<p>async-trait-static 则采用了 GAT 来实现这个功能，无需用到 trait object。</p>
+
+<p>当前 rust 的 GAT 依然不够完善，因此该库还是有些功能是缺失的。</p>
+
+<h2 id='regexm'>regexm</h2>
+
+<ul>
+<li><a href='https://github.com/TaKO8Ki/regexm'>仓库链接</a></li>
+
+<li><a href='https://docs.rs/regexm/0.1.0-beta.1/regexm/'>文档链接</a></li>
+
+<li><a href='https://github.com/TaKO8Ki/regexm/tree/main/examples'>示例</a></li>
+</ul>
+
+<p><em>regexm</em> 是一个用于对正则表达式进行模式匹配的库：</p>
+
+<pre><code class="language-`rust">fn main() {
+    let text1 = &quot;2020-01-01&quot;;
+    regexm::regexm!(match text1 {
+        r&quot;^\d{4}$&quot; =&gt; println!(&quot;y&quot;),
+        r&quot;^\d{4}-\d{2}$&quot; =&gt; println!(&quot;y-m&quot;),
+        // block
+        r&quot;^\d{4}-\d{2}-\d{2}$&quot; =&gt; {
+            let y_m_d = &quot;y-m-d&quot;;
+            println!(&quot;{}&quot;, y_m_d);
+        }
+        _ =&gt; println!(&quot;default&quot;),
+    });
+}</code></pre>
+
+<h2 id='swc'>swc</h2>
+
+<ul>
+<li><a href='https://swc.rs/'>项目主页</a></li>
+
+<li><a href='https://github.com/swc-project/swc'>仓库链接</a></li>
+</ul>
+
+<p><em>swc</em> 是一个 typescript/javascript 的 transpiler，在运行速度上，单核比 babel 快 4 倍，4 核比 babel 快 70 倍，同时也具有 treeshaking 的功能。</p>
+
+<p><em>swc</em> 被用于 deno 项目中，用于类型擦除。 swc 的作者是一名 97 年的大二学生，如今已经获得了 Deno 官方的顾问合同。</p>
+
+<h2 id='rlink-rs'>rlink-rs</h2>
+
+<p><em>国产项目</em></p>
+
+<ul>
+<li><a href='https://github.com/rlink-rs/rlink-rs'>仓库链接</a></li>
+</ul>
+
+<p>rlink-rs是基于rust实现的流式计算引擎，用来作为Apache Flink的替代方案。</p>
+
+<p>相对于在线业务，rlink-rs更关注海量数据的离线流式处理场景，提升吞吐能力、降低资源消耗。其特点是针对exactly once提供计算和输出两种语义；基于特殊的exactly once输出语义，结合rust内存管理模型，实现大部分场景的全内存计算，解决state和checkpoint引起的重量级IO操作。</p>
+
+<p>rlink-rs的目标是成为一个计算驱动引擎，允许基于DAG定制你自己的计算流程、实现自己的计算语义。</p>
+
+<p>目前状态：主要针对flink流计算这块做对比。已经实现基本窗口计算流程。</p>
+
+<p>希望能从社区得到关于流引擎设计方面的帮助：</p>
+
+<p>1.因为rust语言不如Java动态语言可以反射，在用户api上不那么优雅。 2.只是想在语义上实现类似flink的api，实现上还是想走一条新的路线，毕竟flink有历史包袱，它的实现我们不需要100%参考。</p>
+
+<h2 id='rapier_2021的路线图'>Rapier 2021的路线图</h2>
+
+<p>Rapier 是一个完全免费的开源物理引擎，可用于游戏，动画和机器人，完全使用 Rust 编程语言编写。 它着重于性能，可移植性和跨平台确定性（可选）。</p>
+
+<p>Rapier 团队希望到2021年年底，Rapier 具有游戏物理引擎所期望的所有功能，实现流行的 C++ 物理引擎，比如：Box2d，Bullet Physics 和 PhysX 等同等的功能， 但是不打算在 GPU 上支持运行物理仿真。</p>
+
+<ol type="2">
+<li>路线图链接：<a href='https://www.dimforge.com/blog/2021/01/01/physics-simulation-with-rapier-2021-roadmap/'>https://www.dimforge.com/blog/2021/01/01/physics-simulation-with-rapier-2021-roadmap/</a></li>
+</ol>
+
+<h2 id='psst：使用rust和druid构建的第三方spotify客户端'>Psst：使用Rust和Druid构建的第三方Spotify客户端</h2>
+
+<ul>
+<li><a href='https://github.com/jpochyla/psst'>仓库链接</a></li>
+</ul>
+
+<p>Psst 是一款GUI的快速Spotify客户端，不带Electron，内置Rust。</p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/ksgtk7/druid_v070/'>Druid</a>是一个原生Rust GUI库，支持Windows，macOS，Linux，之前是xi-editor的一部分。</p>
+
+<h2 id='slotmap:_1.0_released'>slotmap: 1.0 released</h2>
+
+<ul>
+<li><a href='https://github.com/orlp/slotmap'>仓库链接</a></li>
+</ul>
+
+<p>slotmap 提供了三种 map 的实现, SlotMap, HopSlotMap 和 DenseSlotMap.</p>
+
+<p>增加,删除,查询均为O(1)复杂度,而且额外开销非常低. 非常适合存储需要稳定和安全引用的 objects, 例如游戏中的 entities, graph 中的 nodes.</p>
+
+<h2 id='rust_的_webdriver库'>Rust 的 WebDriver库</h2>
+
+<ul>
+<li><a href='https://github.com/stevepryde/thirtyfour'>仓库链接</a></li>
+</ul>
+
+<p>Thirtyfour是一个用于Rust的Selenium / WebDriver库，用于自动化网站UI测试。</p>
+
+<p>它支持完整的W3C WebDriver规范。经过Chrome和Firefox的测试，尽管任何与W3C兼容的WebDriver都可以使用。</p>
+
+<h2 id='webrtc.rs'>webrtc.rs</h2>
+
+<ul>
+<li><a href='https://webrtc.rs/'>官网</a></li>
+
+<li><a href='https://github.com/webrtc-rs/webrtc'>仓库链接</a></li>
+</ul>
+
+<p>用 Rust 重写 Pion WebRTC (http://Pion.ly)。目前 v1.0 仍然处于开发中，欢迎开源贡献者提PR。</p>
+
+<h2 id='rust中的科学计算'>Rust中的科学计算</h2>
+
+<ul>
+<li><a href='https://aftix.xyz/home/bacon/'>文章链接</a></li>
+
+<li><a href='https://github.com/aftix/bacon'>仓库链接</a></li>
+</ul>
+
+<p>这篇文章中作者分享了在课余时间用Rust重写生物膜仿真过程中遇到的问题。</p>
+
+<p>由于crates.io上找不到SciPy的代替品，作者自己实现了一个bacon-sci。</p>
+
+<h2 id='shadow-rs_0.5.14_支持自定义钩子'>shadow-rs 0.5.14 支持自定义钩子</h2>
+
+<ul>
+<li><a href='https://github.com/baoyachi/shadow-rs'>仓库链接</a></li>
+</ul>
+
+<p>shadow-rs是一个使得程序能在运行时读取到编译过程中信息的库，这些信息包括：</p>
+
+<ul>
+<li>Cargo.toml 中的项目版本</li>
+
+<li>依赖信息</li>
+
+<li>git commit</li>
+
+<li>编译中用到的Rust工具链</li>
+
+<li>build类型，debug版还是release版</li>
+</ul>
+
+<p>之前想要增加加自定义信息会很麻烦，在0.5.14支持了自定义钩子后就容易多啦。</p>
+
+<h2 id='ballista：分布式计算平台'>Ballista：分布式计算平台</h2>
+
+<ul>
+<li><a href='https://github.com/ballista-compute/ballista'>仓库链接</a></li>
+</ul>
+
+<p>Ballista 用 Rust 实现的概念验证分布式计算平台，使用 Apache Arrow 作为内存模型。它建立在一种体系结构之上，这种体系结构允许将其他编程语言作为一级公民进行支持，而不需要为序列化付出代价。</p>
+
+<h2 id='德国亚琛工业大学研究项目：rustyhermit_介绍'>德国亚琛工业大学研究项目：RustyHermit 介绍</h2>
+
+<ul>
+<li><a href='https://rust-osdev.com/showcase/rusty-hermit/'>RustyHermit 介绍文章</a></li>
+</ul>
+
+<p>相关链接：</p>
+
+<ul>
+<li><a href='https://os.phil-opp.com/'>Phil-Opp OS 教程</a></li>
+
+<li><a href='https://github.com/hermitcore/libhermit-rs'>libhermit-rs</a></li>
+
+<li><a href='https://github.com/hermitcore/rusty-hermit'>rusty-hermit</a></li>
+</ul>
+
+<p>RustyHermit 是一个 Unikernel（我理解这就是  Unique-Kernel 的缩写，独立内核？）。 Unikernel 被认为是有可能改变未来云生态格局的技术。</p>
+
+<p>Unikernel是使用libOS(library os)构建的具有专门用途的单地址空间机器镜像。为了支撑程序的运行，开发者从模块栈中选择最小的类库集合，构建对应的OS。类库和应用代码、配置文件一起构建成固定用途的镜像，可以直接运行在hypervisor或者硬件上而无需Linux或者Windows这样的操作系统。所以，也有人称它为下一代容器技术。</p>
+
+<p>Unikernel 其最大的卖点就是在，没有用户空间与内核空间之分，只有一个连续的地址空间。这样使得 Unikernel 中只能运行一个应用，而且对于运行的应用而言，没有硬件抽象可言，所有的逻辑，包括应用逻辑和操作硬件的逻辑，都在一个地址空间中。</p>
+
+<p>但是目前 Unikernel 仍然出于研究阶段。</p>
+
+<p>RustyHermit 是依赖于 libhermit-rs（库操作系统）实现的。</p>
+
+<p>这两个项目都出自 亚琛工大，有意思的是，它们都是基于著名的 Rust实现操作系统教程phil-opp 衍生实现的。</p>
+
+<h2 id='用_rust_编写现代操作系统'>用 Rust 编写现代操作系统</h2>
+
+<p><a href='https://github.com/theseus-os/Theseus'>仓库链接</a></p>
+
+<p>Theseus 是从Rust编写的新操作系统，尝试使用新颖的OS结构，更好的状态管理以及如何将OS职责（如资源管理）转移到编译器中。</p>
+
+<p>我们一直在不断改进操作系统，包括其故障恢复能力，以提供更高的系统可用性而没有冗余，以及更轻松，更随意的实时演进和运行时灵活性。尽管仍然是一个不完整的原型，但我们认为These修斯将对高端嵌入式系统或边缘数据中心环境很有用。请参阅我们的已发表论文，以获取有关These修斯的设计原理和实现理念的更多信息，以及我们避免状态泄漏现象或尽可能减轻其影响的目标。</p>
+
+<h2 id='evcxr:_a_rust_repl_的解决方案'>Evcxr: A Rust REPL 的解决方案</h2>
+
+<p>并且它还包含了 Jupyter Kernel 指南</p>
+
+<p>该项目挂在 Google 的 GitHub 组织下。</p>
+
+<ul>
+<li><a href='https://github.com/google/evcxr'>仓库链接</a></li>
+
+<li><a href='https://github.com/google/evcxr/blob/master/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb'>Jupyter Kernel 指南</a></li>
+</ul>
+
+<h2 id='findomain:_可提供子域监视服务'>Findomain: 可提供子域监视服务</h2>
+
+<ul>
+<li><a href='https://github.com/Findomain/Findomain'>仓库链接</a></li>
+</ul>
+
+<p>该服务可提供：目录模糊处理/端口扫描/漏洞发现（使用Nuclei），等等。</p>
+
+<p>允许您使用多个顶级工具（OWASP Amass，Sublist3r，Assetfinder和Subfinder）监视目标域，并在出现新的子域时将警报发送到Discord，Slack，Telegram，电子邮件或推送通知（Android / iOS / Smart Watch / Desktop）。</p>
+
+<p>您唯一要做的就是使用您的电子邮件地址（如果适用）或/和webhooks / Telegram聊天信息配置文件，然后将域放入另一个文件中。</p>
+
+<p>一旦完成，您便拥有了一个完全自动化的子域监视服务，可以让您 包含最新发现的新子域，主机IP，HTTP状态，HTTP网站的屏幕快照，开放端口，子域CNAME等。 您所有的数据都安全地保存在关系数据库中，您可以随时请求转储数据。</p>
+
+<h2 id='weylus：让你的平板电脑用作电脑上的图形平板/触摸屏'>Weylus：让你的平板电脑用作电脑上的图形平板/触摸屏</h2>
+
+<p>特点：</p>
+
+<ul>
+<li>用平板电脑控制鼠标</li>
+
+<li>将屏幕镜像到平板电脑上</li>
+</ul>
+
+<p>上述功能在所有操作系统上都可以使用，但<code>Weylus</code>在<code>Linux</code>上效果最好。<code>Linux</code>上的其他功能有：</p>
+
+<ul>
+<li>
+<p>支持手写笔/笔（支持压力和倾斜）。</p>
+</li>
+
+<li>
+<p>多点触控。用支持多点触控的软件试试，- 比如Krita，你就会知道了。</p>
+</li>
+
+<li>
+<p>捕捉特定的窗口，并只对其进行绘制。</p>
+</li>
+
+<li>
+<p>更快的屏幕镜像</p>
+</li>
+
+<li>
+<p>硬件加速视频编码</p>
+</li>
+
+<li>
+<p>平板电脑作为第二屏幕</p>
+</li>
+
+<li>
+<p><a href='https://github.com/H-M-H/Weylus'>仓库链接</a></p>
+</li>
+</ul>
+]]></content:encoded></item><item><title>本月简报 | 学习资源</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/learns.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报：学习资源'>本月简报：学习资源</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：Rust 日报小组</li>
+</ul>
+
+<h2 id='🎈rust_design_patterns_book'>🎈Rust Design Patterns Book</h2>
+
+<p>非官方好书系列, 再次安利! Rust Design Patterns Book. 作者最近更新了很多东西。</p>
+
+<p>看下翻译的中文引言吧。</p>
+
+<h4 id='引言'>引言</h4>
+
+<h4 id='设计模式'>设计模式</h4>
+
+<p>在开发程序中，我们必须解决许多问题。一个程序可以看作是一个问题的解决方案。它也可以被看作是许多不同问题的解决方案的集合。所有这些解决方案共同解决一个更大的问题。</p>
+
+<h4 id='在rust中的设计模式'>在Rust中的设计模式</h4>
+
+<p>有许多问题的形式是相同的，由于事实上，rust不是面向对象设计，模式不同于其他面向对象程序设计语言，虽然细节是不同的，因为他们有相同的形式，他们可以解决使用相同的基本方法。</p>
+
+<p><a href='https://rust-unofficial.github.io/patterns/patterns/index.html'>设计模式</a>是解决编写软件时常见问题的方法。</p>
+
+<p><a href='https://rust-unofficial.github.io/patterns/anti_patterns/index.html'>反模式</a>是解决这些相同问题的方法。</p>
+
+<p>然而，尽管设计模式给我们带来了好处，反模式却带来了更多的问题。</p>
+
+<p><a href='https://rust-unofficial.github.io/patterns/idioms/index.html'>惯用法</a>，是编码是要遵守的指南，他们是社区的社区规范，你可以破他们，但如果你这样做，你应该有一个很好的理由。</p>
+
+<p>TODO: 说明为什么Rust是一个有点特殊功能要素，类型系统，借用检查。</p>
+
+<p><a href='https://rust-unofficial.github.io/patterns/'>book 链接</a></p>
+
+<h2 id='🎈异步书翻译更新啦'>🎈异步书翻译更新啦</h2>
+
+<p>这次翻译新增了第八章-关于生态的叙述（<a href='https://github.com/EthanYuan'>@EthanYuan</a>) 以及第九章http服务器项目（<a href='https://github.com/huangjj27'>@huangjj27</a>), 欢迎来指正错误或贡献~</p>
+
+<p><a href='https://rust-lang.github.io/async-book/01_getting_started/01_chapter.html'>english book link</a></p>
+
+<p><a href='https://huangjj27.github.io/async-book/index.html'>中文翻译链接</a></p>
+
+<p>​</p>
+
+<h2 id='🎈manning的rust新书《refactoring_to_rust》'>🎈Manning的Rust新书《Refactoring to Rust》</h2>
+
+<p>这本书正在MEAP阶段，目前才更新了3章，感兴趣的同学可以看看。</p>
+
+<p><a href='https://www.manning.com/books/refactoring-to-rust'>Refactoring to Rust</a></p>
+
+<h2 id='🎈rust_书籍宝库'>🎈Rust 书籍宝库</h2>
+
+<p><a href='https://www.reddit.com/user/glynnormington/'>glynnormington</a>整理了网络上大部分有关rust的mdbook，有官方的，也有非官方的。值得注意的一点是大家关注的rust宏小册很多人以为一直没有更新，但是其实有另一个团队重新在原来的基础上，更新了新的版本，目前已收录到该书库中。</p>
+
+<p><a href='https://lborb.github.io/book/title-page.html'>Rust 书籍宝库</a></p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/kwiwb8/the_little_book_of_rust_books/'>Read More on reddit</a></p>
+
+<h2 id='🎈使用rust_编写一门语言'>🎈使用Rust 编写一门语言</h2>
+
+<p>有关使用<a href='https://rust-lang.org/'>Rust</a>编程语言制作称为<a href='https://github.com/arzg/eldiro'>Eldiro</a>的编程语言的系列文章。</p>
+
+<p><a href='https://arzg.github.io/lang/'>原文链接</a></p>
+
+<h2 id='rust_错误处理:_python_同学专用'>Rust 错误处理: python 同学专用</h2>
+
+<p>本文是python同学专用，介绍了python日常中的错误处理以及如何在rust中达到类似效果和最佳实践。</p>
+
+<p><a href='https://theomn.com/rust-error-handling-for-pythonistas/'>原文链接</a></p>
+
+<h2 id='🎈其他语言调用rust_-_c++'>🎈其他语言调用Rust - C++</h2>
+
+<p>作者选择Rust作为运行时库的实现语言，并且希望使同一库可用于不同的编程语言。</p>
+
+<p>最初，选择从对三种语言的支持开始：</p>
+
+<ul>
+<li><strong>Rust</strong>：因为这是我们的实现语言。</li>
+
+<li><strong>C ++</strong>：这是我们熟悉的低级语言，仍然是嵌入式设备领域中最成熟的语言之一。</li>
+
+<li><strong>JavaScript / TypeScript</strong>：因为它是一种非常流行的动态语言。</li>
+</ul>
+
+<p><img src='https://sixtyfps.io/blog/expose-rust-library-to-other-languages/diagrams.png' alt='img' /></p>
+
+<p>Rust库（也称为板条箱) 分为两部分，共享实现板条箱和精简惯用的API条板箱。</p>
+
+<p>对于JavaScript，我们使用<a href='https://github.com/neon-bindings/neon'>Neon</a>公开API。Neon使我们能够方便地编写JavaScript API和创建NPM包。</p>
+
+<p>C ++部分更具挑战性。</p>
+
+<p><a href='https://sixtyfps.io/blog/expose-rust-library-to-other-languages.html'>原文链接</a></p>
+
+<h2 id='🎈使用_rust_创建一个模拟器:_part_1'>🎈使用 Rust 创建一个模拟器: part 1</h2>
+
+<p>这个系列中，作者会通过神经网络和遗传算法制作一个进化模拟器。</p>
+
+<p>作者首先会介绍神经网络和遗传算法是如何工作的，然后会使用Rust来实现他们，并且编译成WebAssembly，下图是一个预览图。</p>
+
+<p>教程地址： <a href='https://pwy.io/en/posts/learning-to-fly-pt1/'>https://pwy.io/en/posts/learning-to-fly-pt1/</a></p>
+
+<h2 id='🎈rust陷阱:_repr(transparent)'>🎈Rust陷阱: repr(transparent)</h2>
+
+<p>repr(transparent)可以让类似struct Foo(i32)和i32有同样的内存分布方式。他作用范围非常具体，只能有一个非 0 size 的字段。</p>
+
+<p>本文章介绍了如何使用repr(transparent)以及一些陷阱。</p>
+
+<p>原文链接：<a href='https://jack.wrenn.fyi/blog/semver-snares-transparent/'>https://jack.wrenn.fyi/blog/semver-snares-transparent/</a></p>
+
+<h2 id='🎈unsafe_rust：该如何或何时使用它'>🎈Unsafe Rust：该如何或何时使用它</h2>
+
+<p>本文包含了以下内容：</p>
+
+<ul>
+<li>关于 Unsafe Rust 的五点迷思</li>
+
+<li>什么时候不该用 Unsafe 的代码</li>
+
+<li>处理未初始化的内存</li>
+
+<li>内部可变性</li>
+
+<li>内在动机</li>
+
+<li>内联汇编</li>
+
+<li>FFi</li>
+
+<li>编写Unsafe Rust时候应该使用的工具</li>
+</ul>
+
+<p>原文链接：<a href='https://blog.logrocket.com/unsafe-rust-how-and-when-not-to-use-it/'>https://blog.logrocket.com/unsafe-rust-how-and-when-not-to-use-it/</a></p>
+
+<h2 id='🎈mozilla:_如何导出_rust_组件给_kotlin'>🎈Mozilla: 如何导出 Rust 组件给 Kotlin</h2>
+
+<p>Mozilla应用服务平台这个仓库中提供了一个login组件可以很好地展示这个示例。</p>
+
+<p>概要：</p>
+
+<p>假设你已经的组件在./src/目录下编写了一个不错的Rust核心代码。</p>
+
+<p>首先，你需要将Rust API扁平化为一组FFI绑定，通常是在 <code>./ffi/ </code>目录下。使用 <code>ffi_support</code> crate来帮助实现这个功能，这将涉及到在核心Rust代码中实现一些特性。</p>
+
+<p>接下来，你需要编写消耗<code>FFI</code>的<code>Kotlin</code>代码，通常是在<code>./android/</code>目录下。这段代码应该使用<code>JNA</code>通过共享库加载编译后的<code>Rust</code>代码，并将其作为一个漂亮的安全且易于使用的<code>Kotlin API</code>暴露出来。</p>
+
+<p>似乎我们很可能在这里提供一个有用的模板来让你入门。但我们还没有这样做。</p>
+
+<p>最后，将你的包添加到<code>android-components repo</code>中。</p>
+
+<p>文章还回答了一些导出过程中的问题。</p>
+
+<p>原文链接：<a href='https://github.com/mozilla/application-services/blob/020a3eb831da8cd9d21978e3d1fb7af3a6ffcfea/docs/howtos/exposing-rust-components-to-kotlin.md'>https://github.com/mozilla/application-services/blob/020a3eb831da8cd9d21978e3d1fb7af3a6ffcfea/docs/howtos/exposing-rust-components-to-kotlin.md</a></p>
+
+<h2 id='入门教程：用rust写一个todo应用'>入门教程：用Rust写一个todo应用</h2>
+
+<p>在这篇教程里，作者依照javscript的传统，教你用Rust写一个todo应用。 你会学到：</p>
+
+<ul>
+<li>Rust中的错误处理</li>
+
+<li>Option的使用</li>
+
+<li>Struct和impl</li>
+
+<li>终端输入输出</li>
+
+<li>文件操作</li>
+
+<li>所有权和借用</li>
+
+<li>模式匹配</li>
+
+<li>迭代器和闭包</li>
+
+<li>使用外部crate</li>
+</ul>
+
+<p>链接：<a href='https://www.freecodecamp.org/news/how-to-build-a-to-do-app-with-rust/'>https://www.freecodecamp.org/news/how-to-build-a-to-do-app-with-rust/</a></p>
+
+<h2 id='🎈libhunt:_根据reddit_被提及状态展示_rust_库的热度'>🎈LibHunt: 根据reddit 被提及状态展示 rust 库的热度</h2>
+
+<p>LibHunt根据reddit上大家提及到库的热度来排序出一些热门的rust库.</p>
+
+<p>对于调研阶段的同学来说,是一个很好的工具.</p>
+
+<p>libhunt的主页地址: <a href='https://www.libhunt.com/lang/rust'>https://www.libhunt.com/lang/rust</a></p>
+
+<h2 id='🎈用_rust_实现一个_rest_client'>🎈用 Rust 实现一个 Rest Client</h2>
+
+<p>这是 <code>Zero To Production In Rust</code> 的这本书中的一个示例。在本文，作者演示了：</p>
+
+<ul>
+<li>如何使用reqwests来写一个REST API client。</li>
+
+<li>如何来使用wiremock来进行测试。</li>
+</ul>
+
+<p>原文链接: <a href='https://www.lpalmieri.com/posts/how-to-write-a-rest-client-in-rust-with-reqwest-and-wiremock/'>https://www.lpalmieri.com/posts/how-to-write-a-rest-client-in-rust-with-reqwest-and-wiremock/</a></p>
+
+<h2 id='🎈太素os：基于_riscv_架构的_rust_系统内核实现（中文）教程和源码'>🎈太素OS：基于 RISCV 架构的 Rust 系统内核实现（中文）教程和源码</h2>
+
+<p>构建于QEMU 之上，适合学习</p>
+
+<ul>
+<li>源码： <a href='https://github.com/belowthetree/TisuOS'>https://github.com/belowthetree/TisuOS</a></li>
+
+<li>教程： <a href='https://www.zhihu.com/column/c_1118934193425629184'>https://www.zhihu.com/column/c_1118934193425629184</a></li>
+</ul>
+
+<h2 id='【译】async/await（二）——_futures'>【译】Async/Await（二）—— Futures</h2>
+
+<p>新的文章翻译来啦。</p>
+
+<p>来自：公众号：「Rust 碎碎念」，翻译 by：Praying</p>
+
+<ul>
+<li>翻译链接： <a href='https://mp.weixin.qq.com/s/OL7_usSmY_gAZzYYydyr8A'>https://mp.weixin.qq.com/s/OL7_usSmY_gAZzYYydyr8A</a></li>
+
+<li>原文链接：<a href='https://os.phil-opp.com/async-await/#multitasking'>https://os.phil-opp.com/async-await/#multitasking</a></li>
+</ul>
+
+<h2 id='rust_programming_language:_the_ultimate_guide'>Rust Programming Language: The Ultimate Guide</h2>
+
+<p>这篇文章中作者从伪代码出发，一步步教你实现一个爱情计算器。</p>
+
+<p>作者称这是线上最通俗易懂的Rust入门指南，你怎么认为呢？快来试试吧。</p>
+
+<p>链接：<a href='https://masteringbackend.com/posts/rust-programming-the-ultimate-guide'>https://masteringbackend.com/posts/rust-programming-the-ultimate-guide</a></p>
+
+<h2 id='rust:_initial_thoughts'>Rust: Initial thoughts</h2>
+
+<p>作者分享了自己刚开始学Rust的一些想法和与其它语言的对比。</p>
+
+<p><a href='https://dev.to/hb/rust-initial-thoughts-4jka'>原文链接</a></p>
+
+<h2 id='关于future::join设计的思考'>关于Future::join设计的思考</h2>
+
+<p>这篇文章中作者分享了关于如何将<code>Future::{try_}join</code>和<code>{try_}join!</code>以一种更一致的形式加入标准库中的思考，以及对于const-eval可能起到的作用的讨论。</p>
+
+<p><a href='https://blog.yoshuawuyts.com/future-join-and-const-eval/'>原文链接</a></p>
+
+<h3 id='rust_教程:_从头开始学_rust'>Rust 教程: 从头开始学 Rust</h3>
+
+<p>Rust越来越被更多的人喜爱，很多小伙伴也想入坑。这篇教程可以帮助零基础的小伙伴了解 Rust。</p>
+
+<p><img src='https://www.educative.io/api/page/5328531525992448/image/download/6018549143830528' alt='img' /></p>
+
+<p><a href='https://www.educative.io/blog/rust-tutorial-from-scratch'>原文链接</a></p>
+
+<h3 id='ref_vs_&_in_variables'>ref vs &amp; in variables</h3>
+
+<p>帖子讨论了ref和&amp;的使用，哪个使用更好。</p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/l451ux/ref_vs_in_variables/'>原文链接</a></p>
+
+<h3 id='在rust中包装错误'>在Rust中包装错误</h3>
+
+<p>在开发时错误处理是必须，有时错误处理非常糟糕，文章中提高了warp Error提高体验。</p>
+
+<p><a href='https://edgarluque.com/blog/wrapping-errors-in-rust'>原文链接</a></p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/l3x6p0/wrapping_errors_in_rust/'>on reddit</a></p>
+]]></content:encoded></item><item><title>本月简报 | Rust唠嗑室本月汇总</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rust_laoke.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_rust_唠嗑室本月汇总'>本月简报 | Rust 唠嗑室本月汇总</h1>
+
+<ul>
+<li>来源：<a href='https://space.bilibili.com/25566598'>Rust 唠嗑室</a></li>
+
+<li>主持人：MikeTang</li>
+</ul>
+
+<h2 id='《rust_唠嗑室》第_16_期_-_tensorbase_高性能数据仓库'>《Rust 唠嗑室》第 16 期 - tensorbase 高性能数据仓库</h2>
+
+<p><strong>时间</strong>: 2021/01/05 20:30-21:30</p>
+
+<p><strong>主讲人</strong>：金明剑</p>
+
+<p><strong>内容</strong>：金明剑老师在 RustChinaConf2020 上分享了《<a href='https://www.bilibili.com/video/BV1Yy4y1e7zR?p=25'>基于 Rust 构建高性能新型开源数据仓库</a>》，很多人感兴趣 <a href='https://github.com/tensorbase/tensorbase'>Tensorbase</a> 的技术内幕，这次唠嗑室一起来聊 Tensorbase。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1TA411H7ap'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<p><a href='https://www.bilibili.com/video/BV1Yy4y1e7zR'>RustChinaConf2020 大会合集</a></p>
+
+<h2 id=''></h2>
+
+<h2 id='《rust_唠嗑室》第_17_期_-_用_rust_写_protobuf_扩展'>《Rust 唠嗑室》第 17 期 - 用 Rust 写 Protobuf 扩展</h2>
+
+<p><strong>时间</strong>: 2021/01/19 20:30-21:30</p>
+
+<p><strong>主讲人</strong>：宁志伟</p>
+
+<p><strong>内容</strong>：</p>
+
+<p><a href='https://en.wikipedia.org/wiki/Protocol_Buffers'>Protocol Buffers</a> (简称 Protobuf ) ，是 Google 出品的序列化框架，与开发语言无关，和平台无关。具有体积小，速度快，扩展性好，与 <a href='https://en.wikipedia.org/wiki/GRPC'>gRPC</a> 搭配好，支持的语言多等特点，是目前应用最广泛的序列化框架。</p>
+
+<p><a href='https://github.com/cita-cloud'>CITA-Cloud</a> 是一个以区块链技术为基础，融合云原生技术的柔性集成开放平台。区块链部分提供了非常灵活的微服务架构，可以适应各种各样的企业应用场景。</p>
+
+<p>CITA-Cloud 计划提供一个框架，方便用户自定义交易和区块等核心数据结构。使用 Protobuf 的扩展能力，用户只需用 Protobuf 描述数据结构，框架会自动生成相关代码，得到一个定制的区块链。</p>
+
+<p>这次主要来聊聊 Protobuf 扩展的原理，以及 Rust 已有的相关的库。最后通过一个 <a href='https://github.com/rink1969/proto_desc_printer'>Demo</a> 展示如何使用 Rust 来写 Protobuf 扩展。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1Ff4y1k7Bo'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<p><a href='https://github.com/cita-cloud'>CITA-Cloud</a></p>
+
+<p><a href='https://cita-cloud-docs.readthedocs.io/zh_CN/latest/'>CITA-Cloud 文档</a></p>
+
+<p><a href='https://github.com/cita-cloud/cita_cloud_proto'>cita_cloud_proto</a></p>
+
+<p><a href='https://github.com/dropbox/pb-jelly'>Dropbox-pb-jelly</a></p>
+
+<p><a href='https://github.com/stepancheg/rust-protobuf/'>rust-protobuf</a></p>
+
+<p><a href='https://crates.io/crates/prost'>Prost</a></p>
+
+<p><a href='https://github.com/rink1969/proto_desc_printer'>Demo 代码</a></p>
+]]></content:encoded></item><item><title>RustChinaConf2020 精选 | 用Rust设计高性能JIT执行引擎</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/jit.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rustchinaconf2020_精选_|_jit_开发实践'>RustChinaConf2020 精选 | JIT 开发实践</h1>
+
+<p>说明：本文为视频演讲文字版，编者听录的时候可能会出现一些误差，欢迎指正。</p>
+
+<p>后期编辑: 大海，编程爱好者，对技术充满热情。</p>
+
+<p><strong>讲师:</strong></p>
+
+<p><a href='https://github.com/losfair'>周鹤洋</a>是<code>wasmer</code>核心开发者，南航2018级本科生，主要掌握编译/OS/VM/微架构等技术，2017年开始使用Rust.</p>
+
+<p>视频地址：<a href='https://www.bilibili.com/video/BV1Yy4y1e7zR?p=18'>https://www.bilibili.com/video/BV1Yy4y1e7zR?p=18</a></p>
+
+<h3 id='jit技术含义及应用场合'>JIT技术含义及应用场合</h3>
+
+<p>​	JIT技术全名为 Just-In-Time compilation，翻译为&quot;即时编译&quot;，是在运行期进行编译的方法，是将源代码或更常见的字节码到机器码的转换，然后直接执行的方法。JIT技术主要应用在各种语言的虚拟机上。在其他场合，比如动态链接器，会在运行之前动态重启程序，对它进行链接; 在linux 内核中, ebpf技术和5.10版本最新引入的static calls机制都使用了类似JIT的机制。</p>
+
+<p>​	以虚拟机(VM)为例来简单介绍下JIT技术的应用。VM技术，可以大致分为三类，简单的解释器，优化的解释器和即时编译。简单的解释器，类似wasmi，由于对标准的实现非常好，导致没有资源去做优化，没有为运行效率做优化。其次是优化解释器，比如CPython,wasm3,BEAM(erlang 解释器). 而第三种则包括绝大多数高性能运行时虚拟机，JVM，CLR，V8，LuaJIT，Wasmer，Wasmtime.</p>
+
+<p>​	虚拟机主要应用于当我们需要执行的目标代码格式与机器指令格式不一致时，需要翻译处理的情况。然而当出现我们无法直接静态地翻译到目标机器指令的特性，比如说动态特性( javascript的一些动态约束)，硬件层面难以实现的沙盒特性，比如WebAssembly的内存隔离, 不同的指令集，比如从riscv动态编译到aarch64或者x86-64指令集情况下，我们就需要使用二进制翻译器去进行Jit编译。</p>
+
+<p>​	jit的优点很明显，可以让程序更效率地运行，可以① 动态优化代码②高效支持语言动态特性和安全要求③ 在一些特殊场合比如static call机制和动态链接器，支持运行环境的初始化操作来避免运行时的大量开销。</p>
+
+<p>​	<strong>我们现在从动态优化方面来讲述jit相对传统静态编译的关键点。</strong></p>
+
+<p><img src='../image/Jan_Jit7.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图1 不同引擎在各JIT优化级别所采用的编译器后端&lt;/center&gt;</p>
+
+<p>​	如图1所示，以JavaScriptCore,V8,Wasmer三个引擎为例，他们均实现了用户可以自由选择后端的操作或者在运行时自动在不同后端间切换的方式，使得可以支持编译优化从低优化级别切换到高优化级别，并且经过未经优化代码的时候，再切换回去的操作。</p>
+
+<p>​	这里动态优化的流程是我们通过不断Profile,追踪运行状态，去编译优化等级更高的代码，同时编译开销变大，也会做deoptimize操作，当优化的代码做一些错误的假设时，我们就需要回滚。</p>
+
+<p><strong>而用来实现动态切换优化级别的主要技术是OSR技术 ，即栈上替换(on-stack replacement).</strong></p>
+
+<p><img src='../image/Jan_Jit1.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图2 切换优化等级:OSR&lt;/center&gt;</p>
+
+<p>​	让我们来看看OSR技术的简易流程。如图2所示，调用栈出现了左边的假想情况时，函数Baz代码优化从解释执行提升到 jit级别1 时， 运行时就会触发函数baz的编译，一旦编译完成，则会发生调用栈的重构，使得 原调用栈中所有函数Baz的记录映射到Jit级别1 的堆栈结构上，使得在原来状态基础之上，以Jit级别1的机器码上继续运行。代价 是 提升了计算的复杂度。</p>
+
+<p>​	我曾经的一个工作，  在wasmer中实现的OSR技术。 OSR入口动态加载Image,在OSR退出的时候把image提取出来(从调用栈到wasm抽象表示，回到另一种优化等级的wasmer调用栈内的结构。(&lt;font color=red&gt;8:39&lt;/font&gt;)</p>
+
+<p><img src='../image/Jan_Jit2.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图3 动态切换机制实例随时间变化的性能曲线&lt;/center&gt;</p>
+
+<p>​	图3则是我当时项目benchmark的表现。在图3中，singlepass是我编写的编译最快，运行最慢的后端。llvm是优化等级最高的后端。红线为使用LLVM后端的性能曲线，蓝线为前面2s左右使用singlepass后端，后面使用llvm后端的性能曲线。</p>
+
+<p>​	如果我们直接用llvm编译的话，我们就需要在程序执行之前，在测试程序中等待2s左右。如果我们引入动态切换机制，在程序启动时可以先使用编译快，但执行满的引擎去做执行，当优化等级高的编译器准备好之后，就动态地切换执行流，得到二者的平衡。红线和蓝线后面没有重合，只是由于我们在蓝线上针对一些做了一些额外操作,性能理论上还是一样的。</p>
+
+<p>​	\<em>\</em>我要介绍的第二钟动态优化技术 是 内联缓存inline caching。\<em>\</em>我了解到有两种典型的用例。</p>
+
+<ol type="1">
+<li>
+<p>一些动态语言中的method lookup （方法查找）</p>
+
+<pre><code class="language-`javascript">for (let x of list){
+   document.write(x); // method lookup
+}</code></pre>
+
+<p>​	其中write函数是可以被动态重写的，但是这种情况发生的概率非常小，所以说我们在运行时可以假设它不变，去编译生成机器码。当假设不成立的时候，回滚。本来需要从哈希表中查找该方法，对缓存不友好，运行速度慢。</p>
+
+<p>​	所以我们可以直接对该指令映射为一个缓存槽(slot)，把write函数对应的某些标记和write函数地址写入，检查运行条件是否符合，符合就可以直接执行，避免哈希表查找的开销，否则进行回滚。</p>
+</li>
+
+<li>
+<p>RISC-V二进制翻译</p>
+
+<p><img src='../image/Jan_Jit8.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图4  RISC-V 二进制翻译代码示例 &lt;/center&gt;</p>
+
+<p>​	在RISC-V当中，主要有访存指令和跳转指令会涉及到较大的内存结构查找开销。</p>
+
+<p>​	① 对于全系统模拟的访存指令(load/store)，需要在内存管理单元钟进行tlb lookup，用软件实现非常慢，遍历4层页表。或者在一些高层次结构的模拟时，在b-tree结构去查找内存空间，效率也很低。</p>
+
+<p>​	对于这种指令，我们可以对指令关联一个缓存槽，当该指令第一次需求查表的时候，将查表预期的虚拟地址范围和真实物理地址  写入到缓存槽中，以后每次执行到该指令时，我们就直接用缓存信息直接提取内存信息即可。</p>
+
+<p>​	② 如图4，jalr指令，间接跳转指令的例子。对于这种指令，除了需要mmu lookup , 还需要查找Jit 翻译，即被翻译后的字节码(translation lookup)，共两层查找。 而内联缓存技术就可以消除这两层查找的开销。</p>
+</li>
+</ol>
+
+<p>让我来介绍一下关于内联缓存我所做的简单应用吧。 rvjt-aa64项目 是我所完成的riscv到aarch64的jit引擎(<a href='https://github.com/losfair/rvjit-aa64'>rvjit-aa64</a>)</p>
+
+<p><img src='../image/Jan_Jit3.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图5 rvjit-aa64 快速路径(从内存加载数据)&lt;/center&gt;</p>
+
+<p>​	图5展示了访存指令的快速路径，可以看见我们分配了关于上界和下界的两个缓存槽。检查目标虚拟地址是否位于预期界限当中，如果在范围内，就直接加载，不用回滚到解释执行了。否则就走慢速路径，执行查表处理。</p>
+
+<p><img src='../image/Jan_Jit4.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图6 rvjit-aa64慢速路径(从内存加载数据)&lt;/center&gt;</p>
+
+<p>​	图6展示了访存指令的慢速路径。当发生<code>load/store miss</code>时，我们就会针对地址addr进行查表， 检查读写权限和相关信息，如果可以的话就将其写入缓存槽内，下次就可以快速执行。</p>
+
+<p>​	<strong>接下来我来介绍有关内存安全方面的内容。</strong></p>
+
+<p>​	我们知道rust作为一个以安全性著称的语言，保证safe代码内存安全。所以我们就需要在运行时通过动态的机制确保内存安全。</p>
+
+<p>​	我以空指针检查和访问越界检查为例来介绍Jit如何确保内存安全。</p>
+
+<p>​	①空指针检查:</p>
+
+<p>​	比如在java,c#这类有空指针的语言中，我们会遇到一个很常见的情况。当引用为空的时候，我们不应该对它解引用并且成功。我们应该检查它是否为空，如果为空，应该产生异常而非解引用。一个显而易见的方法是<code>if (a == null){ throw Exception(...)}</code>，但这样开销很大。如同下面代码所展示的，在<code>mov</code>指令前需要插入<code>cmp</code>和<code>je</code>指令，就会增加额外的分支预测的开销。</p>
+
+<pre><code class="language-`assembly">1: 1 cmp $0, %rdi
+2: je null_pointer_exception 
+3: mov %rdi,16(rsp)
+...
+
+null_pointer_exception:
+	call host_npe_handler
+	...</code></pre>
+
+<p>​	所以我们可以尝试一些别的方法。利用硬件trap机制，访问空指针时，从第三行mov指令直接trap到sigsegv异常(以Linux为例)，从而让硬件去检查我们的指针有效性。</p>
+
+<p>​	②访问越界检查</p>
+
+<p>​	对于webassembly中线性内存访问 的处理也可以使用trap机制,比如wasmer和wasmtime的处理方法是，直接分配6GB的虚拟地址空间，只对其中有webassembly分配的区域去做映射。一旦访问到存在映射区域以外的区域时,就会抛出异常,被sigsegv处理器捕获。这样是以慢速路径中的时间增加为代价去换取快速路径上的开销,因为慢速路径钟加入了sigsegv异常处理机制，而快速路径则不再需要界限判断。</p>
+
+<p>​	当然具体的细节会复杂一些，比如wasmer中一段代码,采用Unix信号处理同步异常.调用low level的system api去绑定,关联这些异常信号到处理器上,处理器会分发,然后进一步找出路径.</p>
+
+<p>​	<strong>最后我们来介绍一下linux kernel中运用到jit方法的一些技术。</strong></p>
+
+<p>​	①比如ebpf,是一种允许用户代码安全接入内核的机制. 他有interpreter和jit两种实现方式.大多数主流架构都是用Jit实现.</p>
+
+<p><img src='../image/Jan_Jit5.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图7  Retpoline, Static call机制处理间接跳转的简要代码&lt;/center&gt;</p>
+
+<p>​		②linux 5.10引入的static call机制。 在此之前，为了缓解 spectre 系列漏洞,特别是spectre v2 漏洞,我们会采用retpoline技术.</p>
+
+<p>依赖于RSB(Return Stack Buffer), 它的目的是所有间接调用不经过分支目标缓存(Branch Target Buffer),这样保证攻击无法生效.</p>
+
+<p>​	为方便大家理解Retpoline原理，我这里参考了<a href='https://terenceli.github.io/%E6%8A%80%E6%9C%AF/2018/03/24/retpoline'>retpoline: 原理与部署</a>一文来作原理的解释。如图7所示，jmp指令通过rax值进行间接跳转，在original方式下，CPU会询问indirect branch preditor。如果有攻击者之前训练过该分支，就会导致CPU跳转执行特定代码。而retpoline机制阻止CPU的投机执行。在Retpoline方式下，</p>
+
+<p>​	①执行<code>call L2</code>后，会将<code>lfence</code>地址压栈，并填充到Return Stack Buffer(RSB)，然后跳转到L2位置。</p>
+
+<p>​	②<code>mov %rax, (%rsp)</code>指令将间接跳转地址(<code>*%rax</code>)放到栈顶，此时栈顶地址和RSB中地址不同。</p>
+
+<p>​	③此时对于<code>ret</code>指令如果CPU投机执行时，会使用第一步中放入RSB中的地址，而<code>lfence</code>，<code>jmp L1</code>指令会导致一个死循环。</p>
+
+<p>​	④CPU发现内存栈上的返回地址和RSB投机地址不同，所以投机执行终止，跳转到<code>*%rax</code></p>
+
+<p>​	这样Retpoline机制就避免了CPU的投机执行。</p>
+
+<p>​	但是在 linux内核中我们发现,有很多pattern的间接调用目标是一定的,比如虚表所以我们会把它装化成两次直接调用,第二次直接调用代码使用jit重写,如图7  <code>_trampoline</code>所示, 这样我们消除了spectre v2的可能性, 而且也减少了间接调用的开销(因为使用了直接调用)</p>
+
+<h3 id='在我的项目中是否应该使用jit?'>在我的项目中是否应该使用jit?</h3>
+
+<p><img src='../image/Jan_Jit6.PNG' alt='' /></p>
+
+<p>&lt;center&gt;图8 wasm引擎执行效率与工程复杂度的表现&lt;/center&gt;</p>
+
+<p>​	如图8所示，wasm3虽然是一个解释器，但是相较于Wasmer,LLVM(最好的wasmer jit实现)性能低了10倍，对于解释器来说，是一个非常好的性能表现。并且wasm3的工程复杂度也低了许多。</p>
+
+<p>​	考虑到 执行效率与工程复杂性的关系, 工程复杂性低,意味着出现的Bug数量少, 项目代码也就更安全.。所以对于安全要求高的话,就需要 谨慎考虑jit.</p>
+
+<p>​	在今年linux内核中 ebpf jit发现了两个LPE bug(CVE-2020-8835, CVE-2020-27194), 即使在使用开发人员众多的linux内核中，较小的语言ebpf当中仍出现了比较严重的bug, 这说明Jit编译器工程复杂度很高,需要团队巨大的资源支持维护.</p>
+
+<h3 id='用rust实现jit的体验'>用rust实现jit的体验</h3>
+
+<p>​	使用过程宏 处理汇编很方便, 编写一些Low  level的jit体验非常好. rust语言作为源语言去实现目标语言的编译,无法保证其语言之外的安全性,这可以说是一种局限性吧.rust语言相对于c和c++还是比较有优势的.</p>
+
+<h2 id='提问环节'>提问环节</h2>
+
+<p>问题1: (猜测: 图3使用的Benchenmark使用了hashmap吗？)</p>
+
+<p>回答: 我使用的Benchmark用hashmap会慢50%左右, 因为hashmap对缓存不友好。</p>
+
+<p>问题2: 在jit空指针检查中，将普通的软件判断替换成trap，变成硬件中断，会提升效率吗？</p>
+
+<p>回答:  trap可以类比为rust当中panic,比如数组越界等,在绝大多数情况下都会执行快速路径,当程序出现bug才会执行trap路径.</p>
+
+<p>问题3: 有关内存越界的问题，如果a内存和b内存相邻，a内存已经被映射了，此时越界访问到b内存，这个检查是否失效？</p>
+
+<p>回答: 因为我们在内联缓存中，存储了上界与下界的缓存。我们会对访问的内存比较上界和下界，如果越界就排除在外了。对于这里的比较开销，我们经过一层的比较，对缓存是友好的，并且相较于查表，开销很大。</p>
+
+<p>问题4: wasmer如何兼容x86和arm指令集?</p>
+
+<p>回答:  我们使用的编译器后端<a href='https://crates.io/crates/wasmer-compiler-singlepass'>singlepass</a>和llvm后端都是支持arm指令的.</p>
+
+<p><strong>补充</strong>:  通过硬件来提高jit的性能</p>
+
+<p>wasmer 在运行时会做一些检查,比如跳转时要查询某个表,然后在表中找到目标地址,然后跳转.这样我们就需要在代码中做分支处理. 如果在risc-v Physical Memory Protection (PMP)的扩展下,就可以在一些情况避免上面查表的开销. 而苹果m1 中兼容x86的机制,通过硬件上添加一个x86 的<a href='https://www.cs.utexas.edu/~bornholt/post/memory-models.html'>total store ordering</a> (TSO)开关去使用x86内存顺序,提升模拟效率. 同时我们可以看到，arm指令集这几个版本也引入了支持javascript-operations 的一些指令，可以使得我们常用的一些jit目标语言提高执行效率。</p>
+
+<p>参考文章:</p>
+
+<ol type="1">
+<li><a href='https://github.com/terenceli'>Terenceli</a>  <a href='https://terenceli.github.io/%E6%8A%80%E6%9C%AF/2018/03/24/retpoline'>retpoline: 原理与部署</a></li>
+
+<li><a href='https://www.infoq.com/profile/Sergio-De-Simone/'>Sergio De Simone</a>  <a href='https://www.infoq.com/news/2020/11/rosetta-2-translation/'>How x86 to arm64 Translation Works in Rosetta 2</a></li>
+</ol>
+
+<p>​</p>
+]]></content:encoded></item><item><title>RustChinaConf2020 精选 | Rust 异步与并发</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rust_async.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rustchinaconf2020_精选_|_rust_异步与并发'>RustChinaConf2020 精选 | Rust 异步与并发</h1>
+
+<p>说明：本文为视频演讲文字版，编者听录的时候可能会出现一些误差，欢迎指正。</p>
+
+<p>讲师：赖智超 - Onchain 区块链架构师</p>
+
+<p>视频地址：<a href='https://www.bilibili.com/video/BV1Yy4y1e7zR?p=14'>https://www.bilibili.com/video/BV1Yy4y1e7zR?p=14</a></p>
+
+<p>后期编辑：李冬杰，阿里巴巴淘系技术部，花名齐纪。</p>
+
+<p>————————</p>
+
+<h2 id='自我介绍'>自我介绍</h2>
+
+<p><img src='../image/rust-china-config-async-1.png' alt='自我介绍' /></p>
+
+<p>大家好，今天我跟大家分享一下 Rust 的异步模型，以及实现这个模型时面临的一些并发方面的挑战。首先介绍一下 Rust 在我们公司的应用情况，我们公司在区块链是布局比较早的，现在大概成立有四年多了，目前我们公司主要还是 golang 为核心的技术栈，但是在 Rust 方面我们也在积极探索，有一些应用的实践。首先我们的区块链支持 wasm 虚拟机，使用 Rust 基于 cranelift/wasmtime 实现了 JIT 的版本，目前已经运行了一年多了。有了 wasm 虚拟机的支持后，我们也在智能合约和配套的工具链上下了功夫，目前团队智能合约开发首选 Rust，它具有开发效率高和迭代速度快的优点，前些天统计我们使用 Rust 开发的智能合约代码已经上 10 万了。还有密码学库，我们也是用的 Rust。</p>
+
+<ol type="1">
+<li>区块链 wasm JIT 虚拟机：基于 cranelift/wasmtime;</li>
+
+<li>智能合约开发库和配套的工具链：目前合约开发都首选 Rust，开发效率高，迭代速度快；</li>
+
+<li>密码学库；</li>
+</ol>
+
+<h2 id='同步任务多线程池'>同步任务多线程池</h2>
+
+<p><img src='../image/rust-china-config-async-2.png' alt='同步任务多线程池' /></p>
+
+<p>为了讲解异步编程模型，我们先来看一看大家都比较熟悉的同步任务多线程池的实现，一个比较典型的实现如 PPT 左图所示，有一个全局的队列（Global Task Queue），由用户调用 <code>spawn</code> 把任务压到全局队列，全局队列关联着一个或者多个 <code>worker</code> 线程，每个工作线程都会轮询的从全局队列中把任务拿出来执行，用代码实现也比较简单。</p>
+
+<pre><code class="language-`rust">use std::thread;
+use crossbeam::channel::{unbounded, Sender};
+use once_cell::sync::Lazy;
+
+type Task = Box&lt;dyn FnOnce() + Send + &#8217;static&gt;;
+
+static QUEUE: Lazy&lt;Sender&lt;Task&gt;&gt; = Lazy::new(|| {
+    let (sender, reciver) = unbounded::&lt;Task&gt;();
+    for _ in 0..4 {
+        let recv = reciver.clone();
+        thread::spawn(|| {
+            for task in recv {
+                task();
+            }
+        })
+    }
+    sender
+});
+
+fn spawn&lt;F&gt;(task: F) where F: FnOnce() + Send + &#8217;static {
+    QUEUE.send(Box::new(task)).unwrap();
+}</code></pre>
+
+<p>首先我们在第5行代码定义了什么叫做同步任务，因为同步任务的话只需要执行一次就行了，所以是 <code>FnOnce()</code>，因为这个任务是从用户线程 push 到全局队列，跨线程到工作线程，所以需要有<code>Send</code>约束和 <code>static</code> 生命周期，然后封装到 Box 中。第 8 行构建了一个并发的队列，起了 4 个线程，每个线程拿到队列的接收端，然后在一个循环中执行 task，当然执行 task 的过程可能会 panic，这里为了演示我就没有处理。第17行 <code>sender</code> 就保存着在全局静态变量 QUEUE 上，当用户调用 <code>spawn</code>时，拿到 <code>QUEUE</code> 调用 <code>send</code> 方法，将任务 push 到队列中。</p>
+
+<h2 id='异步任务的多线程'>异步任务的多线程</h2>
+
+<p><img src='../image/rust-china-config-async-3.png' alt='异步任务的多线程' /></p>
+
+<pre><code class="language-`rust">type Task = Box&lt;dyn FnMut() -&gt; bool + Send + &#8217;static&gt;;</code></pre>
+
+<p>接下来我们看一下异步任务的多线程池，首先定义不能立即完成，需要多次执行的任务为异步任务，因此 <code>FnOnce()</code> 就不满足了，需要使用 <code>FnMut </code>，它返回的结果是个布尔值，表示是否执行完任务。但是这样定义就有个问题，如果这个函数没有被工作线程执行完，工作线程就不知道接下来该怎么办了，如果一直等着直到这个任务能够执行，全局队列中的其他任务就不能被执行；直接扔掉这个任务也不行。因此Rust的设计用了一个很巧妙的办法，<code>Exector</code> 就不关心这个任务什么时候好，在执行的时候创建一个 <code>Waker</code>，然后告诉 task，“如果你什么时候好了，可以通过 <code>Waker</code> 把它重新放到全局队列里去” 以便再次执行，这样的话 Task 的定义就多出了 <code>Waker</code> 参数，如下所示：</p>
+
+<pre><code class="language-`rust">type Task = Box&lt;dyn FnMut(&amp;Waker) -&gt; bool + Send + &#8217;static&gt;;</code></pre>
+
+<p>这样异步任务执行没有 ready 的时候，可以将拿到 <code>Waker</code> 注册到能监控任务状态的 <code>Reactor</code> 中，如 ioepoll、timer 等，<code>Reactor</code> 发现任务 ready 后调用 <code>Waker</code> 把任务放到全局队列中。</p>
+
+<h3 id='异步任务的多线程_executor'>异步任务的多线程 Executor</h3>
+
+<p><img src='../image/rust-china-config-async-4.png' alt='异步任务的多线程 Executor' /></p>
+
+<p>在Rust中，对于异步计算的标准定义是Future trait</p>
+
+<pre><code class="language-`rust">pub enum Poll&lt;T&gt; {
+    Ready(T),
+    Pending,
+}
+
+pub trait Future {
+    type Output;
+    fn poll(&amp;mut self, cx: &amp;Waker) -&gt; Poll&lt;Self::Output&gt;;
+    // fn poll(self: Pin&lt;&amp;mut Self&gt;, cx: &amp;mut Context&lt;&#8217;_&gt;) -&gt; Poll&lt;Self::Output&gt;;
+}</code></pre>
+
+<p>poll 方法返回的是一个枚举类型 <code>Poll</code>，它和返回布尔值是类似的，只不过语义会更清晰一些，如果没好的话就返回一个 <code>Pending</code>，好了的话就返回一个 <code>Ready</code>。标准库里用的不是<code>&amp;mut self</code>，而是<code>Pin&lt;&amp;mut Self&gt;</code>，因为 30 分钟讲不完，所以在这里先跳过。下面就是整个异步任务多线程的模型图：</p>
+
+<p><img src='../image/rust-china-config-async-5.png' alt='异步任务的多线程 Executor' /></p>
+
+<p>首先用户通过 <code>spawn</code> 函数把异步任务 push 到全局队列里去，然后工作线程会拿到 task 执行，并且创建一个 <code>Waker</code>，传给执行的 <code>Future</code>，如果任务执行完成了，那就 ok 了；如果没执行完成，<code>Future</code> 负责把 <code>Waker</code> 注册到 <code>Reactor</code> 上面，<code>Reactor</code> 负责监听事件，收到事件后会把 <code>Waker</code> 唤醒，把 task 放到全局队列中，这样下次其他线程可以拿到这个 task 继续执行，这样循环重复直到任务执行完毕。</p>
+
+<h3 id='waker_接口的要求'>Waker 接口的要求</h3>
+
+<p><img src='../image/rust-china-config-async-6.png' alt='Waker 使用方' /></p>
+
+<p><code>Waker</code> 在这个过程中充当着十分重要的角色，我们来看一下 Waker 的接口需要满足哪些要求：</p>
+
+<pre><code class="language-`rust">impl Waker {
+    pub fn wake(self);
+}
+
+impl Clone for Waker;
+
+impl Send for Waker;
+
+impl Sync for Waker;</code></pre>
+
+<p>对于使用方的要求，首先 <code>Waker</code> 本身是唤醒的功能，所以它要提供一个 <code>wake</code> 方法。异步任务可能会关心多个事件源，比如说定时器、IO，也就是说 <code>Waker</code> 可能对应不同的 <code>Reactor</code>，因为 <code>Future</code> 在 <code>poll</code> 的时候只是传了一个 <code>Waker</code>，现在要把 <code>Waker</code> 注册到多个 <code>Reactor</code> 上，就需要 <code>clone</code>。然后 <code>Executor</code> 和 <code>Waker</code> 可能不在一个线程里面，<code>Waker</code> 需要跨线程发送到 <code>Reactor</code> 上面，所以也就需要一个 <code>Send</code> 的约束。最后多个事件源可能同时调用这个 <code>Waker</code>，这里就存在并发调用的问题，要满足并发调用的话就需要实现<code>Sync</code>约束。这是对 <code>Waker</code> 使用方的要求。</p>
+
+<p><img src='../image/rust-china-config-async-7.png' alt='Waker 提供方' /></p>
+
+<pre><code class="language-`rust">impl Waker {
+    pub unsafe fn from_raw(waker: RawWaker) -&gt; Waker
+}
+
+pub struct RawWaker {
+    data: *const (),
+    vtable: &amp;&#8217;static RawWakerTable,
+}
+
+pub struct RawWakerTable {
+    clone: unsafe fn(*const ()) -&gt; RawWaker,
+    wake: unsafe fn(*const ()),
+    wake_by_ref: unsafe fn(*const ()),
+    drop: unsafe fn(*const ())
+}</code></pre>
+
+<p>不同的 <code>Executor</code> 有不同的内部实现，而 <code>Waker</code> 又是一个公共统一的 API。有的<code>Executor</code>有一个全局队列，有的是一个线程局部队列，有的 <code>Executor</code> 可能只支持单个 task 的执行，因此他们的唤醒机制是完全不一样的。要构造统一的 <code>Waker</code> 必然涉及多态，Rust 中是采用自定义虚表的方式实现的，通过 <code>RawWaker</code> 来构造 <code>Waker</code>，<code>RawWaker</code> 有个数据字段，和一个静态的虚表，不同的 <code>Executor</code> 就是要把这些虚表中的方法全部实现，</p>
+
+<h3 id='waker_实现需要考虑的并发问题'>Waker 实现需要考虑的并发问题</h3>
+
+<p><img src='../image/rust-china-config-async-8.png' alt='Waker 实现需要考虑的并发问题' /></p>
+
+<p><code>Waker</code> 在实现上可能会有一些并发上的问题，我们先说第一个问题，<code>wake</code> 调用之间的并发，需要保证只将任务push执行队列一次。如果有两(多)个 <code>Reactor</code> 同时执行 <code>Waker::wake</code> 的话，两个 <code>Reactor</code> 都成功把任务 push 到全局队列里去，如果第一次push的让线程 A 拿到了，第二次pushed让线程 B 拿到了，线程 A 和 B 现在同时调用<code>poll</code>，因为 <code>poll</code> 本身 <code>Self</code> 参数是 <code>&amp;mut self</code> 的，也就是说是互斥的，这样就会造成线程安全问题。</p>
+
+<p>第二个问题，<code>wake</code> 调用和 <code>poll</code> 之间的并发，一个任务正在执行<code>poll</code>，但是之前调用<code>poll</code>的时候把已经<code>Waker</code>注册到一个 <code>Reactor</code> 中，这个 <code>Reactor</code> 突然好了，现在它调用<code>Waker::wake</code>试图把任务push到并发队列里去，如果push能成功的话，那么另一个线程从队列里取到任务，并尝试调用<code>poll</code>，而当前这个任务又在<code>poll </code>的过程中，因此会导致和上面一样的并发问题。</p>
+
+<p><code>async-task</code> 完美的解决了这些并发问题，并且它提供了十分优雅的 API，我把<a href='https://zhuanlan.zhihu.com/p/92679351'>源码解析</a>放在了知乎上面，大家有兴趣可以看一下。</p>
+
+<h3 id='异步任务多线程_executor'>异步任务多线程 Executor</h3>
+
+<p><img src='../image/rust-china-config-async-9.png' alt='异步任务多线程 Executor' /></p>
+
+<p>如果用 <code>async-task</code> 处理这个问题，代码应该是这样的：</p>
+
+<pre><code class="language-`rust">use std::thread;
+use crossbeam::channel::{unbounded, Sender};
+use once_cell::sync::Lazy;
+use async_task;
+
+static QUEUE: Lazy&lt;Sender&lt;async_task::Task&lt;()&gt;&gt;&gt; = Lazy::new(|| {
+    let (sender, reciver) = unbounded::&lt;Task&gt;();
+    for _ in 0..4 {
+        let recv = reciver.clone();
+        thread::spawn(|| {
+            for task in recv {
+                task();
+            }
+        })
+    }
+    sender
+});
+
+fn spawn&lt;F, R&gt;(future: F) -&gt; async_task::JoinHandle&lt;R, ()&gt; 
+where 
+    F: Future&lt;Output = R&gt; + Send + &#8217;static,
+    R: Send + &#8217;static,
+{
+    let schedule = |task| QUEUE.send(task).unwrap();
+    let (task, handle) = async_task::spawn(future, schedule, ());
+    task.schedule();
+    handle
+}</code></pre>
+
+<p>可以看到和之前的同步任务多线程池相比，工作线程的代码基本一致，<code>spawn</code> 函数有一些区别。使用 <code>async_task</code> 很简单实现了异步任务多线程池的处理。</p>
+
+<h3 id='future_和_reactor_之间的并发'>Future 和 Reactor 之间的并发</h3>
+
+<p><img src='../image/rust-china-config-async-10.png' alt='Future 和 Executor 之间的并发' /></p>
+
+<p><code>Future</code> 如果<code>poll</code>的时候没有好的话，它负责把 <code>Waker</code> 注册到 <code>Reactor</code> 里去，这里面会有一个 <code>Waker</code> 过期的问题。第一次调用 <code>poll</code> 和第二次调用 <code>poll</code> 时，<code>Executor</code> 传的 <code>Waker</code> 可能不是同一个，只有最新的 <code>Waker</code> 能把 task 唤醒，老的 <code>Waker</code> 就唤不醒，这样导致的问题是每次 <code>poll</code> 的时候都要把 <code>waker</code> 更新到 <code>Reactor</code> 里，以确保能够唤醒 task。</p>
+
+<p>比如上图中的例子，<code>Future</code> 同时对两个事件感兴趣，对应着两个 <code>Reactor</code>。<code>Future</code> 在 <code>poll</code> 的时候需要向 Reactor1 注册 <code>waker</code>，也要向 Reactor2 注册 <code>waker</code>，当它下次 <code>poll</code> 的时候每次都要把两个 <code>waker</code> 更新，那么现在问题来了，<code>Future</code> 的 <code>poll</code> 执行在 <code>Executor</code> 线程，<code>Reactor</code> 执行在 <code>Reactor</code> 线程，一个线程往里面写，另一个线程试图从里面读，并发问题就出现了。为了处理这个问题，最简单的方式就是加一把锁，每个 <code>Reactor</code> 都要加锁解锁，这个操作本身就比较复杂，比较耗时。</p>
+
+<p><img src='../image/rust-china-config-async-11.png' alt='AtomicWaker' /></p>
+
+<p><code>AtomicWaker</code> 完美处理了这个问题，它通过单生产者多消费者的模式，将 <code>waker</code> 放到 <code>AtomicWaker</code> 里面，<code>AtomicWaker</code> 被多个 <code>Reactor</code> 共享，<code>Waker</code>只需要更新一次，所有 <code>Reactor</code> 就能拿到最新的 <code>waker</code>。</p>
+
+<h2 id='future_的可组合性'>Future 的可组合性</h2>
+
+<p><img src='../image/rust-china-config-async-12.png' alt='Future 的可组合性' /></p>
+
+<p>异步任务本身是可以组合的，比如发起一个 HTTPS 请求涉及查询 DNS 拿到 IP，建立 TLS 链接，发送请求数据，拿到响应数据，过程中的每一步都是异步任务，把这些异步任务组合到一起就是一个大的异步任务。 <code>Future</code>本身设计也是可组合的，比如下面的代码：</p>
+
+<pre><code class="language-`rust">future1
+    .map(func)
+    .then(func_return_future)
+    .join(future2);</code></pre>
+
+<p>因为 <code>Future</code> 要执行的话必须发到 <code>Executor</code> 里面，因此上面的代码还没有发到 <code>Executor</code> 里面去，所以它本身是没有执行的。上面的代码等于：</p>
+
+<pre><code class="language-`rust">Join::new(
+    Then::new(
+        Map::new(future1, func), 
+        func_return_future
+    ), 
+    future2
+);</code></pre>
+
+<p>它是一个声明式的，最终会产生一个结构体，是一个如上图所示的树形结构，当整个任务丢到 <code>Executor</code> 里去执行的时候，<code>poll</code> 方法 <code>Future</code> 的树根结点开始，执行到叶子节点，最底层的叶子节点 futrue 是专门跟 <code>Reactor</code> 打交道的，所以大部分开发者是不需要关心 <code>Reactor</code> 的，因此可能对 <code>Reactor</code> 概念可能了解不多。</p>
+
+<p>当一个叶子节点没好的时候，它会把传下来的 <code>waker</code> 注册到 <code>Reactor</code> 里面去。当<code>Reactor</code> 发现任务可以继续推进了，会调用 <code>waker</code> 把 任务 放入到全局队列中，某个线程拿到任务后，会重新从根节点 poll。以上就是整个的执行过程。</p>
+
+<h3 id='joinn_组合的效率'>JoinN 组合的效率</h3>
+
+<p><img src='../image/rust-china-config-async-13.png' alt='JoinN 组合的效率' /></p>
+
+<p>上面的 <code>Future</code> 组合模型涉及到一个 <code>JoinN</code> 组合的效率问题，问题是怎么产生的呢？<code>waker</code> 只用于唤醒整个task，但是没有携带任何唤醒信息，比如 task 是怎么被唤醒的。<code>JoinN</code> 负责把多个 <code>Future</code> 组合在一起同时并发的执行，<code>Join4</code> 把 4 个 <code>Future</code> 组合，每次 <code>poll</code> 的时候挨个去执行子 <code>Future</code>，如果没有好的话就会注册到 <code>Reactor</code> 里面，假设第二个突然就好了，下一次 <code>poll</code> 时，Join4 并不知道自己为什么被唤醒了，只能挨个再遍历一遍 <code>Future</code>，但其实第一、三、四都是浪费掉的。</p>
+
+<p><img src='../image/rust-china-config-async-14.png' alt='Waker 的拦截和包装' /></p>
+
+<p>怎么解决这个问题呢？<code>futures-rs</code> 里面有一个 <code>FuturesUnordered</code> 专门处理这个事情，可以管理成千上万个子 <code>Future</code>，它内置了一个并发队列，维护已经 ready 的子 <code>Future</code>。当 <code>Executor</code> 在 <code>poll</code> 整个任务的时候，它只遍历并发队列，挨个拿出来执行，执行的时候并不是把 <code>waker</code> 原封不动的传下去，而是进行了一次包装拦截：<code>wake</code>调用的时候，它会先把 <code>Future</code> 添加到自己的ready队列里面去，再去通知<code>Executor</code>的全局队列，<code>Executor</code> 下次再 <code>poll</code> 的时候直接从内置的并发队列去执行 <code>Future</code>，这样能达到效率最大化。</p>
+
+<h2 id='异步任务之间的同步'>异步任务之间的同步</h2>
+
+<p><img src='../image/rust-china-config-async-15.png' alt='异步任务之间的同步' /></p>
+
+<p>传统多个线程之间也有同步的需求，比如说锁。异步任务之间也不可能是完全隔离的，它们之间可能做一些消息的交互，我们比较一下线程和 Task 之间的区别：</p>
+
+<p>||线程|Task| |--|------|----| |睡眠|thread::park|return Pending| |唤醒|thread::unpark|Waker::wake| |获取方式|thread::current()|poll的参数|</p>
+
+<p>线程如果想暂停工作可以调用 <code>thread::park</code>，task想暂停工作可以直接 <code>return Pending</code>；线程可以通过 <code>thread::unpark</code> 唤醒，task 需要调用 <code>Waker::wake</code>；获取方式上，线程直接调用 <code>thread::current</code>，task 是通过 <code>poll</code> 的参数拿到 <code>waker</code>。</p>
+
+<h3 id='异步任务之间的同步_mutex'>异步任务之间的同步 Mutex</h3>
+
+<p><img src='../image/rust-china-config-async-16.png' alt='异步任务之间的同步 Mutex' /></p>
+
+<p><code>Mutex</code> 数据结构里面有一个数据字段，表示要锁的数据，一个 <code>locked</code> 原子变量表示有没有被锁住，还有一个等待队列，异步任务想拿锁却没有拿到，它就只能进入等待队列里面，等着别人去通知它。先看一下拿锁的过程，如果 <code>waker</code> 拿到锁之前 <code>locked</code> 是 false，表示拿锁成功了，如果没拿到失败了的话，就只能等，把 <code>waker</code> 丢到等待队列里。拿到锁的任务想释放这把锁的时候，把 <code>locked</code> 改成 false，并从等待队列中拿一个 <code>waker</code> 出来，去唤醒相应的task。</p>
+
+<p>这里跟大家讲一个很多人误区的地方，很多人认为异步任务里面是必须要用异步锁的，同步锁有阻塞就不行，这是不对的。大部分的等待队列的实现都是用了同步锁，也就是说 <code>Mutex</code> 也不是完全异步的，它本身有个同步锁在里面。如果你在应用里面只是想保护一段数据，对共享的数据做点加减操作，那么应该用 std 里面的同步锁，因为用异步锁的话，更新内部的等待队列需要加同步锁，这个开销可能比你直接用同步锁更新共享数据还要复杂很多。</p>
+
+<p>那么什么时候用异步锁呢？在保护 IO 资源的时候，当你的锁需要跨越多个 <code>.await</code>，时间差的比较大的时候，那应该优先使用异步锁。</p>
+
+<h3 id='异步任务之间的同步_oneshot'>异步任务之间的同步 Oneshot</h3>
+
+<p><img src='../image/rust-china-config-async-17.png' alt='异步任务之间的同步 Oneshot' /></p>
+
+<p><code>Oneshot</code> 是做什么事情的呢？它负责在两个线程之间传递一个数据，一个 task 在执行，另一个 task 在等待，前者执行完会通过 <code>Oneshot</code> 把数据传递给后者。图上所示就是 <code>Oneshot</code> 的数据结构，<code>state</code> 中纪录了很多元信息，比如数据是否已经写了，<code>sender</code> 是否应析构掉了，<code>TxWaker</code> 是否已经存了，<code>RxWaker</code> 是否已经存了，<code>receiver</code> 是否已经 <code>drop</code> 掉了。</p>
+
+<p>发送端发送数据的时候，首先在修改state前， data是完全由 <code>sender</code> 自由访问的，写完 data 后把 <code>state</code> 状态改掉，表示这个 data 已经写完了。然后把接收端的 <code>RxWaker</code> 取出来然后唤醒，唤醒之后 task 下次执行就可以把数据拿到了。如果 <code>sender</code> 没有发送数据，现在要把它析构掉，析构时要注意接收端还在一直等，因此 <code>sender</code> 析构是也要把 <code>state</code> 修改掉，把相关的 <code>RxWaker</code> 唤醒，通知 <code>reciver</code> 不要再等了。</p>
+
+<p>接收端的实现是一个 <code>Future</code>，它本身在 <code>poll</code> 的时候会读取 <code>state</code>，如果有数据那就说明发送端数据已经写完了，直接读取数据。如果没有数据的话就要等待，把它的 <code>waker</code> 存在 <code>Oneshot</code> 的 <code>RxWaker</code> 里面，同时也更新相应的 <code>state</code>，表示接收端的 <code>RxWaker</code> 已经存在。接收端在 <code>drop</code> 的时候，也要通知 <code>sender</code>，表示“我现在对你的数据没有兴趣了，你可以不用继续计算下去&quot;，所以接受端在 drop 的时候也要修改 <code>state</code>，从 <code>Oneshot</code> 里面拿到发送端的 <code>TxWaker</code>，把发送端唤醒。</p>
+
+<h3 id='异步任务之间的同步_waitgroup'>异步任务之间的同步 WaitGroup</h3>
+
+<p><img src='../image/rust-china-config-async-18.png' alt='异步任务之间的同步 WaitGroup' /></p>
+
+<p>接下来讲一下我自己实现的 <code>WaitGroup</code>，它在 golang 里面是非常常见的。它可以构造出多个子任务，等待所有的子任务完成后，再继续执行下去，下面是一个演示代码：</p>
+
+<pre><code class="language-`rust">use waitgroup::WaitGroup;
+use async_std::task;
+
+async {
+    let wg = WaitGroup::new();
+    for _ in 0..100 {
+        let w = wg.worker();
+        task::spawn(async move {
+            drop(w);
+        });
+    }
+    wg.wait().await;
+}</code></pre>
+
+<p>首先先构造一个 <code>WaitGroup</code>，然后创建 100 个 <code>worker</code>，在每个任务执行完后，只要把 <code>worker</code> drop 掉，就说明任务已经完成了。然后 <code>WaitGroup</code> 等到所有的子任务完成后继续执行。下面介绍一下它的实现，其实比较简单：</p>
+
+<pre><code class="language-`rust">struct Inner {
+    waker: AtomicWaker,
+}
+
+impl Drop for Inner {
+    fn drop(&amp;mut self) {
+        self.waker.wake();
+    }
+}
+
+pub struct Worker {
+    inner: Arc&lt;Inner&gt;,
+}
+
+pub struct WaitGroup {
+    inner: Weak&lt;Inner&gt;
+}
+
+impl Future for WaitGroup {
+    type Output = ();
+
+    fn poll(self: Pin&lt;&amp;mut Self&gt;, cx: &amp;mut Context&lt;&#8217;_&gt;) -&gt; Poll&lt;Self::Output&gt; {
+        match self.inner.upgrade() {
+            Some(inner) =&gt; {
+                inner.waker.register(cx.waker());
+                Poll::Pending
+            }
+            None =&gt; Poll::Ready(())
+        }
+    }
+}</code></pre>
+
+<p>注意到如果某一个 <code>worker</code> 完成了 task，它并不需要去唤醒 <code>Waker</code>，<code>WaitGroup</code> 只关心所有任务都结束了，只需要让最后一个 <code>worker</code> 去唤醒 <code>waker</code>。什么时候是最后一个 <code>worker</code> 呢？我们可以借用标准库里的 <code>Arc</code>，<code>Arc</code> 是一个共享引用，当所有的 <code>Arc</code> 强引用都销毁的时候，就会析构内部的数据，只要在 <code>Arc</code> 包装的数据的 <code>drop</code> 方法里面把 <code>waker</code> 唤醒就可以了。</p>
+
+<p><code>WaitGroup</code> 持有一个弱引用，所有的 <code>Worker</code> 都持有强引用，<code>WaitGroup</code> 在 <code>poll</code> 的时候试图把弱引用升级成强引用，如果升级失败了，说明所有的强引用都没了，也就是任务都执行完了，就可以返回 <code>Ready</code>。如果升级成功了，说明现在至少还有一个强引用，那就把 <code>waker</code> 注册到 <code>AtomicWaker</code> 里面。这里有一个边界条件，在升级结束的瞬间，所有的 <code>worker</code> 全部 <code>drop</code> 掉了，这时还不会调用 <code>wake</code>，因为在升级成功时，会产生一个临时的强引用 <code>inner</code>，这时更新waker后，在这个临时的强引用销毁的时候调用 <code>drop</code>，然后调用 <code>waker.wake()</code> 把任务唤醒，因此不会丢失通知。整个过程就完整了。</p>
+]]></content:encoded></item><item><title>生产实践 |「译」1password 的 Rust 实践</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/1password.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='生产实践_|「译」1password_的_rust_实践'>生产实践 |「译」1password 的 Rust 实践</h1>
+
+<h2 id=''></h2>
+
+<p><a href='https://serokell.io/blog/rust-in-production-1password'>英文原文</a></p>
+
+<p>Rust已经风靡编程语言界。自2015年发布1.0版本以来，它一直是最受喜爱的编程语言之一，拥有一批忠实的开发者和贡献者。</p>
+
+<p>为何 Rust 在软件开发者中会如此受宠？为了解答这个疑问，我们踏上了一段关于 Rust 软件开发的新旅程。我们将采访一些在重要项目中使用 Rust 的技术人员。这些重要项目涉及但不限于手机应用、服务程序、初创公司的最小可行化产品。</p>
+
+<p>在本系列的第一期中，我们采访了 <a href='https://1password.com/'>1Password</a> 的工程副总裁 Michael Fey。他们为什么选择 Rust 做开发？Rust 给安全软件带来了哪些好处？如果你想使用 Rust 开发类似的软件，应该关注哪些库？如果你想知道这些问题的答案，请继续阅读。</p>
+
+<p><strong>你能给我们介绍下关于公司和你的一些情况吗?</strong></p>
+
+<p>1Password 是一款已经被数百万人和70,000家企业采用的优秀的密码管理软件，用于保护他们的敏感数据。它支持主流浏览器、桌面和移动设备. 它能帮助你记住所有你没有必要去记住的密码。</p>
+
+<p>我是 1Password 客户端开发的工程副总裁。如果您曾在 Mac、Windows PC、iPhone、iPad、Android 手机、平板电脑或浏览器中使用过1Password，那么您就使用了我们团队开发的软件。从2004年开始，我们就专注于打造这款软件。这是一款体验绝佳的安全产品，为此我们感到非常自豪。</p>
+
+<p><img src='../image/password.jpg' alt='' /></p>
+
+<p><strong>你能谈谈 1Password 的技术栈吗？你们的代码中有多大一部分是用 Rust 编写的?</strong></p>
+
+<p>我们在 1Password 中使用Rust已经有好几年了。我们的 Windows 团队是这项工作的领头羊。Windows版的1Password 7 中大约 70% 的代码是用 Rust 编写的。我们还在2019年底把 1Password Brian (一种浏览器填充逻辑的引擎) 从 Go 移植到 Rust，然后把 Rust 编译为 WebAssembly，最后再部署到浏览器插件中。这样我们就可以利用到 WebAssembly 的速度和性能。</p>
+
+<p>它们得益于产品采用了Rust，在过去几年我们取得了巨大成功。现在我们正在对几乎整个产品线进行重写，Rust 在其中扮演主要角色。我们正在使用 Rust 创建一个headless 1Password 应用: 把所有的业务逻辑、加密解密、数据库访问、服务器通信等统统包裹到一个薄薄的 UI 层中，然后作为原生应用部署到系统中。</p>
+
+<p><strong>1Password 采用 Rust 的原因是什么，是看中它的高性能或类型/内存安全吗？</strong></p>
+
+<p>最初吸引我们使用 Rust 的主要原因之一是内存安全; Rust 可以增强我们对保护客户数据安全的信心，这无疑让我们兴奋不已。不过，除了内存安全之外，我们对Rust生态系统的喜爱还有很多。没有传统的运行时是一个显著的性能优势；例如，我们不再担心垃圾收集器的性能开销。Rust提供了一种 &quot;程序正确性 &quot;的形式和许多针对运行时未定义行为的保证。强类型系统在编译时会强制保证这些规则。仔细地将应用逻辑与Rust的强类型规则对齐，使API难以被误用。同时，因为不需要对约束和不变量进行运行时检查，所以可以写出简洁的代码。在程序执行之前，编译器就可以保证: 不存在无效的运行时代码路径, 不会因此产生程序异常。因为运行时状态验证更少，所以写出的代码会更干净、更高效、更内聚、质量也更高。与其他语言相比，Rust 很少需要运行时调试。如果能编译通过，你就可以相当确定它不会表现出未定义行为。它可能不是你想要的，但它会是 &quot;正确的&quot;</p>
+
+<p>Rust 的另一个非常强大却常被忽视的特性是程序化宏系统\[1]。它使我们能够编写一种工具：可以自动将 Rust 中定义的类型与我们的客户端语言 (Swift、Kotlin和 TypeScript) 共享。这种工具的输出会自动处理序列化/反序列化过程。这意味着客户端开发人员在与 Rust 库交互时，可以继续使用他们选择的语言进行编程，同时又可以消除使用 FFI 进行 JSON 解析的烦恼。除了上述这些益处，我们还能获得每一种目标语言在编译期类型检查的好处。我们已经把这个工具集成到持续集成服务器中，这意味着对Rust模型的改变会导致客户端应用程序的编译失败，而这些失败情况会在代码评审中被发现。</p>
+
+<p>这个工具已经成为我们开发过程中不可或缺的组成部分，让我们的进度比以前快得多。一旦我们的类型在Rust中被定义，我们就能立即在客户端语言中生成等价类型。这使我们的开发人员能够专注于解决问题。而不必去捋模版代码，再使用 FFI 进行通信</p>
+
+<p><strong>Rust对开发像1Password这样以安全为中心的应用程序的支持（库和其他）有多好？</strong></p>
+
+<p>对于实现安全软件的大部分基础组件来说，那是绰绰有余的。有两个大型的、突出的密码学平台( <a href='https://github.com/briansmith/ring'>ring</a>  和<a href='https://github.com/RustCrypto'>Rust Crypto</a> 组)，它们提供了丰富的功能。正如我在前面提到的，用 Rust 编写程序会让你对内存的使用充满信心，也让你更难意外引入与内存相关的漏洞。还有一个很好的系统，用来跟踪Rust crates中不时出现的漏洞：<a href='https://rustsec.org/'>RustSec</a> 数据库。它是由其他 Rust 开发者提供的社区资源，并且经常更新。此外，Rust 和 Cargo 还包含了 batteries-included 测试框架。这意味着你总是有一种容易的方式来编写单元测试套件，以保证关键代码(比如加密函数)的正确性。</p>
+
+<p>如果存在 Rust 原生安全库，那当然是最理想的 (而且它们会及时出现) 。如果没有也不必担心，我们还有其他选项：使用C语言或原生平台库中的一些东西。在我们的Rust代码中，我们将这一点发挥得淋漓尽致，比如调用生物识别解锁的原生实现（Touch ID、Face ID、Windows Hello）和特定平台的设置实现(比如苹果平台上的NSUserDefaults)。</p>
+
+<p><strong>其中有什么特别的Rust库是你想介绍一下的吗？</strong></p>
+
+<p>当然有。1Password 使用了 Tokio、Hyper/Reqwest、Ring 和Neon。得益于这些 Rust 库，我们才能完成这个雄心勃勃的项目。你也应该看看我们在 <a href='http://crates.io/'>crates.io</a> 上的 <a href='https://crates.io/crates/password-rules-parser'>密码规则解析器</a>  。它主要基于苹果支持的规范。他们的工具和文档可以在 <a href='https://developer.apple.com/password-rules/'>这里</a> 找到。</p>
+
+<p><strong>在用 Rust 开发 1Password 的过程中，遇到的最大挑战是什么？</strong></p>
+
+<p>我们团队中的许多人都是Rust的新手，他们经历了典型的学习曲线，这与它的内存管理和所有权模型有关。我们还发现编译时间很长；我们的CPU和风扇肯定会受到锻炼。😄</p>
+
+<p><strong>你对结果满意吗？</strong></p>
+
+<p>绝对满意</p>
+
+<p><strong>你有什么关键的心得想跟我们的观众分享吗？</strong></p>
+
+<p>如果你是Rust的新手，请从小处着手，并在此基础上进行改进。我们在刚开始的时候进行了大量的实验，试图找到基于Rust的最佳解决方案。当你的实验成功后，回顾一下你过去使用其他语言的工作方式，看看你的代码能否从Rust的理念中获益。</p>
+
+<p>如果你是1Password的新用户，今天就可以通过这个链接注册，家庭和个人账户第一年可以节省50%的费用。如果你正在做一个开源项目，你可以免费获得一个1Password Teams账户。请前往我们的 GitHub 仓库了解更多信息。</p>
+
+<p>附录</p>
+
+<p>\<a href='https://github.com/1Password/typeshare'>1]  指的是[typeshare</a>. 它的功能是把一些用rust 写的结构体生成为其他语言的结构体，比如下面的rust 的一个struct</p>
+
+<pre><code class="language-`rust">#[derive(Serialize, Deserialize, Debug)]
+struct Teacher {
+    name: String,
+    age: u64,
+    id: u64,
+}</code></pre>
+
+<p>转化为typescript的变成如下:</p>
+
+<pre><code class="language-`typescript">export interface Teacher {
+    name: string;
+    age: number;
+    id: number;
+}</code></pre>
+
+<p>它同时支持typescript,swift,java. 它把Rust写的struct生成了团队其他中定义各语言结构体的规范。所以该规范也只是1password团队内部定义domain层的规范。不一定适合其他团队。</p>
+
+<p>\<a href='https://bitwarden.com/'>2]  另一款开源的密码管理器[bitwarden</a>.  也有rust 实现后台<a href='https://github.com/dani-garcia/bitwarden_rs'>bitwarden_rs</a>.  有兴趣可以进一步阅读。</p>
+
+<h2 id=''></h2>
+
+<p>译者简介：</p>
+
+<p>柴杰，中国科学技术大学集成电路工程专业，在读硕士研究生。兴趣与专长为虚拟内存系统、分布式系统。</p>
+
+<p>审校：</p>
+
+<ul>
+<li>严炳（ryan），算法，大数据开发从业者，喜欢和有开源精神的人一起共事。</li>
+</ul>
+]]></content:encoded></item><item><title>生产实践 | 溪塔科技: 用Rust写Protobuf扩展</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/cita_protobuf-ext.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='溪塔科技:_用rust写protobuf扩展'>溪塔科技: 用Rust写Protobuf扩展</h1>
+
+<p>作者： 宁志伟</p>
+
+<p>本文为《Rust 唠嗑室》第 17 期 - 《用 Rust 写 Protobuf 扩展》的文字版本。</p>
+
+<h2 id=''></h2>
+
+<h2 id='protobuf'>Protobuf</h2>
+
+<p><code>Protocol Buffers</code> (简称 <code>Protobuf</code> ) ，是 <code>Google</code> 出品的序列化框架，与开发语言无关，和平台无关。具有体积小，速度快，扩展性好，与 <code>gRPC</code> 搭配好，支持的语言多等特点，是目前应用最广泛的序列化框架。</p>
+
+<p>使用场景一般是在微服务架构中，用来定义微服务之间的 <code>gRPC</code> 接口，以及相关的参数/返回值等数据结构的定义。</p>
+
+<p>通过官方的编译器 <code>protoc</code> 以及相应的插件可以方便的生成不同语言的实现代码。这样不同的微服务可以使用不同的开发语言，同时还能顺利进行交互。</p>
+
+<h2 id='cita-cloud_中的_protobuf'><code>CITA-Cloud</code>中的<code>Protobuf</code></h2>
+
+<p><code>CITA-Cloud</code> 采用了<a href='https://cita-cloud-docs.readthedocs.io/zh_CN/latest/blockchain.html'>微服务架构</a>，因此也采用了 <code>Protobuf</code> 和 <code>gRPC</code> 的组合。</p>
+
+<p>但是因为 <code>Protobuf</code> 语言无关的特性和广泛的应用，使得其具有抽象和通用的特点。因此也可以把 <code>Protobuf</code> 当作一种建模语言来使用，<a href='https://zhuanlan.zhihu.com/p/162839054'>参见文章</a>。</p>
+
+<p><code>CITA-Cloud</code> 目前是在<a href='https://github.com/cita-cloud/cita_cloud_proto'>协议</a>中直接把交易和区块等数据结构固定下来的。但是最近的思考发现，其中的很多字段都是为了实现某种应用层面的协议而存在的。比如交易中的 <code>nonce</code> 字段就是为了实现应用层面的去重协议。</p>
+
+<p>因此，后续计划提供一个框架，方便用户自定义交易和区块等核心数据结构，以及相关的处理函数。但是 <code>Protobuf</code> 通常只能生成数据结构，以及相关的 <code>get/set</code> 等模式比较固定的代码，如果要生成复杂的成员函数，就需要一些扩展能力。</p>
+
+<h2 id='protobuf_扩展'><code>Protobuf</code>扩展</h2>
+
+<p><code>Protobuf</code> 的扩展能力可以分为两种： <code>Protobuf</code> 本身的扩展和 <code>Protobuf</code> 插件。</p>
+
+<p><code>Protobuf</code> 其实是个标准的编译器架构。我们可以把 <code>.proto </code>文件视作源码，官方的 <code>protoc</code> 编译器可以对应到编译器前端。</p>
+
+<p><code>protoc</code> 接收一个或者一批 <code>.proto</code> 文件作为输入，解析之后输出一种中间描述格式，对应编译器中的 <code>IR</code> 。</p>
+
+<p>但是有意思的是，这种中间描述格式是二进制的，其结构依旧由 <code>Protobuf</code> 本身描述。详细可以参见<a href='https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto'>descriptor.proto</a>。</p>
+
+<p><code>Protobuf</code> 插件可以对应到编译器后端，接收中间描述格式，解析其中的信息，据此生成具体语言的代码。</p>
+
+<p>这里其实有个非常有意思的问题。插件在解析中间描述格式的数据时，因为这种格式是由 <code>descriptor.proto</code> 描述的，所以得先有个插件能把 <code>descriptor.proto</code> 生成开发插件所使用的开发语言的代码。</p>
+
+<p>上面的话有点绕，举个具体的例子。比如我想用 <code>Rust</code> 实现一个插件，假如目前还没有 <code>Protobuf</code> 相关的 <code>Rust</code> 库，那就没办法用 <code>Rust</code> 代码来解析 <code>descriptor.proto</code> 对应的中间描述格式的数据，也就没法实现插件了。</p>
+
+<p>这个问题其实就对应编译器里的自举问题。比如，想用 <code>Rust</code> 来写 <code>Rust</code> 编译器，那么一开始就是个死结了。解决办法也很简单，最开始的 <code>Rust</code> 编译器是用 <code>Ocaml</code> 实现的，然后就可以用 <code>Rust</code> 来写 <code>Rust</code> 编译器，实现编译器的 <code>Rust</code> 代码用前面 <code>Ocaml</code> 实现的版本去编译就可以解决自举问题了。</p>
+
+<p><code>Protobuf</code> 这里也是同样的，官方提供了 <code>Java/Go/C++/Python</code> 等版本的实现，可以先用这些语言来过渡。</p>
+
+<p>另外一种扩展方式是 <code>Protobuf</code> 本身提供了语法上的<a href='https://developers.google.com/protocol-buffers/docs/proto#extensions'>扩展机制</a>。这个功能可以对应到编程语言提供的宏等元编程功能。</p>
+
+<p><code>Protobuf</code> 这个扩展能力有点类似<a href='https://www.liaoxuefeng.com/wiki/1252599548343744/1266265125480448'>`AOP`</a>，可以方便的在已经定义的 <code>Message</code> 中增加一些成员。</p>
+
+<p>更有意思的是，前面提到过，所有的 <code>.proto</code> 文件，经过 <code>protoc </code>之后，会被转换成由 <code>descriptor.proto</code> 对应的中间描述格式。而 <code>descriptor.proto</code> 中的 <code>Message</code> 也同样支持上述扩展功能，因此可以实现一种类似全局 <code>AOP</code> 的功能。</p>
+
+<p>通过扩展 <code>descriptor.proto</code> 中的 <code>Message</code> ，可以实现给所有的 <code>Message</code> 都加一个 <code>option</code> 这样的操作。</p>
+
+<h2 id='rust_中相关的库'><code>Rust</code>中相关的库</h2>
+
+<p><code>dropbox</code> 实现了一个 <code>Protobuf </code>库<a href='https://github.com/dropbox/pb-jelly'>`pb-jelly`</a>，它就是用 <code>Python</code> 来实现生成 <code>Rust</code> 代码部分的功能。具体实现其实比较简单，就是在拼 <code>Rust</code> 代码字符串。</p>
+
+<p><a href='https://github.com/stepancheg/rust-protobuf'>`rust-protobuf`</a>是一个实现比较完整的 <code>Protobuf</code> 库，支持 <code>gRPC</code> 和相关的扩展能力。其中实现分为两部分，生成数据结构 <code>Rust</code> 代码的插件和生成 <code>gRPC</code> 相关代码的插件。具体实现封装的稍微好了一点，但是基本上还是在拼 <code>Rust</code> 代码字符串。</p>
+
+<p><a href='https://github.com/danburkert/prost'>`prost`</a>是一个比较新的 <code>Protobuf</code> 库实现。功能上有点欠缺，不支持扩展。库本身只支持生成数据结构的<code>Rust</code> 代码。生成 <code>gRPC</code> 相关代码的功能在<a href='https://github.com/hyperium/tonic'>`tonic-build`</a>里，这个有点奇怪。</p>
+
+<p>但是 <code>prost</code> 采用了很多新的技术。前面提到，插件只会生成数据结构相关的 <code>get/set</code> 等模式比较固定的代码， <code>prost</code> 实现了一个 <code>derive</code> 来自动给数据结构增加这些成员函数，这样生成的 <code>Rust</code> 代码就大大简化了，<a href='https://github.com/cita-cloud/cita_cloud_proto/blob/master/src/common.rs'>参见例子</a>。</p>
+
+<p>这也跟编译器架构能对应上：一个选择是把编译器后端做的很复杂，直接生成所有的代码，运行时比较薄；另外一个选择是编译器后端做的很简单，生成的代码也简单，但是运行时比较厚重。</p>
+
+<p>另外 <code>gRPC</code> 相关的代码比较复杂， <code>tonic-build</code> 在生成的时候用了<a href='https://github.com/dtolnay/quote'>`quote`</a>库，提供类似<code> Rust</code> 代码语法树上的 <code>sprintf</code> 方法的功能，不管是便利性还是代码的可读性都比之前两个库好很多。</p>
+
+<h2 id='后续计划'>后续计划</h2>
+
+<p>后续计划使用 <code>Protobuf</code> 及其扩展能力，实现一个框架，不但用来描述交易和区块等核心数据结构，也以一种可配置的方式生成一些比较复杂的相关代码。</p>
+
+<p>最重要的第一步就是要能解析出 <code>Protobuf</code> 扩展相关的信息，因为正常的 <code>.proto</code> 文件只能用于描述数据结构，扩展的 <code>option</code> 是唯一可以赋值的地方。</p>
+
+<p>目前实现了一个<a href='https://github.com/rink1969/proto_desc_printer'>`proto_desc_printer`</a>，可以解析中间描述格式，特别是其中的扩展信息。</p>
+
+<p>后续可以在这个基础上去做代码生成部分的工作，这里可以从 <code>prost</code> 吸取很多好的经验。</p>
+
+<h2 id=''></h2>
+
+<p>作者简介：</p>
+
+<p>宁志伟</p>
+
+<p>溪塔科技首席架构师 首个微服务架构区块链<code>CITA</code> 首席架构师，区块链+云原生框架 <code>CITA-Cloud</code> 设计者。前阿里巴巴、华为技术专家，超过 <code>10</code> 年分布式系统架构设计，编程语言和虚拟机方面工作经验。</p>
+
+<ul>
+<li>
+<p>Blog   : <a href='https://rink1969.github.io/'>https://rink1969.github.io</a></p>
+</li>
+
+<li>
+<p>GitHub : <a href='https://github.com/rink1969'>https://github.com/rink1969</a></p>
+</li>
+
+<li>
+<p>为国产自主云原生区块链<code>CITA-Cloud</code>点赞[https://github.com/cita-cloud/cita<em>cloud</em>proto ](https://github.com/cita-cloud/cita<em>cloud</em>proto)</p>
+</li>
+</ul>
+
+<p>后期编辑：</p>
+
+<p><a href='https://github.com/higker'>丁 烁(Jarvib Ding)</a>，Rust 爱好者。</p>
+]]></content:encoded></item><item><title>学习园地 | 「系列」Rust设计模式之创建者模式</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rust-design-patterns/builder.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='建造者模式（builder)'>建造者模式（Builder)</h1>
+
+<h2 id='概述'>概述</h2>
+
+<p>构建者模式是一种设计模式，提供一种灵活的解决方案，已解决面向对象程序设计中的各种对象创建问题。Builder设计模式的目的是将复杂对象的构造与其表示分离开来。是&quot;是四人帮&quot;设计模式之一\[wiki]。建造者模式是一种创建型设计模式，使你能够分步骤创建复杂对象。该模式允许你使用相同的创建代码生成不同类型和形式的对象。</p>
+
+<p>定义：Builder设计模式的目的是将复杂对象的构造与其表示分离开来。通过这样做，同样的构造过程可以创建不同的表示。</p>
+
+<h2 id='历史'>历史</h2>
+
+<p>假如有一个复杂的对象，需要对其进行构造时需要对诸多成员变量和嵌套对象进行繁杂的初始化工作。有时这些初始化代码通常深藏于一个包含众多参数且让人看不懂的构造函数中；或者这些代码散落在客户端代码的多个位置。</p>
+
+<ol type="1">
+<li>例如，创建一个房子，不同种类的房子有不同的风格，为每一种类型的房子创建一个子类，这可能会导致程序变得过于复杂。</li>
+
+<li>或者无需生成子类，但是需要创建一个包括所有可能参数的超级构造函数，并用它来控制房屋对象的创建。这样虽然可以避免生成子类，但是会造成当拥有大量输入参数的构造函数不是每次都要全部用上。通常情况下，绝大部分的参数都没有使用，这使得对于构造函数的调用十分不简洁。</li>
+</ol>
+
+<h2 id='建造者模式_的使用'>建造者模式 的使用</h2>
+
+<p>建造者模式建议将对象构造的代码从产品类中抽取出来，并将其放在一个名为生成器的独立对象中。每次创建对象时，都需要通过生成器对象执行一系列步骤。重点在于无需调用所有步骤，而只需调用创建特定对象配置所需的那些步骤。</p>
+
+<h2 id='适用场景'>适用场景</h2>
+
+<ul>
+<li>
+<p>使用建造者设计模式可以避免“重叠构造函数”的出现。</p>
+
+<ul>
+<li>假设复杂函数中有十几个可选参数，那么调用这些函数会非常不方便，因此需要重载这个构造函数，新建几个只有较少参数的简化版本。</li>
+
+<li>建造者设计模式让你可以分步骤生成对象，而且允许你仅适用必须的步骤。</li>
+</ul>
+</li>
+
+<li>
+<p>当使用代码创建不同形式的产品时，可使用生成器模式</p>
+
+<ul>
+<li>如果你需要创建各种形式的产品，他们的制造过程相似且仅有细节上的差异，此时可使用生成器模式。</li>
+
+<li>基本生成器接口中定义了所有可能的制造步骤，具体生成器将实现这些步骤来制造特定形式的产品。</li>
+</ul>
+</li>
+
+<li>
+<p>使用构造者模式构造其他复杂对象</p>
+
+<ul>
+<li>构造者模式让你能分步骤构造产品，你可以延迟执行某些步骤而不会影响最终产品。</li>
+</ul>
+</li>
+</ul>
+
+<h2 id='优点'>优点</h2>
+
+<ul>
+<li>可以分步骤创建对象，暂缓创建步骤或者递归运行创建步骤。</li>
+
+<li>生成不同形式的产品，你可以复用相同的制造代码</li>
+
+<li>单一职责原则，可以将复杂构造代码从产品的业务逻辑中分离出来。</li>
+</ul>
+
+<h2 id='缺点'>缺点</h2>
+
+<p>由于该模式需要新增多个类，因此代码整体复杂程度会有所增加。</p>
+
+<h2 id='描述'>描述</h2>
+
+<p>通过使用构建者助手创建一个对象。</p>
+
+<h2 id='例子'>例子</h2>
+
+<pre><code class="language-`rust">fn main() {
+    let foo = Foo {
+        bar: String::from(&quot;Y&quot;),
+    };
+    let foo_from_builder = FooBuilder::new().name(String::from(&quot;Y&quot;)).build();
+    println!(&quot;foo = {:?}&quot;, foo);
+    println!(&quot;foo from builfer = {:?}&quot;, foo_from_builder);
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Foo {
+    // lots of complicated fields
+    bar : String,
+}
+
+pub struct FooBuilder {
+    // Probably lots of optional fields.
+    bar: String,
+}
+
+impl FooBuilder {
+    pub fn new() -&gt; Self {
+        // set the minimally required fields of Foo.
+        Self {
+            bar: String::from(&quot;x&quot;),
+        }
+    }
+
+    pub fn name(mut self, bar: String) -&gt; FooBuilder {
+        // set the name on the builder iteself,
+        // and return the builder by value.
+        self.bar = bar;
+        self 
+    }
+    // if we can get away with not consuming the builder here, that is an 
+    // advantage. It means we can use the FooBuilder as a template for constructing many Foo.
+    pub fn build(self) -&gt; Foo {
+        // Create a Foo from Foo the FooBuilder, applying all settings in FooBuilder to Foo. 
+        Foo { bar: self.bar }
+    }
+}</code></pre>
+
+<pre><code class="language-`rust">// Rust 编程之道. P234
+struct Circle {
+    x: f64,
+    y: f64,
+    radius: f64,
+}
+
+struct CircleBuilder {
+    x: f64,
+    y: f64,
+    radius: f64,
+}
+
+impl Circle {
+    fn area(&amp;self) -&gt; f64 {
+        std::f64::consts::PI * (self.radius * self.radius)
+    }
+    fn new() -&gt; CircleBuilder {
+        CircleBuilder {
+            x: 0.0, y: 0.0, radius: 1.0,
+        }
+    }
+}
+
+impl CircleBuilder {
+    fn x(&amp;mut self, coordinate: f64) -&gt; &amp;mut CircleBuilder {
+        self.x = coordinate;
+        self
+    }
+    fn y(&amp;mut self, coordinate: f64) -&gt; &amp;mut CircleBuilder {
+        self.y = coordinate;
+        self
+    }
+    fn radius(&amp;mut self, radius: f64) -&gt; &amp;mut CircleBuilder {
+        self.radius = radius;
+        self
+    }
+
+    fn build(&amp;self) -&gt; Circle {
+        Circle {
+            x: self.x, y: self.y, radius: self.radius,
+        }
+    }
+}
+
+fn main() {
+  let c = Circle::new().x(1.0).y(2.0).radius(2.0).build();
+  println!(&quot;area = {:?}&quot;, c.area());
+  println!(&quot;c.x = {:?}&quot;, c.x);
+  println!(&quot;c.y = {:?}&quot;, c.y);
+}</code></pre>
+
+<h2 id='动机'>动机</h2>
+
+<p>当你需要许多不同的构造函数或者当构造有副作用时，这种方法有用。</p>
+
+<h2 id='优点'>优点</h2>
+
+<p>将构造方法与其他方法分离。</p>
+
+<p>防止构造函数的扩散</p>
+
+<p>可用于单次初始化以及更加复杂的构造。</p>
+
+<h2 id='缺点'>缺点</h2>
+
+<p>比直接创建结构对象或简单的的构造函数更复杂。</p>
+
+<h2 id='讨论'>讨论</h2>
+
+<p>这种模式在Rust（以及简单对象）中比在其他许多语言中更常见，这是因为Rust缺乏重载。由于你只能使用给定名称的单个方法，因此在Rust中使用多个构造函数要比C++、Java或其他语言好。</p>
+
+<p>这种模式通常用于构建器对象本身就很有用的地方，而不仅仅是一个构建器。例如：std::process::Command 是Child的构建器。在这种情况下，不使用T和TBuilder的命名模式。</p>
+
+<p>该示例通过值获取并返回生成器。接受并返回构建器作为可变引用通常更符合人体工程学（并且更有效）。</p>
+
+<pre><code class="language-`rust">let mut fb = FooBuilder::new();
+fb.a();
+fb.b();
+let f = fb.builder();</code></pre>
+
+<p>以及FooBuilder::new().a().b().builder()样式。</p>
+
+<h2 id='参见'>参见</h2>
+
+<ul>
+<li><a href='https://web.archive.org/web/20210104103100/https://doc.rust-lang.org/1.12.0/style/ownership/builders.html'>Description in the style guide</a></li>
+
+<li><a href='https://crates.io/crates/derive_builder'>derive_builder</a>, a crate for automatically implementing this pattern while avoiding the boilerplate.</li>
+
+<li><a href='https://rust-unofficial.github.io/patterns/idioms/ctor.html'>Constructor pattern</a> for when construction is simpler.</li>
+
+<li><a href='https://en.wikipedia.org/wiki/Builder_pattern'>Builder pattern (wikipedia)</a></li>
+
+<li><a href='https://web.archive.org/web/20210104103000/https://rust-lang.github.io/api-guidelines/type-safety.html#c-builder'>Construction of complex values</a></li>
+
+<li>Rust编程之道 ch7,p234</li>
+</ul>
+
+<h2 id='项目中的使用'>项目中的使用</h2>
+
+<h3 id='tokio_中的建造者模式_struct_tokio_::_runtime_::_builder'>Tokio 中的建造者模式 Struct <a href='https://docs.rs/tokio/1.1.0/tokio/index.html'>tokio</a>::<a href='https://docs.rs/tokio/1.1.0/tokio/runtime/index.html'>runtime</a>::<a href='https://docs.rs/tokio/1.1.0/tokio/runtime/struct.Builder.html'>Builder</a></h3>
+
+<pre><code class="language-`rust">pub struct Builder {
+    /// Runtime type
+    kind: Kind,
+
+    /// Whether or not to enable the I/O driver
+    enable_io: bool,
+
+    /// Whether or not to enable the time driver
+    enable_time: bool,
+
+    /// The number of worker threads, used by Runtime.
+    ///
+    /// Only used when not using the current-thread executor.
+    worker_threads: Option&lt;usize&gt;,
+
+    /// Cap on thread usage.
+    max_blocking_threads: usize,
+
+    /// Name fn used for threads spawned by the runtime.
+    pub(super) thread_name: ThreadNameFn,
+
+    /// Stack size used for threads spawned by the runtime.
+    pub(super) thread_stack_size: Option&lt;usize&gt;,
+
+    /// Callback to run after each thread starts.
+    pub(super) after_start: Option&lt;Callback&gt;,
+
+    /// To run before each worker thread stops
+    pub(super) before_stop: Option&lt;Callback&gt;,
+
+    /// Customizable keep alive timeout for BlockingPool
+    pub(super) keep_alive: Option&lt;Duration&gt;,
+}
+
+pub fn new_current_thread() -&gt; Builder // 设置current thread 类型
+//Returns a new builder with the current thread scheduler selected.
+//Configuration methods can be chained on the return value.
+
+pub fn new_multi_thread() -&gt; Builder // 设置 multi thread 类型
+//This is supported on crate feature rt-multi-thread only.
+//Returns a new builder with the multi thread scheduler selected.
+//Configuration methods can be chained on the return value.
+
+pub fn enable_all(&amp;mut self) -&gt; &amp;mut Self
+// Enables both I/O and time drivers.
+// Doing this is a shorthand for calling enable_io and enable_time individually. If additional components are added to Tokio in the future, enable_all will include these future components.
+
+pub fn worker_threads(&amp;mut self, val: usize) -&gt; &amp;mut Self // 设置的runtime 用于工作的线程数
+// Sets the number of worker threads the Runtime will use.
+// This should be a number between 0 and 32,768 though it is advised to keep this value on the smaller side.
+
+pub fn max_blocking_threads(&amp;mut self, val: usize) -&gt; &amp;mut Self // 设置生成的用于阻塞操作的线程最大数
+//Specifies limit for threads spawned by the Runtime used for blocking operations.
+//Similarly to the worker_threads, this number should be between 1 and 32,768.
+//The default value is 512.
+//Otherwise as worker_threads are always active, it limits additional threads (e.g. for blocking annotations).
+
+pub fn thread_name(&amp;mut self, val: impl Into&lt;String&gt;) -&gt; &amp;mut Self // 设置线程的名字
+//Sets name of threads spawned by the Runtime&#8217;s thread pool.
+//The default name is &quot;tokio-runtime-worker&quot;.
+
+// .....
+
+pub fn build(&amp;mut self) -&gt; Result&lt;Runtime&gt; // 构造出tokio中的runtime结构
+//Creates the configured Runtime.
+//The returned Runtime instance is ready to spawn tasks.
+
+//etc..
+
+//example
+// build runtime
+let runtime = Builder::new_multi_thread()
+                .worker_threads(4)
+                .thread_name(&quot;my-custom-name&quot;)
+                .thread_stack_size(3 * 1024 * 1024)
+                .build()
+                .unwrap();</code></pre>
+
+<p>从Builder的build函数可以知道Builder结构是Runtime的辅助结构体用来帮助构造Runtime的。</p>
+
+<h2 id='futures_中的建造者设计模式_struct_futures_::_executor_::_threadpoolbuilder'>Futures 中的建造者设计模式 Struct <a href='https://docs.rs/futures/0.3.12/futures/index.html'>futures</a>::<a href='https://docs.rs/futures/0.3.12/futures/executor/index.html'>executor</a>::<a href='https://docs.rs/futures/0.3.12/futures/executor/struct.ThreadPoolBuilder.html'>ThreadPoolBuilder</a></h2>
+
+<pre><code class="language-`rust">/// A general-purpose thread pool for scheduling tasks that poll futures to
+/// completion.
+///
+/// The thread pool multiplexes any number of tasks onto a fixed number of
+/// worker threads.
+///
+/// This type is a clonable handle to the threadpool itself.
+/// Cloning it will only create a new reference, not a new threadpool.
+///
+/// This type is only available when the `thread-pool` feature of this
+/// library is activated.
+#[cfg_attr(docsrs, doc(cfg(feature = &quot;thread-pool&quot;)))]
+pub struct ThreadPool {
+    state: Arc&lt;PoolState&gt;,
+}
+
+/// Thread pool configuration object.
+///
+/// This type is only available when the `thread-pool` feature of this
+/// library is activated.
+#[cfg_attr(docsrs, doc(cfg(feature = &quot;thread-pool&quot;)))]
+pub struct ThreadPoolBuilder {
+    pool_size: usize,
+    stack_size: usize,
+    name_prefix: Option&lt;String&gt;,
+    after_start: Option&lt;Arc&lt;dyn Fn(usize) + Send + Sync&gt;&gt;,
+    before_stop: Option&lt;Arc&lt;dyn Fn(usize) + Send + Sync&gt;&gt;,
+}
+
+
+struct PoolState {
+    tx: Mutex&lt;mpsc::Sender&lt;Message&gt;&gt;,
+    rx: Mutex&lt;mpsc::Receiver&lt;Message&gt;&gt;,
+    cnt: AtomicUsize,
+    size: usize,
+}
+
+enum Message {
+    Run(Task),
+    Close,
+}
+
+impl ThreadPoolBuilder {
+    /// Create a default thread pool configuration.
+    ///
+    /// See the other methods on this type for details on the defaults.
+    pub fn new() -&gt; Self {
+        Self {
+            pool_size: cmp::max(1, num_cpus::get()),
+            stack_size: 0,
+            name_prefix: None,
+            after_start: None,
+            before_stop: None,
+        }
+    }
+
+    /// Set size of a future ThreadPool
+    ///
+    /// The size of a thread pool is the number of worker threads spawned. By
+    /// default, this is equal to the number of CPU cores.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pool_size == 0`.
+    pub fn pool_size(&amp;mut self, size: usize) -&gt; &amp;mut Self {
+        assert!(size &gt; 0);
+        self.pool_size = size;
+        self
+    }
+
+    /// Set stack size of threads in the pool, in bytes.
+    ///
+    /// By default, worker threads use Rust&#8217;s standard stack size.
+    pub fn stack_size(&amp;mut self, stack_size: usize) -&gt; &amp;mut Self {
+        self.stack_size = stack_size;
+        self
+    }
+
+    /// Set thread name prefix of a future ThreadPool.
+    ///
+    /// Thread name prefix is used for generating thread names. For example, if prefix is
+    /// `my-pool-`, then threads in the pool will get names like `my-pool-1` etc.
+    ///
+    /// By default, worker threads are assigned Rust&#8217;s standard thread name.
+    pub fn name_prefix&lt;S: Into&lt;String&gt;&gt;(&amp;mut self, name_prefix: S) -&gt; &amp;mut Self {
+        self.name_prefix = Some(name_prefix.into());
+        self
+    }
+
+    /// Execute the closure `f` immediately after each worker thread is started,
+    /// but before running any tasks on it.
+    ///
+    /// This hook is intended for bookkeeping and monitoring.
+    /// The closure `f` will be dropped after the `builder` is dropped
+    /// and all worker threads in the pool have executed it.
+    ///
+    /// The closure provided will receive an index corresponding to the worker
+    /// thread it&#8217;s running on.
+    pub fn after_start&lt;F&gt;(&amp;mut self, f: F) -&gt; &amp;mut Self
+        where F: Fn(usize) + Send + Sync + &#8217;static
+    {
+        self.after_start = Some(Arc::new(f));
+        self
+    }
+
+    /// Execute closure `f` just prior to shutting down each worker thread.
+    ///
+    /// This hook is intended for bookkeeping and monitoring.
+    /// The closure `f` will be dropped after the `builder` is droppped
+    /// and all threads in the pool have executed it.
+    ///
+    /// The closure provided will receive an index corresponding to the worker
+    /// thread it&#8217;s running on.
+    pub fn before_stop&lt;F&gt;(&amp;mut self, f: F) -&gt; &amp;mut Self
+        where F: Fn(usize) + Send + Sync + &#8217;static
+    {
+        self.before_stop = Some(Arc::new(f));
+        self
+    }
+	
+  	// 从ThreadBuilder的create函数可以看到ThreadPoolBuilder根据配置采纳数创建ThreadPool， 是ThreadPool的辅助结构体 
+    /// Create a [`ThreadPool`](ThreadPool) with the given configuration.
+    pub fn create(&amp;mut self) -&gt; Result&lt;ThreadPool, io::Error&gt; {
+        let (tx, rx) = mpsc::channel();
+        let pool = ThreadPool {
+            state: Arc::new(PoolState {
+                tx: Mutex::new(tx),
+                rx: Mutex::new(rx),
+                cnt: AtomicUsize::new(1),
+                size: self.pool_size,
+            }),
+        };
+
+        for counter in 0..self.pool_size {
+            let state = pool.state.clone();
+            let after_start = self.after_start.clone();
+            let before_stop = self.before_stop.clone();
+            let mut thread_builder = thread::Builder::new();
+            if let Some(ref name_prefix) = self.name_prefix {
+                thread_builder = thread_builder.name(format!(&quot;{}{}&quot;, name_prefix, counter));
+            }
+            if self.stack_size &gt; 0 {
+                thread_builder = thread_builder.stack_size(self.stack_size);
+            }
+            thread_builder.spawn(move || state.work(counter, after_start, before_stop))?;
+        }
+        Ok(pool)
+    }
+}</code></pre>
+
+<p>从ThreadBuilder的create函数可以看到ThreadPoolBuilder根据配置采纳数创建ThreadPool， 是ThreadPool的辅助结构体</p>
+
+<h2 id='surf中的建造者设计模式'>Surf中的建造者设计模式</h2>
+
+<pre><code class="language-`rust">/// Request Builder
+///
+/// Provides an ergonomic way to chain the creation of a request.
+/// This is generally accessed as the return value from `surf::{method}()`,
+/// however [`Request::builder`](crate::Request::builder) is also provided.
+///
+/// # Examples
+///</code></pre>
+
+<p>/// use surf::http::{Method, mime::HTML, Url}; /// # #[async_std::main] /// # async fn main() -&gt; surf::Result&lt;()&gt; { /// let mut request = surf::post(&quot;https://httpbin.org/post&quot;) ///     .body(&quot;&lt;html&gt;hi&lt;/html&gt;&quot;) ///     .header(&quot;custom-header&quot;, &quot;value&quot;) ///     .content_type(HTML) ///     .build(); /// /// assert<em>eq!(request.take</em>body().into_string().await.unwrap(), &quot;&lt;html&gt;hi&lt;/html&gt;&quot;); /// assert_eq!(request.method(), Method::Post); /// assert_eq!(request.url(), &amp;Url::parse(&quot;https://httpbin.org/post&quot;)?); /// assert_eq!(request[&quot;custom-header&quot;], &quot;value&quot;); /// assert_eq!(request[&quot;content-type&quot;], &quot;text/html;charset=utf-8&quot;); /// # Ok(()) /// # }</p>
+
+<pre><code class="language- ```">///</code></pre>
+
+<p>/// use surf::http::{Method, Url}; /// # #[async_std::main] /// # async fn main() -&gt; surf::Result&lt;()&gt; { /// let url = Url::parse(&quot;https://httpbin.org/post&quot;)?; /// let request = surf::Request::builder(Method::Post, url).build(); /// # Ok(()) /// # }</p>
+
+<pre><code class="language- ```">pub struct RequestBuilder {
+    /// Holds the state of the request.
+    req: Option&lt;Request&gt;,
+    /// Hold an optional Client.
+    client: Option&lt;Client&gt;,
+    /// Holds the state of the `impl Future`.
+    fut: Option&lt;BoxFuture&lt;&#8217;static, Result&lt;Response&gt;&gt;&gt;,
+}
+
+impl RequestBuilder {
+    /// Create a new instance.
+    ///
+    /// This method is particularly useful when input URLs might be passed by third parties, and
+    /// you don&#8217;t want to panic if they&#8217;re malformed. If URLs are statically encoded, it might be
+    /// easier to use one of the shorthand methods instead.
+    ///
+    /// # Examples
+    ///</code></pre>
+
+<pre><code>/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// use surf::http::{Method, Url};
+///
+/// let url = Url::parse(&quot;https://httpbin.org/get&quot;)?;
+/// let req = surf::RequestBuilder::new(Method::Get, url).build();
+/// # Ok(()) }
+/// ```
+pub fn new(method: Method, url: Url) -&gt; Self {
+    Self {
+        req: Some(Request::new(method, url)),
+        client: None,
+        fut: None,
+    }
+}</code></pre>
+
+<pre><code>pub(crate) fn with_client(mut self, client: Client) -&gt; Self {
+    self.client = Some(client);
+    self
+}</code></pre>
+
+<pre><code>/// Sets a header on the request.
+///
+/// # Examples
+///
+/// ```
+/// let req = surf::get(&quot;https://httpbin.org/get&quot;).header(&quot;header-name&quot;, &quot;header-value&quot;).build();
+/// assert_eq!(req[&quot;header-name&quot;], &quot;header-value&quot;);
+/// ```
+pub fn header(mut self, key: impl Into&lt;HeaderName&gt;, value: impl ToHeaderValues) -&gt; Self {
+    self.req.as_mut().unwrap().insert_header(key, value);
+    self
+}</code></pre>
+
+<pre><code>/// Sets the Content-Type header on the request.
+///
+/// # Examples
+///
+/// ```
+/// # use surf::http::mime;
+/// let req = surf::post(&quot;https://httpbin.org/post&quot;).content_type(mime::HTML).build();
+/// assert_eq!(req[&quot;content-type&quot;], &quot;text/html;charset=utf-8&quot;);
+/// ```
+pub fn content_type(mut self, content_type: impl Into&lt;Mime&gt;) -&gt; Self {
+    self.req
+        .as_mut()
+        .unwrap()
+        .set_content_type(content_type.into());
+    self
+}</code></pre>
+
+<pre><code>/// Sets the body of the request.
+///
+/// # Examples
+///
+/// ```
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// use serde_json::json;
+/// let mut req = surf::post(&quot;https://httpbin.org/post&quot;).body(json!({ &quot;any&quot;: &quot;Into&lt;Body&gt;&quot;})).build();
+/// assert_eq!(req.take_body().into_string().await.unwrap(), &quot;{\&quot;any\&quot;:\&quot;Into&lt;Body&gt;\&quot;}&quot;);
+/// # Ok(())
+/// # }
+/// ```
+pub fn body(mut self, body: impl Into&lt;Body&gt;) -&gt; Self {
+    self.req.as_mut().unwrap().set_body(body);
+    self
+}</code></pre>
+
+<pre><code>/// Set the URL querystring.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use serde::{Deserialize, Serialize};
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// #[derive(Serialize, Deserialize)]
+/// struct Index {
+///     page: u32
+/// }
+///
+/// let query = Index { page: 2 };
+/// let mut req = surf::get(&quot;https://httpbin.org/get&quot;).query(&amp;query)?.build();
+/// assert_eq!(req.url().query(), Some(&quot;page=2&quot;));
+/// assert_eq!(req.url().as_str(), &quot;https://httpbin.org/get?page=2&quot;);
+/// # Ok(()) }
+/// ```
+pub fn query(mut self, query: &amp;impl Serialize) -&gt; std::result::Result&lt;Self, Error&gt; {
+    self.req.as_mut().unwrap().set_query(query)?;</code></pre>
+
+<pre><code>    Ok(self)
+}</code></pre>
+
+<pre><code>/// Submit the request and get the response body as bytes.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// let bytes = surf::get(&quot;https://httpbin.org/get&quot;).recv_bytes().await?;
+/// assert!(bytes.len() &gt; 0);
+/// # Ok(()) }
+/// ```
+pub async fn recv_bytes(self) -&gt; Result&lt;Vec&lt;u8&gt;&gt; {
+    let mut res = self.send().await?;
+    Ok(res.body_bytes().await?)
+}</code></pre>
+
+<pre><code>/// Submit the request and get the response body as a string.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// let string = surf::get(&quot;https://httpbin.org/get&quot;).recv_string().await?;
+/// assert!(string.len() &gt; 0);
+/// # Ok(()) }
+/// ```
+pub async fn recv_string(self) -&gt; Result&lt;String&gt; {
+    let mut res = self.send().await?;
+    Ok(res.body_string().await?)
+}</code></pre>
+
+<pre><code>/// Submit the request and decode the response body from json into a struct.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use serde::{Deserialize, Serialize};
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// #[derive(Deserialize, Serialize)]
+/// struct Ip {
+///     ip: String
+/// }
+///
+/// let uri = &quot;https://api.ipify.org?format=json&quot;;
+/// let Ip { ip } = surf::get(uri).recv_json().await?;
+/// assert!(ip.len() &gt; 10);
+/// # Ok(()) }
+/// ```
+pub async fn recv_json&lt;T: serde::de::DeserializeOwned&gt;(self) -&gt; Result&lt;T&gt; {
+    let mut res = self.send().await?;
+    Ok(res.body_json::&lt;T&gt;().await?)
+}</code></pre>
+
+<pre><code>/// Submit the request and decode the response body from form encoding into a struct.
+///
+/// # Errors
+///
+/// Any I/O error encountered while reading the body is immediately returned
+/// as an `Err`.
+///
+/// If the body cannot be interpreted as valid json for the target type `T`,
+/// an `Err` is returned.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use serde::{Deserialize, Serialize};
+/// # #[async_std::main]
+/// # async fn main() -&gt; surf::Result&lt;()&gt; {
+/// #[derive(Deserialize, Serialize)]
+/// struct Body {
+///     apples: u32
+/// }
+///
+/// let url = &quot;https://api.example.com/v1/response&quot;;
+/// let Body { apples } = surf::get(url).recv_form().await?;
+/// # Ok(()) }
+/// ```
+pub async fn recv_form&lt;T: serde::de::DeserializeOwned&gt;(self) -&gt; Result&lt;T&gt; {
+    let mut res = self.send().await?;
+    Ok(res.body_form::&lt;T&gt;().await?)
+}
+	</code></pre>
+
+<p>// 从build函数可以知道最后RequestBuilder是Request的辅助结构体，用来构造返回Request // 这个函数返回的是Request</p>
+
+<pre><code>/// Return the constructed `Request`.
+pub fn build(self) -&gt; Request {
+    self.req.unwrap()
+}</code></pre>
+
+<pre><code>/// Create a `Client` and send the constructed `Request` from it.
+pub async fn send(mut self) -&gt; Result&lt;Response&gt; {
+    self.client
+        .take()
+        .unwrap_or_else(Client::new_shared_or_panic)
+        .send(self.build())
+        .await
+}</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">从build函数可以知道最后RequestBuilder是Request的辅助结构体，用来构造返回Request
+
+## Reqwest中的建造者设计模式</code></pre>
+
+<p>/// A request which can be executed with <code>Client::execute()</code>. pub struct Request {</p>
+
+<pre><code>method: Method,
+url: Url,
+headers: HeaderMap,
+body: Option&lt;Body&gt;,
+timeout: Option&lt;Duration&gt;,</code></pre>
+
+<p>}</p>
+
+<p>/// A builder to construct the properties of a <code>Request</code>. /// /// To construct a <code>RequestBuilder</code>, refer to the <code>Client</code> documentation. #[must_use = &quot;RequestBuilder does nothing until you &#8217;send&#8217; it&quot;] pub struct RequestBuilder {</p>
+
+<pre><code>client: Client,
+request: crate::Result&lt;Request&gt;,</code></pre>
+
+<p>}</p>
+
+<p>impl Request {</p>
+
+<pre><code>/// Constructs a new request.
+#[inline]
+pub fn new(method: Method, url: Url) -&gt; Self {
+    Request {
+        method,
+        url,
+        headers: HeaderMap::new(),
+        body: None,
+        timeout: None
+    }
+}</code></pre>
+
+<pre><code>/// Get the method.
+#[inline]
+pub fn method(&amp;self) -&gt; &amp;Method {
+    &amp;self.method
+}</code></pre>
+
+<pre><code>/// Get a mutable reference to the method.
+#[inline]
+pub fn method_mut(&amp;mut self) -&gt; &amp;mut Method {
+    &amp;mut self.method
+}</code></pre>
+
+<pre><code>/// Get the url.
+#[inline]
+pub fn url(&amp;self) -&gt; &amp;Url {
+    &amp;self.url
+}</code></pre>
+
+<pre><code>/// Get a mutable reference to the url.
+#[inline]
+pub fn url_mut(&amp;mut self) -&gt; &amp;mut Url {
+    &amp;mut self.url
+}</code></pre>
+
+<pre><code>/// Get the headers.
+#[inline]
+pub fn headers(&amp;self) -&gt; &amp;HeaderMap {
+    &amp;self.headers
+}</code></pre>
+
+<pre><code>/// Get a mutable reference to the headers.
+#[inline]
+pub fn headers_mut(&amp;mut self) -&gt; &amp;mut HeaderMap {
+    &amp;mut self.headers
+}</code></pre>
+
+<pre><code>/// Get the body.
+#[inline]
+pub fn body(&amp;self) -&gt; Option&lt;&amp;Body&gt; {
+    self.body.as_ref()
+}</code></pre>
+
+<pre><code>/// Get a mutable reference to the body.
+#[inline]
+pub fn body_mut(&amp;mut self) -&gt; &amp;mut Option&lt;Body&gt; {
+    &amp;mut self.body
+}</code></pre>
+
+<pre><code>/// Get the timeout.
+#[inline]
+pub fn timeout(&amp;self) -&gt; Option&lt;&amp;Duration&gt; {
+    self.timeout.as_ref()
+}</code></pre>
+
+<pre><code>/// Get a mutable reference to the timeout.
+#[inline]
+pub fn timeout_mut(&amp;mut self) -&gt; &amp;mut Option&lt;Duration&gt; {
+    &amp;mut self.timeout
+}</code></pre>
+
+<pre><code>/// Attempt to clone the request.
+///
+/// `None` is returned if the request can not be cloned, i.e. if the body is a stream.
+pub fn try_clone(&amp;self) -&gt; Option&lt;Request&gt; {
+    let body = match self.body.as_ref() {
+        Some(ref body) =&gt; Some(body.try_clone()?),
+        None =&gt; None,
+    };
+    let mut req = Request::new(self.method().clone(), self.url().clone());
+    *req.timeout_mut() = self.timeout().cloned();
+    *req.headers_mut() = self.headers().clone();
+    req.body = body;
+    Some(req)
+}</code></pre>
+
+<pre><code>pub(super) fn pieces(self) -&gt; (Method, Url, HeaderMap, Option&lt;Body&gt;, Option&lt;Duration&gt;) {
+    (self.method, self.url, self.headers, self.body, self.timeout)
+}</code></pre>
+
+<p>}</p>
+
+<p>impl RequestBuilder {</p>
+
+<pre><code>pub(super) fn new(client: Client, request: crate::Result&lt;Request&gt;) -&gt; RequestBuilder {
+    let mut builder = RequestBuilder { client, request };</code></pre>
+
+<pre><code>    let auth = builder
+        .request
+        .as_mut()
+        .ok()
+        .and_then(|req| extract_authority(&amp;mut req.url));</code></pre>
+
+<pre><code>    if let Some((username, password)) = auth {
+        builder.basic_auth(username, password)
+    } else {
+        builder
+    }
+}</code></pre>
+
+<pre><code>/// Add a `Header` to this Request.
+pub fn header&lt;K, V&gt;(self, key: K, value: V) -&gt; RequestBuilder
+where
+    HeaderName: TryFrom&lt;K&gt;,
+    &lt;HeaderName as TryFrom&lt;K&gt;&gt;::Error: Into&lt;http::Error&gt;,
+    HeaderValue: TryFrom&lt;V&gt;,
+    &lt;HeaderValue as TryFrom&lt;V&gt;&gt;::Error: Into&lt;http::Error&gt;, 
+{
+    self.header_sensitive(key, value, false)
+}</code></pre>
+
+<pre><code>/// Add a `Header` to this Request with ability to define if header_value is sensitive.
+fn header_sensitive&lt;K, V&gt;(mut self, key: K, value: V, sensitive: bool) -&gt; RequestBuilder
+where
+    HeaderName: TryFrom&lt;K&gt;,
+    &lt;HeaderName as TryFrom&lt;K&gt;&gt;::Error: Into&lt;http::Error&gt;,
+    HeaderValue: TryFrom&lt;V&gt;,
+    &lt;HeaderValue as TryFrom&lt;V&gt;&gt;::Error: Into&lt;http::Error&gt;,
+{
+    let mut error = None;
+    if let Ok(ref mut req) = self.request {
+        match &lt;HeaderName as TryFrom&lt;K&gt;&gt;::try_from(key) {
+            Ok(key) =&gt; match &lt;HeaderValue as TryFrom&lt;V&gt;&gt;::try_from(value) {
+                Ok(mut value) =&gt; {
+                    value.set_sensitive(sensitive);
+                    req.headers_mut().append(key, value);
+                }
+                Err(e) =&gt; error = Some(crate::error::builder(e.into())),
+            },
+            Err(e) =&gt; error = Some(crate::error::builder(e.into())),
+        };
+    }
+    if let Some(err) = error {
+        self.request = Err(err);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Add a set of Headers to the existing ones on this Request.
+///
+/// The headers will be merged in to any already set.
+pub fn headers(mut self, headers: crate::header::HeaderMap) -&gt; RequestBuilder {
+    if let Ok(ref mut req) = self.request {
+        crate::util::replace_headers(req.headers_mut(), headers);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Enable HTTP basic authentication.
+pub fn basic_auth&lt;U, P&gt;(self, username: U, password: Option&lt;P&gt;) -&gt; RequestBuilder
+where
+    U: fmt::Display,
+    P: fmt::Display,
+{
+    let mut header_value = b&quot;Basic &quot;.to_vec();
+    {
+        let mut encoder = Base64Encoder::new(&amp;mut header_value, base64::STANDARD);
+        // The unwraps here are fine because Vec::write* is infallible.
+        write!(encoder, &quot;{}:&quot;, username).unwrap();
+        if let Some(password) = password {
+            write!(encoder, &quot;{}&quot;, password).unwrap();
+        }
+    }</code></pre>
+
+<pre><code>    self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+}</code></pre>
+
+<pre><code>/// Enable HTTP bearer authentication.
+pub fn bearer_auth&lt;T&gt;(self, token: T) -&gt; RequestBuilder
+where
+    T: fmt::Display,
+{
+    let header_value = format!(&quot;Bearer {}&quot;, token);
+    self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+}</code></pre>
+
+<pre><code>/// Set the request body.
+pub fn body&lt;T: Into&lt;Body&gt;&gt;(mut self, body: T) -&gt; RequestBuilder {
+    if let Ok(ref mut req) = self.request {
+        *req.body_mut() = Some(body.into());
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Enables a request timeout.
+///
+/// The timeout is applied from when the request starts connecting until the
+/// response body has finished. It affects only this request and overrides
+/// the timeout configured using `ClientBuilder::timeout()`.
+pub fn timeout(mut self, timeout: Duration) -&gt; RequestBuilder {
+    if let Ok(ref mut req) = self.request {
+        *req.timeout_mut() = Some(timeout);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Sends a multipart/form-data body.
+///
+/// ```
+/// # use reqwest::Error;
+///
+/// # async fn run() -&gt; Result&lt;(), Error&gt; {
+/// let client = reqwest::Client::new();
+/// let form = reqwest::multipart::Form::new()
+///     .text(&quot;key3&quot;, &quot;value3&quot;)
+///     .text(&quot;key4&quot;, &quot;value4&quot;);
+///
+///
+/// let response = client.post(&quot;your url&quot;)
+///     .multipart(form)
+///     .send()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(feature = &quot;multipart&quot;)]
+pub fn multipart(self, mut multipart: multipart::Form) -&gt; RequestBuilder {
+    let mut builder = self.header(
+        CONTENT_TYPE,
+        format!(&quot;multipart/form-data; boundary={}&quot;, multipart.boundary()).as_str(),
+    );</code></pre>
+
+<pre><code>    builder = match multipart.compute_length() {
+        Some(length) =&gt; builder.header(CONTENT_LENGTH, length),
+        None =&gt; builder,
+    };</code></pre>
+
+<pre><code>    if let Ok(ref mut req) = builder.request {
+        *req.body_mut() = Some(multipart.stream())
+    }
+    builder
+}</code></pre>
+
+<pre><code>/// Modify the query string of the URL.
+///
+/// Modifies the URL of this request, adding the parameters provided.
+/// This method appends and does not overwrite. This means that it can
+/// be called multiple times and that existing query parameters are not
+/// overwritten if the same key is used. The key will simply show up
+/// twice in the query string.
+/// Calling `.query([(&quot;foo&quot;, &quot;a&quot;), (&quot;foo&quot;, &quot;b&quot;)])` gives `&quot;foo=a&amp;foo=b&quot;`.
+///
+/// # Note
+/// This method does not support serializing a single key-value
+/// pair. Instead of using `.query((&quot;key&quot;, &quot;val&quot;))`, use a sequence, such
+/// as `.query(&amp;[(&quot;key&quot;, &quot;val&quot;)])`. It&#8217;s also possible to serialize structs
+/// and maps into a key-value pair.
+///
+/// # Errors
+/// This method will fail if the object you provide cannot be serialized
+/// into a query string.
+pub fn query&lt;T: Serialize + ?Sized&gt;(mut self, query: &amp;T) -&gt; RequestBuilder {
+    let mut error = None;
+    if let Ok(ref mut req) = self.request {
+        let url = req.url_mut();
+        let mut pairs = url.query_pairs_mut();
+        let serializer = serde_urlencoded::Serializer::new(&amp;mut pairs);</code></pre>
+
+<pre><code>        if let Err(err) = query.serialize(serializer) {
+            error = Some(crate::error::builder(err));
+        }
+    }
+    if let Ok(ref mut req) = self.request {
+        if let Some(&quot;&quot;) = req.url().query() {
+            req.url_mut().set_query(None);
+        }
+    }
+    if let Some(err) = error {
+        self.request = Err(err);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Send a form body.
+pub fn form&lt;T: Serialize + ?Sized&gt;(mut self, form: &amp;T) -&gt; RequestBuilder {
+    let mut error = None;
+    if let Ok(ref mut req) = self.request {
+        match serde_urlencoded::to_string(form) {
+            Ok(body) =&gt; {
+                req.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static(&quot;application/x-www-form-urlencoded&quot;),
+                );
+                *req.body_mut() = Some(body.into());
+            }
+            Err(err) =&gt; error = Some(crate::error::builder(err)),
+        }
+    }
+    if let Some(err) = error {
+        self.request = Err(err);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Send a JSON body.
+///
+/// # Optional
+///
+/// This requires the optional `json` feature enabled.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`&#8217;s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = &quot;json&quot;)]
+pub fn json&lt;T: Serialize + ?Sized&gt;(mut self, json: &amp;T) -&gt; RequestBuilder {
+    let mut error = None;
+    if let Ok(ref mut req) = self.request {
+        match serde_json::to_vec(json) {
+            Ok(body) =&gt; {
+                req.headers_mut()
+                    .insert(CONTENT_TYPE, HeaderValue::from_static(&quot;application/json&quot;));
+                *req.body_mut() = Some(body.into());
+            }
+            Err(err) =&gt; error = Some(crate::error::builder(err)),
+        }
+    }
+    if let Some(err) = error {
+        self.request = Err(err);
+    }
+    self
+}</code></pre>
+
+<pre><code>/// Disable CORS on fetching the request.
+///
+/// # WASM
+///
+/// This option is only effective with WebAssembly target.
+///
+/// The [request mode][mdn] will be set to &#8217;no-cors&#8217;.
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
+pub fn fetch_mode_no_cors(self) -&gt; RequestBuilder {
+    self
+}</code></pre>
+
+<p><br /></p>
+
+<pre><code>	// 从RequestBuilder的build函数可以知道，RequestBuilder是用来帮助构造Request的辅助结构体
+/// Build a `Request`, which can be inspected, modified and executed with
+/// `Client::execute()`.
+pub fn build(self) -&gt; crate::Result&lt;Request&gt; {
+    self.request
+}</code></pre>
+
+<pre><code>/// Constructs the Request and sends it to the target URL, returning a
+/// future Response.
+///
+/// # Errors
+///
+/// This method fails if there was an error while sending request,
+/// redirect loop was detected or redirect limit was exhausted.
+///
+/// # Example
+///
+/// ```no_run
+/// # use reqwest::Error;
+/// #
+/// # async fn run() -&gt; Result&lt;(), Error&gt; {
+/// let response = reqwest::Client::new()
+///     .get(&quot;https://hyper.rs&quot;)
+///     .send()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn send(self) -&gt; impl Future&lt;Output = Result&lt;Response, crate::Error&gt;&gt; {
+    match self.request {
+        Ok(req) =&gt; self.client.execute_request(req),
+        Err(err) =&gt; Pending::new_err(err),
+    }
+}</code></pre>
+
+<pre><code>/// Attempt to clone the RequestBuilder.
+///
+/// `None` is returned if the RequestBuilder can not be cloned,
+/// i.e. if the request body is a stream.
+///
+/// # Examples
+///
+/// ```
+/// # use reqwest::Error;
+/// #
+/// # fn run() -&gt; Result&lt;(), Error&gt; {
+/// let client = reqwest::Client::new();
+/// let builder = client.post(&quot;http://httpbin.org/post&quot;)
+///     .body(&quot;from a &amp;str!&quot;);
+/// let clone = builder.try_clone();
+/// assert!(clone.is_some());
+/// # Ok(())
+/// # }
+/// ```
+pub fn try_clone(&amp;self) -&gt; Option&lt;RequestBuilder&gt; {
+    self.request
+        .as_ref()
+        .ok()
+        .and_then(|req| req.try_clone())
+        .map(|req| RequestBuilder {
+            client: self.client.clone(),
+            request: Ok(req),
+        })
+}</code></pre>
+
+<p>} <code>`</code>` 从RequestBuilder的build函数可以知道，RequestBuilder是用来帮助构造Request的辅助结构体。</p>
+
+<p>参考链接：</p>
+
+<p>https://docs.rs/tokio/1.1.0/tokio/runtime/struct.Builder.html</p>
+
+<p>https://docs.rs/reqwest/0.11.0/src/reqwest/async_impl/request.rs.html#36-39</p>
+
+<p>https://github.com/http-rs/surf/blob/31315743b91ff003231183c1ec5a3cd2b698c58a/src/request_builder.rs</p>
+
+<p>https://docs.rs/futures/0.3.12/futures/executor/struct.ThreadPoolBuilder.html</p>
+]]></content:encoded></item><item><title>学习园地 | 关于 io_uring 与 Rust 的思考</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/io_uring_and_rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='关于_io_uring_与_rust_的思考'>关于 io_uring 与 Rust 的思考</h1>
+
+<p>作者：王徐旸</p>
+
+<h2 id=''></h2>
+
+<p>io_uring 是 Linux 5.x 时代加入的一套全新的异步机制，被钦定为 Linux 异步的未来。</p>
+
+<p>本文将探讨在 Rust 中安全封装 io_uring 的一系列设计问题，并提出一些可能的解决方案。</p>
+
+<h2 id='io_uring_的工作方式'>io_uring 的工作方式</h2>
+
+<p>io_uring 分为两个队列，提交队列 SQ (Submission Queue) 和完成队列 CQ (Completion Queue)。提交队列存放正在等待执行的异步任务，完成队列存放完成事件。</p>
+
+<p>io_uring 的结构由内核分配，用户态通过 mmap 拿到相关结构的内存访问权限，这样就能让内核态与用户态共享内存，绕过系统调用双向传递数据。</p>
+
+<p>概念工作流程具有三个阶段</p>
+
+<ol type="1">
+<li>准备：应用程序获取一些提交队列项 SQE (Submission Queue Entry)，将每个异步任务分别设置到每个 SQE 中，用操作码、参数初始化。</li>
+
+<li>提交：应用程序向 SQ 中推入一些需要提交的 SQE，通过一次系统调用告诉内核有新的任务，或者让内核不停轮询来获取任务。</li>
+
+<li>收割：应用程序从 CQ 中取得一些完成队列事件 CQE (Completion Queue Event)，通过 user_data 识别并唤醒应用程序中的线程/协程，传递返回值。</li>
+</ol>
+
+<p>epoll 是 Reactor 模型的实现，而 io_uring 是 Proactor 模型的实现。</p>
+
+<p>这意味着基于 epoll 设计的程序难以直接迁移到 io_uring。</p>
+
+<p><strong>问题 1</strong>: 改变异步模型并不是一件容易的事，除非以部分性能为代价抹平差异。</p>
+
+<p><strong>问题 2</strong>: io<em>uring 需要较高版本的内核，现阶段，应用程序不得不考虑在没有 io</em>uring 高版本特性时要怎么回退 (fallback)。</p>
+
+<h2 id='io_uring_的约束'>io_uring 的约束</h2>
+
+<p>在阻塞同步模型和非阻塞同步模型(如 epoll)中，用户态 IO 操作是一锤子买卖，无需担心生存期。</p>
+
+<p>但 io_uring 是 Proactor，是非阻塞异步模型，对资源的生存期有所约束。</p>
+
+<p>以 read 为例，它有 fd 和 buf 两个资源参数，当准备 IO 操作时，我们需要把 fd、buf 指针和 count 填入 SQE，并且<strong>保证在内核完成或取消该任务之前，fd 和 buf 都必须有效</strong>。</p>
+
+<h3 id='fd_意外替换'>fd 意外替换</h3>
+
+<pre><code class="language-`c">fd = 6, buf = 0x5678;
+准备 SQE;
+close fd = 6;
+open -&gt; fd = 6;
+提交 SQE;
+内核执行 IO;</code></pre>
+
+<p>在提交 SQE 之前，应用程序“不小心”关闭又打开了文件，这将导致 IO 操作意外地被执行到一个完全无关的文件上。</p>
+
+<h3 id='栈内存_uaf'>栈内存 UAF</h3>
+
+<pre><code class="language-`c">char stack_buf[1024];
+fd = 6, buf = &amp;stack_buf;
+准备 SQE;
+提交 SQE;
+函数返回;
+内核执行 IO;</code></pre>
+
+<p>内核执行的 IO 会操作已被释放的栈上内存，出现“释放后使用”(use-after-free) 漏洞。</p>
+
+<h3 id='堆内存_uaf'>堆内存 UAF</h3>
+
+<pre><code class="language-`c">char* heap_buf = malloc(1024);
+fd = 6, buf = heap_buf;
+准备 SQE;
+提交 SQE;
+执行其他代码出错;
+free(heap_buf);
+函数返回错误码;
+内核执行 IO;</code></pre>
+
+<p>内核执行的 IO 会使用已被释放的堆上内存，又一个 UAF 漏洞。</p>
+
+<h3 id='移动后使用'>移动后使用</h3>
+
+<pre><code class="language-`rust">struct Buf&lt;T&gt;(T);
+let mut buf1: Buf&lt;[u8;1024]&gt; = Buf([0;1024]);
+fd = 6, buf = buf1.0.as_mut_ptr();
+unsafe {
+    准备 SQE;
+}
+提交 SQE;
+let buf2 = Box::new(buf1);
+内核执行 IO;</code></pre>
+
+<p>当内核执行 IO 时，buf1 已被移动，指针失效。出现“移动后使用”的漏洞，本文称为 UAM 漏洞。</p>
+
+<h3 id='取消后使用'>取消后使用</h3>
+
+<pre><code class="language-`rust">async fn foo() -&gt; io::Result&lt;()&gt; {
+    let mut buf1: [u8;1024] = [0;1024];
+    fd = 6, buf = buf1.as_mut_ptr();
+    unsafe {
+        准备 SQE;
+    }
+    提交 SQE;
+    bar().await
+}</code></pre>
+
+<p>Rust 的 async 函数会生成无栈协程，栈变量保存在一个结构体中。如果这个结构体被析构，底层的叶 Future 就会被析构，同时取消异步操作。</p>
+
+<p>然而析构函数是同步的，<strong>当协程析构时，内核仍然可能正在占用缓冲区来执行 IO</strong>。如果不做处理，就会出现 UAF 漏洞。</p>
+
+<h3 id='关闭后使用'>关闭后使用</h3>
+
+<pre><code class="language-`rust">准备 SQE;
+提交 SQE;
+io_uring_queue_exit(&amp;ring)
+???</code></pre>
+
+<p>内核在 io<em>uring</em>queue_exit 之后会立即取消正在执行的 IO 吗？</p>
+
+<p>// TODO: 找到答案</p>
+
+<p>如果会立即取消，那么用户态程序也无法得到取消事件，无法唤醒任务或释放资源。</p>
+
+<p>如果不会立即取消，那么内核对资源的占用会超出 io_uring 实例的生存期，带来更加麻烦的问题。</p>
+
+<p>这似乎说明 io_uring 实例必须为 static 生存期，与线程本身活得一样长。或者采取某种引用计数的方式，推迟 exit 时机。</p>
+
+<h2 id='具有_rust_特色的_io_uring'>具有 Rust 特色的 io_uring</h2>
+
+<p>Rust 的底线是内存安全，不允许出现内存安全漏洞或数据竞争。Rust 的所有权规则为此提供了很好的保障。</p>
+
+<h3 id='迁移所有权'>迁移所有权</h3>
+
+<p>“迁移所有权” 是本文中自行创造的概念，它表示要进行某个操作就必须放弃对参数的所有权，把参数的所有权“迁移”到其他地方。</p>
+
+<p>当使用 io_uring 时，相当于内核持有资源的所有权。用户态必须放弃对资源的控制权，除非它可以安全地并发操作。IO 操作完成或取消时，内核占用的所有资源会被返还给用户态。</p>
+
+<p>但内核不可能真的去持有所有权，实际上是由异步运行时来存储这些资源，并模拟出“迁移所有权”的模型。</p>
+
+<p><code>BufRead</code> trait 表示一个包含内部缓冲区的可读取类型。<code>BufReader&lt;File&gt;</code> 是一个典型用法。</p>
+
+<p><code>BufReader&lt;File&gt;</code> 可以匹配 io_uring 的工作模式。</p>
+
+<pre><code class="language-`">准备 fd, buf
+准备 SQE
+提交 SQE
+等待唤醒
+拿到返回值
+回收 fd, buf
+暴露 buf 的共享引用</code></pre>
+
+<p><strong>问题 3</strong>: 当 Future 被取消时，buf 仍然被内核占用，<code>BufReader&lt;File&gt;</code> 处于无效状态。再次进行 IO 时，它只能选择死亡。</p>
+
+<p>想象这样一个底层 Future</p>
+
+<pre><code class="language-`rust">pub struct Read&lt;F, B&gt;
+where
+    F: AsRawFd + &#8217;static,
+    B: AsMut&lt;[u8]&gt; + &#8217;static,
+{
+    fd: F,
+    buf: B,
+    ...
+}</code></pre>
+
+<p>buf 可以是 <code>[u8; N]</code>，也满足 <code>AsMut&lt;[u8]&gt; + &#8217;static</code>，但它不能被取指针传递给 io_uring。</p>
+
+<p>buf 在这个 Future 被析构时失效，不满足 io_uring 的约束。</p>
+
+<p>修复方案有两种：在准备 SQE 之前就把 fd 和 buf 都移动到堆上，或者限制 buf 为可安全逃逸的缓冲区类型。</p>
+
+<h3 id='堆分配'>堆分配</h3>
+
+<p>如果要在准备 SQE 之前确保 fd 和 buf 不会被析构，只能堆分配了。</p>
+
+<p>这样 fd 和 buf 在 IO 操作完成或取消之前就不会被移动或析构，保证了有效性。</p>
+
+<pre><code class="language-`rust">pub struct Read&lt;F, B&gt;
+where
+    F: AsRawFd + &#8217;static,
+    B: AsMut&lt;[u8]&gt; + &#8217;static,
+{
+    state: ManualDrop&lt;Box&lt;State&lt;F, B&gt;&gt;&gt;
+}</code></pre>
+
+<p>然而，大部分时候 buf 都是指向堆上动态大小缓冲区的智能指针，为指针本身去堆分配是不太值得的，要提高效率必须以某种方式实现自定义分配器。</p>
+
+<h3 id='逃逸'>逃逸</h3>
+
+<p>通常的“逃逸分析”是分析对象的动态范围，如果对象有可能离开函数作用域，就把它分配到堆上。</p>
+
+<p>本文提出的“逃逸”是指让结构体成员逃脱析构，转移到一个稳定的地方。</p>
+
+<p>可安全逃逸的缓冲区类型在移动时不会改变缓冲区的内存地址。</p>
+
+<p><code>[u8;N]</code> 在移动时完全改变了缓冲区的地址范围，而 <code>Box&lt;[u8]&gt;</code> 和 <code>Vec&lt;u8&gt;</code> 不会改变。</p>
+
+<p><code>SmallVec&lt;[u8;N]&gt;</code> 在容量不大于 N 时会把数据存储在栈上，过大时存储在堆上。</p>
+
+<p><code>Box&lt;[u8]&gt;</code> 和 <code>Vec&lt;u8&gt;</code> 作为缓冲区可以安全逃逸，<code>[u8;N]</code> 和 <code>SmallVec&lt;[u8;N]&gt;</code> 不可以。</p>
+
+<p>如果限制 buf 为可安全逃逸的缓冲区类型，那么在最理想的情况下，进行 IO 操作时不需要系统调用，不需要额外的堆分配，缓冲区由调用者控制，几乎完美。</p>
+
+<p><strong>问题 4</strong>: 如何在不传染 unsafe 的情况下表达这种约束？</p>
+
+<p>定义一个 unsafe trait 自然省事，但无法对所有符合条件的缓冲区通用，还可能受孤儿规则影响，让用户必须去写 newtype 或 unsafe。</p>
+
+<p>可以意识到，这里的“安全逃逸”和 <code>Pin</code> 的概念有某种相关，有没有办法联系起来？</p>
+
+<h3 id='send'>Send</h3>
+
+<p>io_uring 的收割可以由本线程做，也可以由一个专门的驱动线程做。</p>
+
+<p>目前 SQ 不支持多线程提交，全局共享需要上锁。io_uring 更匹配每个线程自带一个 ring 的实现。</p>
+
+<p>考虑这样一个 Future，当它析构时，里面的资源会逃逸到堆上。</p>
+
+<pre><code class="language-`rust">pub struct Read&lt;F, B&gt;
+where
+    F: AsRawFd + &#8217;static,
+    B: EscapedBufMut + &#8217;static,
+{
+    fd: F,
+    buf: B,
+    ...
+}</code></pre>
+
+<p>如果由全局驱动线程做最终析构，那么资源就会从当前线程转移到驱动线程，这需要资源满足 Send。</p>
+
+<p>如果由本线程做最终析构，那么资源不需要转移，可以不满足 Send。</p>
+
+<p><strong>问题 5</strong>: 收割和析构策略也会影响 API 的泛型约束，如何设计合适的 API？</p>
+
+<h3 id='拷贝'>拷贝</h3>
+
+<p>缓冲区必须能在 Future 析构之后保持有效，这意味着我们无法把临时的 <code>&amp;mut [u8]</code> 或 <code>&amp;[u8]</code> 传入 io_uring，无法做原地读取或写入。</p>
+
+<p>而 epoll 可以等待 fd 可读或可写后，再原地读取或写入。</p>
+
+<p>无论如何，把缓冲区放在堆上这一步是不可避免的，区别在于缓冲区是由异步类型本身来控制还是由调用者来控制。</p>
+
+<p>让调用者来控制缓冲区，能避免额外拷贝，但会加大安全审查的难度，必须限制传入的缓冲区具有良好的行为。</p>
+
+<p>异步类型内置缓冲区，会增加额外拷贝，但安全性由库的作者保证，减小了出现漏洞的可能性。</p>
+
+<p><strong>问题6</strong>: io_uring 加大了实现用户态零拷贝的难度。</p>
+
+<h2 id='生态'>生态</h2>
+
+<p><a href='https://github.com/ringbahn/uring-sys'>uring-sys</a>： liburing 的绑定。</p>
+
+<p><a href='https://github.com/ringbahn/iou'>iou</a>：Rust 风格的低层 io_uring 接口。</p>
+
+<p><a href='https://github.com/ringbahn/ringbahn'>ringbahn</a>：实验性的 io_uring 高层封装</p>
+
+<p><a href='https://github.com/ringbahn/maglev'>maglev</a>：实验性的 io_uring 异步驱动/运行时</p>
+
+<h2 id='总结'>总结</h2>
+
+<p>划个重点</p>
+
+<p><strong>问题 1</strong>: epoll 是 Reactor 模型的实现，而 io_uring 是 Proactor 模型的实现。改变异步模型并不是一件容易的事，除非以性能为代价抹平差异。</p>
+
+<p><strong>问题 2</strong>: io<em>uring 需要较高版本的内核，现阶段，应用程序不得不考虑在没有 io</em>uring 高版本特性时要怎么回退 (fallback)。</p>
+
+<p><strong>问题 3</strong>: 当 Future 被取消时，buf 仍然被内核占用，异步类型可能处于无效状态。再次进行 IO 时，它只能选择死亡。</p>
+
+<p><strong>问题 4</strong>: 如果选择限制 buf 为可安全逃逸的缓冲区类型，如何在不传染 unsafe 的情况下表达这种约束？</p>
+
+<p><strong>问题 5</strong>: 收割和析构策略也会影响 API 的泛型约束，如何设计合适的 API？</p>
+
+<p><strong>问题 6</strong>: io_uring 加大了实现用户态零拷贝的难度。</p>
+
+<p>如果不考虑最高性能，我们有各种方案来封装一个能用的 io_uring 库。</p>
+
+<p>如果不考虑通用，我们可以在自己的程序中谨慎地用 io_uring，锁死类型。</p>
+
+<p>Rust 对安全、性能、通用的追求给封装 io_uring 带来了较高的难度。</p>
+
+<p><a href='https://github.com/ringbahn/ringbahn'>ringbahn</a> 的设计思路是其中一种可能的方向。社区还需要探索什么才是最完美的设计。</p>
+
+<h2 id='扩展阅读'>扩展阅读</h2>
+
+<p><a href='http://kernel.dk/io_uring.pdf'>Efficient IO with io_uring</a></p>
+
+<p><a href='https://zhuanlan.zhihu.com/p/62682475'>AIO 的新归宿：io_uring</a></p>
+
+<p><a href='http://icebergu.com/archives/go-iouring'>Go 与异步 IO - io_uring 的思考</a></p>
+
+<p><a href='https://without.boats/blog/io-uring/'>Notes on io-uring</a></p>
+
+<p><a href='https://without.boats/blog/ringbahn/'>Ringbahn: a safe, ergonomic API for io-uring in Rust</a></p>
+
+<p><a href='https://without.boats/blog/ringbahn-ii/'>Ringbahn II: the central state machine</a></p>
+
+<p><a href='https://without.boats/blog/ringbahn-iii/'>Ringbahn III: A deeper dive into drivers</a></p>
+
+<p><a href='https://github.com/axboe/liburing/issues/109'>feature requests: submit requests from any thread</a></p>
+
+<h2 id=''></h2>
+
+<p>本文首发于知乎专栏 「<a href='https://zhuanlan.zhihu.com/p/346219893'>Rust 日常</a>」</p>
+
+<p>作者简介：</p>
+
+<p>王徐旸，大三学生，2018 年开始学习和使用 Rust 语言，造轮子爱好者。</p>
+
+<p>GitHub ID: <a href='https://github.com/Nugine'>Nugine</a></p>
+]]></content:encoded></item><item><title>学习园地 | 「译」 GraphQL in Rust</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/graphql_in_rust/graphql_in_rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='学习园地_|_「译」_graphql_in_rust'>学习园地 | 「译」 GraphQL in Rust</h1>
+
+<h2 id='译者序'>译者序</h2>
+
+<p>Roman Kudryashov(<a href='https://romankudryashov.com'>博客</a>)是一名来自莫斯科的资深后端开发人员，在日常工作中用Rust/Java/Kotlin来完成服务的持久层，微服务之间的集成等工作。在<code>Async-graphql</code>的开发过程中给予了非常多的<a href='https://github.com/async-graphql/async-graphql/issues?q=is%3Aissue+author%3Arkudryashov'>帮助</a>，然后根据这些经验总结出来这篇入门教程（<a href='https://romankudryashov.com/blog/2020/12/graphql-rust/'>英文原版</a>）。</p>
+
+<p>译者老油条（<a href='https://github.com/sunli829'>孙黎</a>），<code>Async-graphql</code>库作者，连续创业者，处女座码农，之前日常工作由C++和Golang完成，两年前一个偶然的机会邂逅Rust语言，并不由自主的爱上了它，之后再也没有碰过其它编程语言，工作中用Rust语言完成所有的事情，是不折不扣的Rust语言狂热粉丝。Rust是我这么多年编程生涯中真正遇到的完美编程语言，无GC，并发安全以及类似Python等脚本语言才提供的高级语法，让我产生给它做一些力所能及的贡献的想法，<a href='https://github.com/sunli829/nvg'>nvg</a>和<a href='https://github.com/sunli829/xactor'>Xactor</a>是刚学Rust不久之后的小试牛刀，而<a href='https://github.com/async-graphql/async-graphql'>Async-graphql</a>是Rust 1.39异步稳定之后的产物。</p>
+
+<p><em>学习Rust的过程很艰辛，需要保持一颗修行的心，当你能够越过那一座座阻碍在面前的高山，也许才能够发现它真正的美好。</em></p>
+
+<h2 id='目录'>目录</h2>
+
+<ul>
+<li>
+<p><a href='#介绍'>介绍</a></p>
+
+<ul>
+<li><a href='#概览'>概览</a></li>
+
+<li><a href='#技术栈'>技术栈</a></li>
+
+<li><a href='#开发工具'>开发工具</a></li>
+</ul>
+</li>
+
+<li>
+<p>实现</p>
+
+<ul>
+<li><a href='#依赖库'>依赖库</a></li>
+
+<li><a href='#核心功能'>核心功能</a></li>
+
+<li><a href='#查询和类型定义'>查询和类型定义</a></li>
+
+<li><a href='#解决N+1问题'>解决N+1问题</a></li>
+
+<li><a href='#接口定义'>接口定义</a></li>
+
+<li><a href='#自定义标量'>自定义标量</a></li>
+
+<li><a href='#定义变更(Mutation'>定义变更(Mutation)</a>)</li>
+
+<li><a href='#定义订阅(Subscription'>定义订阅(Subscription)</a>)</li>
+
+<li><a href='#集成测试'>集成测试</a></li>
+
+<li><a href='#GraphQL客户端'>GraphQL客户端</a></li>
+
+<li><a href='#API安全'>API安全</a></li>
+
+<li><a href='#定义枚举'>定义枚举</a></li>
+
+<li><a href='#日期处理'>日期处理</a></li>
+
+<li><a href='#支持ApolloFederation'>支持Apollo Federation</a></li>
+
+<li><a href='#ApolloServer'>Apollo Server</a></li>
+
+<li><a href='#数据库交互'>数据库交互</a></li>
+
+<li><a href='#运行和API测试'>运行和API测试</a></li>
+
+<li><a href='#订阅测试'>订阅测试</a></li>
+
+<li><a href='#CI/CD'>CI/CD</a></li>
+</ul>
+</li>
+
+<li><a href='#结论'>结论</a></li>
+
+<li><a href='#有用的链接'>有用的链接</a></li>
+</ul>
+
+<p>在今天的文章中，我将描述如何使用Rust及其生态系统创建GraphQL后端服务。 本文提供了创建GraphQL API时最常见任务的实现示例。最后，将使用Apollo Server和Apollo Federation将三个微服务组合为一个端点。 这使客户端可以同时从任意数量的源中获取数据，而无需知道哪些数据来自哪个源。</p>
+
+<h2 id='介绍'>介绍</h2>
+
+<h3 id='概览'>概览</h3>
+
+<p>在功能方面，所描述的项目与我上一篇文章中所描述的非常相似，但是现在它是使用Rust编写的。 该项目的架构如下所示：</p>
+
+<p><img src='architecture.png' alt='architecture' /></p>
+
+<p>架构的每个组件都回答了在实现GraphQL API时可能出现的几个问题。整个模型包括有关太阳系中的行星及其卫星的数据。该项目具有多模块结构，并包含以下模块：</p>
+
+<ul>
+<li>
+<p><a href='https://github.com/rkudryashov/graphql-rust-demo/tree/master/planets-service'>planets-service</a> (Rust)</p>
+</li>
+
+<li>
+<p><a href='https://github.com/rkudryashov/graphql-rust-demo/tree/master/satellites-service'>satellites-service</a> (Rust)</p>
+</li>
+
+<li>
+<p><a href='https://github.com/rkudryashov/graphql-rust-demo/tree/master/auth-service'>auth-service</a> (Rust)</p>
+</li>
+
+<li>
+<p><a href='https://github.com/rkudryashov/graphql-rust-demo/tree/master/apollo-server'>apollo-server</a> (JS)</p>
+</li>
+</ul>
+
+<p>在Rust中有两个库来创建GraphQL后端：<a href='https://github.com/graphql-rust/juniper'>Juniper</a>和<a href='https://github.com/async-graphql/async-graphql'>Async-graphql</a>，但是只有后者支持Apollo Federation，因此我在项目中选择了它（Juniper中的Federation支持存在未解决的<a href='https://github.com/graphql-rust/juniper/issues/376'>问题</a>）。 这两个库都遵循<a href='https://blog.logrocket.com/code-first-vs-schema-first-development-graphql/'>代码优先</a>方法。</p>
+
+<p>同样，PostgreSQL用于持久层实现，<a href='https://jwt.io/'>JWT</a>用于认证，而Kafka用于消息传递。</p>
+
+<h3 id='技术栈'>技术栈</h3>
+
+<p>下表总结了该项目中使用的主要技术栈：</p>
+
+<p>|类型|名字|网站|代码仓库| |------|------|------|------------| |语言|Rust|<a href='https://www.rust-lang.org/'>link</a>|<a href='https://github.com/rust-lang/rust'>link</a>| |GraphQL服务端库|Async-graphql|<a href='https://async-graphql.github.io/async-graphql/zh-CN/index.html'>link</a>|<a href='https://github.com/async-graphql/async-graphql'>link</a>| |GraphQL网关|Apollo Server|<a href='https://www.apollographql.com/docs/apollo-server/'>link</a>|<a href='https://github.com/apollographql/apollo-server'>link</a>| |Web框架|Actix-web|<a href='https://actix.rs/'>link</a>|<a href='https://github.com/actix/actix-web'>link</a>| |数据库|PostgreSQL|<a href='https://www.postgresql.org/'>link</a>|<a href='https://github.com/postgres/postgres'>link</a>| |消息队列|Apache Kafka|<a href='https://kafka.apache.org/'>link</a>|<a href='https://github.com/apache/kafka'>link</a>| |容器编排|Docker Compose|<a href='https://docs.docker.com/compose/'>link</a>|<a href='https://github.com/docker/compose'>link</a>|</p>
+
+<p>另外还有一些需要依赖的Rust库:</p>
+
+<p>|类型|名字|网站|代码仓库| |------|------|------|------------| |ORM|Diesel|<a href='https://diesel.rs/'>link</a>|<a href='https://github.com/diesel-rs/diesel'>link</a>| |Kafka客户端|rust-rdkafka|<a href='https://crates.io/crates/rdkafka'>link</a>|<a href='https://github.com/fede1024/rust-rdkafka'>link</a>| |密码哈希库|argonautica|<a href='https://crates.io/crates/argonautica'>link</a>|<a href='https://github.com/bcmyers/argonautica'>link</a>| |JWT|jsonwebtoken|<a href='https://crates.io/crates/jsonwebtoken'>link</a>|<a href='https://github.com/Keats/jsonwebtoken'>link</a>| |测试|Testcontainers-rs|<a href='https://crates.io/crates/testcontainers'>link</a>|<a href='https://github.com/testcontainers/testcontainers-rs'>link</a>|</p>
+
+<h3 id='开发工具'>开发工具</h3>
+
+<p>要在本地启动项目，你只需要<code>Docker Compose</code>。 如果没有<code>Docker</code>，可能需要安装以下内容：</p>
+
+<ul>
+<li><a href='https://www.rust-lang.org/tools/install'>Rust</a></li>
+
+<li><a href='https://diesel.rs/guides/getting-started/'>Diesel CLI</a> (运行 <code>cargo install diesel_cli --no-default-features --features postgres</code>)</li>
+
+<li><a href='https://releases.llvm.org/download.html'>LLVM</a>(<code>argonautica</code>依赖)</li>
+
+<li><a href='https://cmake.org/install/'>CMake</a> (<code>rust-rdkafka</code>依赖)</li>
+
+<li><a href='https://www.postgresql.org/download/'>PostgreSQL</a></li>
+
+<li><a href='https://kafka.apache.org/quickstart'>Apache Kafka</a></li>
+
+<li><a href='https://www.npmjs.com/get-npm'>npm</a></li>
+</ul>
+
+<h3 id='实现'>实现</h3>
+
+<p><em>清单1. 根<code>Cargo.toml</code>指定三个应用和一个库:</em></p>
+
+<p>根<a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/Cargo.toml'>Cargo.toml</a></p>
+
+<pre><code class="language-`toml">[workspace]
+members = [
+    &quot;auth-service&quot;,
+    &quot;planets-service&quot;,
+    &quot;satellites-service&quot;,
+    &quot;common-utils&quot;,
+]</code></pre>
+
+<p>让我们从<a href='https://github.com/rkudryashov/graphql-rust-demo/tree/master/planets-service'>planets-service</a>开始。</p>
+
+<h3 id='依赖库'>依赖库</h3>
+
+<p>这是Cargo.toml：</p>
+
+<p><em>清单2. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/Cargo.toml'>Cargo.toml</a></em></p>
+
+<pre><code class="language-`toml">[package]
+name = &quot;planets-service&quot;
+version = &quot;0.1.0&quot;
+edition = &quot;2018&quot;
+
+[dependencies]
+common-utils = { path = &quot;../common-utils&quot; }
+async-graphql = &quot;2.4.3&quot;
+async-graphql-actix-web = &quot;2.4.3&quot;
+actix-web = &quot;3.3.2&quot;
+actix-rt = &quot;1.1.1&quot;
+actix-web-actors = &quot;3.0.0&quot;
+futures = &quot;0.3.8&quot;
+async-trait = &quot;0.1.42&quot;
+bigdecimal = { version = &quot;0.1.2&quot;, features = [&quot;serde&quot;] }
+serde = { version = &quot;1.0.118&quot;, features = [&quot;derive&quot;] }
+serde_json = &quot;1.0.60&quot;
+diesel = { version = &quot;1.4.5&quot;, features = [&quot;postgres&quot;, &quot;r2d2&quot;, &quot;numeric&quot;] }
+diesel_migrations = &quot;1.4.0&quot;
+dotenv = &quot;0.15.0&quot;
+strum = &quot;0.20.0&quot;
+strum_macros = &quot;0.20.1&quot;
+rdkafka = { version = &quot;0.24.0&quot;, features = [&quot;cmake-build&quot;] }
+async-stream = &quot;0.3.0&quot;
+lazy_static = &quot;1.4.0&quot;
+
+[dev-dependencies]
+jsonpath_lib = &quot;0.2.6&quot;
+testcontainers = &quot;0.9.1&quot;</code></pre>
+
+<p><code>Async-graphql</code>是GraphQL服务端库，<code>Actix-web</code>是Web服务框架，而<code>Async-graphql-actix-web</code>提供它们之间的集成。</p>
+
+<h3 id='核心功能'>核心功能</h3>
+
+<p>我们转到<code>main.rs</code>：</p>
+
+<p><em>清单3. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/main.rs'>main.rs</a></em></p>
+
+<pre><code class="language-`rust">#[actix_rt::main]
+async fn main() -&gt; std::io::Result&lt;()&gt; {
+    dotenv().ok();
+    let pool = create_connection_pool();
+    run_migrations(&amp;pool);
+
+    let schema = create_schema_with_context(pool);
+
+    HttpServer::new(move || App::new()
+        .configure(configure_service)
+        .data(schema.clone())
+    )
+        .bind(&quot;0.0.0.0:8001&quot;)?
+        .run()
+        .await
+}</code></pre>
+
+<p>这里，使用<code>lib.rs</code>中定义的功能配置环境和HTTP服务器：</p>
+
+<p><em>清单4. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/lib.rs'>lib.rs</a></em></p>
+
+<pre><code class="language-`rust">pub fn configure_service(cfg: &amp;mut web::ServiceConfig) {
+    cfg
+        .service(web::resource(&quot;/&quot;)
+            .route(web::post().to(index))
+            .route(web::get().guard(guard::Header(&quot;upgrade&quot;, &quot;websocket&quot;)).to(index_ws))
+            .route(web::get().to(index_playground))
+        );
+}
+
+async fn index(schema: web::Data&lt;AppSchema&gt;, http_req: HttpRequest, req: Request) -&gt; Response {
+    let mut query = req.into_inner();
+
+    let maybe_role = common_utils::get_role(http_req);
+    if let Some(role) = maybe_role {
+        query = query.data(role);
+    }
+
+    schema.execute(query).await.into()
+}
+
+async fn index_ws(schema: web::Data&lt;AppSchema&gt;, req: HttpRequest, payload: web::Payload) -&gt; Result&lt;HttpResponse&gt; {
+    WSSubscription::start(Schema::clone(&amp;*schema), &amp;req, payload)
+}
+
+async fn index_playground() -&gt; HttpResponse {
+    HttpResponse::Ok()
+        .content_type(&quot;text/html; charset=utf-8&quot;)
+        .body(playground_source(GraphQLPlaygroundConfig::new(&quot;/&quot;).subscription_endpoint(&quot;/&quot;)))
+}
+
+pub fn create_schema_with_context(pool: PgPool) -&gt; Schema&lt;Query, Mutation, Subscription&gt; {
+    let arc_pool = Arc::new(pool);
+    let cloned_pool = Arc::clone(&amp;arc_pool);
+    let details_batch_loader = Loader::new(DetailsBatchLoader {
+        pool: cloned_pool
+    }).with_max_batch_size(10);
+
+    let kafka_consumer_counter = Mutex::new(0);
+
+    Schema::build(Query, Mutation, Subscription)
+        .data(arc_pool)
+        .data(details_batch_loader)
+        .data(kafka::create_producer())
+        .data(kafka_consumer_counter)
+        .finish()
+}</code></pre>
+
+<p>这些函数执行以下操作：</p>
+
+<ul>
+<li><code>index</code> - 处理GraphQL<a href='https://graphql.org/learn/queries/'>查询和变更</a></li>
+
+<li><code>index_ws</code> - 处理GraphQL<a href='https://www.apollographql.com/docs/react/data/subscriptions/'>订阅</a></li>
+
+<li><code>index_playground</code> - 提供Graph Playground IDE</li>
+
+<li><code>create_schema_with_context</code> - 使用可在运行时访问的全局上下文数据（例如数据库连接池）创建GraphQL模式</li>
+</ul>
+
+<h3 id='查询和类型定义'>查询和类型定义</h3>
+
+<p>让我们考虑如何定义查询：</p>
+
+<p><em>清单5. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>定义查询</a></em></p>
+
+<pre><code class="language-`rust">#[Object]
+impl Query {
+    async fn get_planets(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;) -&gt; Vec&lt;Planet&gt; {
+        repository::get_all(&amp;get_conn_from_ctx(ctx)).expect(&quot;Can&#8217;t get planets&quot;)
+            .iter()
+            .map(|p| { Planet::from(p) })
+            .collect()
+    }
+
+    async fn get_planet(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;, id: ID) -&gt; Option&lt;Planet&gt; {
+        find_planet_by_id_internal(ctx, id)
+    }
+
+    #[graphql(entity)]
+    async fn find_planet_by_id(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;, id: ID) -&gt; Option&lt;Planet&gt; {
+        find_planet_by_id_internal(ctx, id)
+    }
+}
+
+fn find_planet_by_id_internal(ctx: &amp;Context&lt;&#8217;_&gt;, id: ID) -&gt; Option&lt;Planet&gt; {
+    let id = id.to_string().parse::&lt;i32&gt;().expect(&quot;Can&#8217;t get id from String&quot;);
+    repository::get(id, &amp;get_conn_from_ctx(ctx)).ok()
+        .map(|p| { Planet::from(&amp;p) })
+}</code></pre>
+
+<p>每个查询都使用<code>repository</code>从数据库获取数据并将获得的记录转换为GraphQL DTO（这使我们可以保留每个结构的单一职责）。 可以从任何GraphQL IDE访问<code>get_planets</code>和<code>get_planet</code>查询，例如：</p>
+
+<p><em>清单6. 查询示例</em></p>
+
+<pre><code class="language-`graphql">{
+  getPlanets {
+    name
+    type
+  }
+}</code></pre>
+
+<p><code>Planet</code>对象定义如下：</p>
+
+<p><em>清单7. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>GraphQL类型定义</a></em></p>
+
+<pre><code class="language-`rust">#[derive(Serialize, Deserialize)]
+struct Planet {
+    id: ID,
+    name: String,
+    planet_type: PlanetType,
+}
+
+#[Object]
+impl Planet {
+    async fn id(&amp;self) -&gt; &amp;ID {
+        &amp;self.id
+    }
+
+    async fn name(&amp;self) -&gt; &amp;String {
+        &amp;self.name
+    }
+
+    /// From an astronomical point of view
+    #[graphql(name = &quot;type&quot;)]
+    async fn planet_type(&amp;self) -&gt; &amp;PlanetType {
+        &amp;self.planet_type
+    }
+
+    #[graphql(deprecation = &quot;Now it is not in doubt. Do not use this field&quot;)]
+    async fn is_rotating_around_sun(&amp;self) -&gt; bool {
+        true
+    }
+
+    async fn details(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;) -&gt; Details {
+        let loader = ctx.data::&lt;Loader&lt;i32, Details, DetailsBatchLoader&gt;&gt;().expect(&quot;Can&#8217;t get loader&quot;);
+        let planet_id = self.id.to_string().parse::&lt;i32&gt;().expect(&quot;Can&#8217;t convert id&quot;);
+        loader.load(planet_id).await
+    }
+}</code></pre>
+
+<p>在这里，我们为每个字段定义一个Resolver。另外，在某些字段中，指定了描述（Rust文档注释）和弃用原因。 这些将显示在GraphQL IDE中。</p>
+
+<h3 id='解决n+1问题'>解决N+1问题</h3>
+
+<p>如果<code>Planet</code>的<code>details</code>函数的实现是直接从数据库中查询对应<code>id</code>的<code>planet</code>对象则将导致N+1问题，如果你发出这样的请求：</p>
+
+<p><em>清单8: 可能消耗过多资源的GraphQL请求的示例</em></p>
+
+<pre><code class="language-`graphql">{
+  getPlanets {
+    name
+    details {
+      meanRadius
+    }
+  }
+}</code></pre>
+
+<p>这将对每个<code>plant</code>对象的<code>details</code>字段执行单独的SQL查询，因为<code>details</code>是与<code>planet</code>关联的类型，并存储在其自己的表中。</p>
+
+<p>但借助<code>Async-graphql</code>的<a href='https://github.com/graphql/dataloader'>DataLoader</a>实现，可以将Resolver定义如下：</p>
+
+<pre><code class="language-`rust">async fn details(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;) -&gt; Result&lt;Details&gt; {
+    let data_loader = ctx.data::&lt;DataLoader&lt;DetailsLoader&gt;&gt;().expect(&quot;Can&#8217;t get data loader&quot;);
+    let planet_id = self.id.to_string().parse::&lt;i32&gt;().expect(&quot;Can&#8217;t convert id&quot;);
+    let details = data_loader.load_one(planet_id).await?;
+    details.ok_or_else(|| &quot;Not found&quot;.into())
+}</code></pre>
+
+<p><code>data_loader</code>是通过以下方式定义的应用程序范围的对象：</p>
+
+<p><em>清单10. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/lib.rs'>DataLoader定义</a></em></p>
+
+<pre><code class="language-`rust">let details_data_loader = DataLoader::new(DetailsLoader {
+    pool: cloned_pool
+}).max_batch_size(10)</code></pre>
+
+<p><code>DetailsLoader</code>的实现：</p>
+
+<p>\_清单11. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>DetailsLoader定义</a></p>
+
+<pre><code class="language-`rust">pub struct DetailsLoader {
+    pub pool: Arc&lt;PgPool&gt;
+}
+
+#[async_trait::async_trait]
+impl Loader&lt;i32&gt; for DetailsLoader {
+    type Value = Details;
+    type Error = Error;
+
+    async fn load(&amp;self, keys: &amp;[i32]) -&gt; Result&lt;HashMap&lt;i32, Self::Value&gt;, Self::Error&gt; {
+        let conn = self.pool.get().expect(&quot;Can&#8217;t get DB connection&quot;);
+        let details = repository::get_details(keys, &amp;conn).expect(&quot;Can&#8217;t get planets&#8217; details&quot;);
+
+        Ok(details.iter()
+            .map(|details_entity| (details_entity.planet_id, Details::from(details_entity)))
+            .collect::&lt;HashMap&lt;_, _&gt;&gt;())
+    }
+}</code></pre>
+
+<p>此方法有助于我们防止N+1问题，因为每个<code>DetailsLoader.load</code>调用仅执行一个SQL查询，返回多个<code>DetailsEntity</code>。</p>
+
+<h1 id='接口定义'>接口定义</h1>
+
+<p>GraphQL接口及其实现通过以下方式定义：</p>
+
+<p><em>清单12. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>GraphQL接口定义</a></em></p>
+
+<pre><code class="language-`rust">#[derive(Interface, Clone)]
+#[graphql(
+    field(name = &quot;mean_radius&quot;, type = &quot;&amp;CustomBigDecimal&quot;),
+    field(name = &quot;mass&quot;, type = &quot;&amp;CustomBigInt&quot;),
+)]
+pub enum Details {
+    InhabitedPlanetDetails(InhabitedPlanetDetails),
+    UninhabitedPlanetDetails(UninhabitedPlanetDetails),
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct InhabitedPlanetDetails {
+    mean_radius: CustomBigDecimal,
+    mass: CustomBigInt,
+    /// In billions
+    population: CustomBigDecimal,
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct UninhabitedPlanetDetails {
+    mean_radius: CustomBigDecimal,
+    mass: CustomBigInt,
+}</code></pre>
+
+<p>在这里你还可以看到，如果该对象没有任何复杂Resolver的字段，则可以使用<code>SimpleObject</code>宏来实现。</p>
+
+<h3 id='自定义标量'>自定义标量</h3>
+
+<p>这个项目包含两个自定义标量定义的示例，两者都是数字类型的包装器（因为由于<a href='https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type'>孤儿规则</a>，你无法在外部类型上实现外部特征）。包装器的实现如下：</p>
+
+<p><em>清单 13. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>自定义标量: 包装BigInt</a></em></p>
+
+<pre><code class="language-`rust">#[derive(Clone)]
+pub struct CustomBigInt(BigDecimal);
+
+#[Scalar(name = &quot;BigInt&quot;)]
+impl ScalarType for CustomBigInt {
+    fn parse(value: Value) -&gt; InputValueResult&lt;Self&gt; {
+        match value {
+            Value::String(s) =&gt; {
+                let parsed_value = BigDecimal::from_str(&amp;s)?;
+                Ok(CustomBigInt(parsed_value))
+            }
+            _ =&gt; Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&amp;self) -&gt; Value {
+        Value::String(format!(&quot;{:e}&quot;, &amp;self))
+    }
+}
+
+impl LowerExp for CustomBigInt {
+    fn fmt(&amp;self, f: &amp;mut Formatter&lt;&#8217;_&gt;) -&gt; fmt::Result {
+        let val = &amp;self.0.to_f64().expect(&quot;Can&#8217;t convert BigDecimal&quot;);
+        LowerExp::fmt(val, f)
+    }
+}</code></pre>
+
+<p><em>清单 14. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>自定义标量: 包装BigDecimal</a></em></p>
+
+<pre><code class="language-`rust">#[derive(Clone)]
+pub struct CustomBigDecimal(BigDecimal);
+
+#[Scalar(name = &quot;BigDecimal&quot;)]
+impl ScalarType for CustomBigDecimal {
+    fn parse(value: Value) -&gt; InputValueResult&lt;Self&gt; {
+        match value {
+            Value::String(s) =&gt; {
+                let parsed_value = BigDecimal::from_str(&amp;s)?;
+                Ok(CustomBigDecimal(parsed_value))
+            }
+            _ =&gt; Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&amp;self) -&gt; Value {
+        Value::String(self.0.to_string())
+    }
+}</code></pre>
+
+<p>前一个示例还支持使用指数表示大数。</p>
+
+<h3 id='定义变更(mutation)'>定义变更(Mutation)</h3>
+
+<p>变更定义如下：</p>
+
+<p><em>清单 15. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>定义变更</a></em></p>
+
+<pre><code class="language-`rust">pub struct Mutation;
+
+#[Object]
+impl Mutation {
+    #[graphql(guard(RoleGuard(role = &quot;Role::Admin&quot;)))]
+    async fn create_planet(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;, planet: PlanetInput) -&gt; Result&lt;Planet, Error&gt; {
+        let new_planet = NewPlanetEntity {
+            name: planet.name,
+            planet_type: planet.planet_type.to_string(),
+        };
+
+        let details = planet.details;
+        let new_planet_details = NewDetailsEntity {
+            mean_radius: details.mean_radius.0,
+            mass: BigDecimal::from_str(&amp;details.mass.0.to_string()).expect(&quot;Can&#8217;t get BigDecimal from string&quot;),
+            population: details.population.map(|wrapper| { wrapper.0 }),
+            planet_id: 0,
+        };
+
+        let created_planet_entity = repository::create(new_planet, new_planet_details, &amp;get_conn_from_ctx(ctx))?;
+
+        let producer = ctx.data::&lt;FutureProducer&gt;().expect(&quot;Can&#8217;t get Kafka producer&quot;);
+        let message = serde_json::to_string(&amp;Planet::from(&amp;created_planet_entity)).expect(&quot;Can&#8217;t serialize a planet&quot;);
+        kafka::send_message(producer, message).await;
+
+        Ok(Planet::from(&amp;created_planet_entity))
+    }
+}</code></pre>
+
+<p><code>Mutation.create_planet</code>输入参数需要定义以下结构：</p>
+
+<p><em>清单 16: <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>定义输入类型</a></em></p>
+
+<pre><code class="language-`rust">#[derive(InputObject)]
+struct PlanetInput {
+    name: String,
+    #[graphql(name = &quot;type&quot;)]
+    planet_type: PlanetType,
+    details: DetailsInput,
+}</code></pre>
+
+<p><code>create_planet</code>受<code>RoleGuard</code>保护，可确保只有具有<code>Admin</code>角色的用户才能访问它。要执行变异，如下所示：</p>
+
+<pre><code class="language-`graphql">mutation {
+  createPlanet(
+    planet: {
+      name: &quot;test_planet&quot;
+      type: TERRESTRIAL_PLANET
+      details: { meanRadius: &quot;10.5&quot;, mass: &quot;8.8e24&quot;, population: &quot;0.5&quot; }
+    }
+  ) {
+    id
+  }
+}</code></pre>
+
+<p>你需要从<code>auth-service</code>获得JWT，并指定<code>Authorization</code>作为HTTP请求的标头（稍后将对此进行描述）。</p>
+
+<h3 id='定义订阅(subscription)'>定义订阅(Subscription)</h3>
+
+<p>在上面的Mutation定义中，你可以看到在<code>planet</code>创建过程中发送了一条消息：</p>
+
+<p><em>清单 18. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>发送消息到Kafka</a></em></p>
+
+<pre><code class="language-`rust">let producer = ctx.data::&lt;FutureProducer&gt;().expect(&quot;Can&#8217;t get Kafka producer&quot;);
+let message = serde_json::to_string(&amp;Planet::from(&amp;created_planet_entity)).expect(&quot;Can&#8217;t serialize a planet&quot;);
+kafka::send_message(producer, message).await;</code></pre>
+
+<p>使用者可以通过监听Kafka订阅将事件通知给API客户端：</p>
+
+<p><em>清单 19. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>订阅定义</a></em></p>
+
+<pre><code class="language-`rust">pub struct Subscription;
+
+#[Subscription]
+impl Subscription {
+    async fn latest_planet&lt;&#8217;ctx&gt;(&amp;self, ctx: &amp;&#8217;ctx Context&lt;&#8217;_&gt;) -&gt; impl Stream&lt;Item=Planet&gt; + &#8217;ctx {
+        let kafka_consumer_counter = ctx.data::&lt;Mutex&lt;i32&gt;&gt;().expect(&quot;Can&#8217;t get Kafka consumer counter&quot;);
+        let consumer_group_id = kafka::get_kafka_consumer_group_id(kafka_consumer_counter);
+        let consumer = kafka::create_consumer(consumer_group_id);
+
+        async_stream::stream! {
+            let mut stream = consumer.start();
+
+            while let Some(value) = stream.next().await {
+                yield match value {
+                    Ok(message) =&gt; {
+                        let payload = message.payload().expect(&quot;Kafka message should contain payload&quot;);
+                        let message = String::from_utf8_lossy(payload).to_string();
+                        serde_json::from_str(&amp;message).expect(&quot;Can&#8217;t deserialize a planet&quot;)
+                    }
+                    Err(e) =&gt; panic!(&quot;Error while Kafka message processing: {}&quot;, e)
+                };
+            }
+        }
+    }
+}</code></pre>
+
+<p>订阅可以像查询(Query)和变更(Mutation)一样使用：</p>
+
+<p><em>清单 20. 订阅使用例子</em></p>
+
+<pre><code class="language-`graphql">subscription {
+  latestPlanet {
+    id
+    name
+    type
+    details {
+      meanRadius
+    }
+  }
+}</code></pre>
+
+<p>订阅的URL是<code>ws://localhost:8001</code>。</p>
+
+<h3 id='集成测试'>集成测试</h3>
+
+<p>查询和变更的测试可以这样写：</p>
+
+<p><em>清单 21. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/tests/query_tests.rs'>查询测试</a></em></p>
+
+<pre><code class="language-`rust">#[actix_rt::test]
+async fn test_get_planets() {
+    let docker = Cli::default();
+    let (_pg_container, pool) = common::setup(&amp;docker);
+
+    let mut service = test::init_service(App::new()
+        .configure(configure_service)
+        .data(create_schema_with_context(pool))
+    ).await;
+
+    let query = &quot;
+        {
+            getPlanets {
+                id
+                name
+                type
+                details {
+                    meanRadius
+                    mass
+                    ... on InhabitedPlanetDetails {
+                        population
+                    }
+                }
+            }
+        }
+        &quot;.to_string();
+
+    let request_body = GraphQLCustomRequest {
+        query,
+        variables: Map::new(),
+    };
+
+    let request = test::TestRequest::post().uri(&quot;/&quot;).set_json(&amp;request_body).to_request();
+
+    let response: GraphQLCustomResponse = test::read_response_json(&amp;mut service, request).await;
+
+    fn get_planet_as_json(all_planets: &amp;serde_json::Value, index: i32) -&gt; &amp;serde_json::Value {
+        jsonpath::select(all_planets, &amp;format!(&quot;$.getPlanets[{}]&quot;, index)).expect(&quot;Can&#8217;t get planet by JSON path&quot;)[0]
+    }
+
+    let mercury_json = get_planet_as_json(&amp;response.data, 0);
+    common::check_planet(mercury_json, 1, &quot;Mercury&quot;, &quot;TERRESTRIAL_PLANET&quot;, &quot;2439.7&quot;);
+
+    let earth_json = get_planet_as_json(&amp;response.data, 2);
+    common::check_planet(earth_json, 3, &quot;Earth&quot;, &quot;TERRESTRIAL_PLANET&quot;, &quot;6371.0&quot;);
+
+    let neptune_json = get_planet_as_json(&amp;response.data, 7);
+    common::check_planet(neptune_json, 8, &quot;Neptune&quot;, &quot;ICE_GIANT&quot;, &quot;24622.0&quot;);
+}</code></pre>
+
+<p>如果查询的一部分可以在另一个查询中重用，则可以使用<a href='https://graphql.org/learn/queries/#fragments'>片段(Fragment)</a>：</p>
+
+<p><em>清单 22. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/tests/query_tests.rs'>查询测试（使用片段）</a></em></p>
+
+<pre><code class="language-`rust">const PLANET_FRAGMENT: &amp;str = &quot;
+    fragment planetFragment on Planet {
+        id
+        name
+        type
+        details {
+            meanRadius
+            mass
+            ... on InhabitedPlanetDetails {
+                population
+            }
+        }
+    }
+&quot;;
+
+#[actix_rt::test]
+async fn test_get_planet_by_id() {
+    ...
+
+    let query = &quot;
+        {
+            getPlanet(id: 3) {
+                ... planetFragment
+            }
+        }
+        &quot;.to_string() + PLANET_FRAGMENT;
+
+    let request_body = GraphQLCustomRequest {
+        query,
+        variables: Map::new(),
+    };
+
+    ...
+}</code></pre>
+
+<p>要使用<a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/tests/query_tests.rs'>变量</a>，你可以通过以下方式编写测试：</p>
+
+<p><em>清单 23. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/tests/query_tests.rs'>查询测试（使用片段和变量）</a></em></p>
+
+<pre><code class="language-`rust">#[actix_rt::test]
+async fn test_get_planet_by_id_with_variable() {
+    ...
+
+    let query = &quot;
+        query testPlanetById($planetId: String!) {
+            getPlanet(id: $planetId) {
+                ... planetFragment
+            }
+        }&quot;.to_string() + PLANET_FRAGMENT;
+
+    let jupiter_id = 5;
+    let mut variables = Map::new();
+    variables.insert(&quot;planetId&quot;.to_string(), jupiter_id.into());
+
+    let request_body = GraphQLCustomRequest {
+        query,
+        variables,
+    };
+
+    ...
+}</code></pre>
+
+<p>在这个项目中，<code>Testcontainers-rs</code>库用于准备测试环境，创建一个临时PostgreSQL数据库。</p>
+
+<h3 id='graphql客户端'>GraphQL客户端</h3>
+
+<p>你可以使用上一部分中的代码段来创建外部GraphQL API的客户端。另外，有一些库可用于此目的，例如<code>graphql-client</code>，但我还没有使用它们。</p>
+
+<h3 id='api安全'>API安全</h3>
+
+<p>GraphQL API有一些不同程度的安全威胁（请参阅此<a href='https://leapgraph.com/graphql-api-security'>清单</a>以了解更多信息），让我们考虑其中的一些方面。</p>
+
+<h4 id='限制查询的深度和复杂度'>限制查询的深度和复杂度</h4>
+
+<p>如果<code>Satellite</code>对象容纳<code>planet</code>字段，则可能有以下查询：</p>
+
+<p><em>清单 24. 昂贵查询的例子</em></p>
+
+<pre><code class="language-`graphql">{
+  getPlanet(id: &quot;1&quot;) {
+    satellites {
+      planet {
+        satellites {
+          planet {
+            satellites {
+              ... # 更深的嵌套！
+            }
+          }
+        }
+      }
+    }
+  }
+}</code></pre>
+
+<p>为了使这样的查询无效，我们可以指定：</p>
+
+<p><em>清单 25. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/lib.rs'>限制查询深度和复杂度的例子</a></em></p>
+
+<pre><code class="language-`rust">pub fn create_schema_with_context(pool: PgPool) -&gt; Schema&lt;Query, Mutation, Subscription&gt; {
+    ...
+
+    Schema::build(Query, Mutation, Subscription)
+        .limit_depth(3)
+        .limit_complexity(15)
+
+    ...
+}</code></pre>
+
+<p>请注意，如果你指定深度或复杂度限制，则API文档可能不能在GraphQL IDE中显示，这是因为IDE尝试执行具有相当深度和复杂度的自省查询。</p>
+
+<h4 id='认证'>认证</h4>
+
+<p>使用<code>argonautica</code>和<code>jsonwebtoken</code>库在<code>auth-service</code>中实现此功能。 前一个库负责使用<a href='https://en.wikipedia.org/wiki/Argon2'>Argon2</a>算法对用户的密码进行哈希处理。<strong>身份验证和授权功能仅用于演示，请针对生产用途进行更多研究。</strong></p>
+
+<p>让我们看看登录的实现方式：</p>
+
+<p><em>清单 26. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/auth-service/src/graphql.rs'>实现登录</a></em></p>
+
+<pre><code class="language-`rust">pub struct Mutation;
+
+#[Object]
+impl Mutation {
+
+    async fn sign_in(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;, input: SignInInput) -&gt; Result&lt;String, Error&gt; {
+        let maybe_user = repository::get_user(&amp;input.username, &amp;get_conn_from_ctx(ctx)).ok();
+
+        if let Some(user) = maybe_user {
+            if let Ok(matching) = verify_password(&amp;user.hash, &amp;input.password) {
+                if matching {
+                    let role = AuthRole::from_str(user.role.as_str()).expect(&quot;Can&#8217;t convert &amp;str to AuthRole&quot;);
+                    return Ok(common_utils::create_token(user.username, role));
+                }
+            }
+        }
+
+        Err(Error::new(&quot;Can&#8217;t authenticate a user&quot;))
+    }
+}
+
+#[derive(InputObject)]
+struct SignInInput {
+    username: String,
+    password: String,
+}</code></pre>
+
+<p>你可以在<code>utils</code><a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/auth-service/src/utils.rs'>模块</a>中查看<code>verify_password</code>函数的实现，在<code>common_utils</code><a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/common-utils/src/lib.rs'>模块</a>中查看<code>create_token</code>函数的实现。如你所料，<code>sign_in</code>函数将颁发JWT，该JWT可进一步用于其他服务中的授权。</p>
+
+<p>要获得JWT，你需要执行以下变更：</p>
+
+<p><em>清单 27. 获取JWT</em></p>
+
+<pre><code class="language-`graphql">mutation {
+  signIn(input: { username: &quot;john_doe&quot;, password: &quot;password&quot; })
+}</code></pre>
+
+<p>使用 <em>john_doe/password</em> ，将获得的JWT用于在进一步的请求中，可以访问受保护的资源（请参阅下一节）。</p>
+
+<h4 id='鉴权'>鉴权</h4>
+
+<p>要请求受保护的数据，你需要以<code>Authorization：Bearer $ JWT</code>格式向HTTP请求中添加标头。 <code>index</code>函数将从请求中提取用户的角色，并将其添加到查询数据中：</p>
+
+<p><em>清单 28. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/lib.rs'>角色提取</a></em></p>
+
+<pre><code class="language-`rust">async fn index(schema: web::Data&lt;AppSchema&gt;, http_req: HttpRequest, req: Request) -&gt; Response {
+    let mut query = req.into_inner();
+
+    let maybe_role = common_utils::get_role(http_req);
+    if let Some(role) = maybe_role {
+        query = query.data(role);
+    }
+
+    schema.execute(query).await.into()
+}</code></pre>
+
+<p>以下属性应用于先前定义的<code>create_planet</code>变更：</p>
+
+<p><em>清单 29. 使用字段守卫</em></p>
+
+<pre><code class="language-`rust">#[graphql(guard(RoleGuard(role = &quot;Role::Admin&quot;)))]</code></pre>
+
+<p>这个守卫自身实现如下：</p>
+
+<p><em>清单 30. 守卫实现</em></p>
+
+<pre><code class="language-`rust">struct RoleGuard {
+    role: Role,
+}
+
+#[async_trait::async_trait]
+impl Guard for RoleGuard {
+    async fn check(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;) -&gt; Result&lt;()&gt; {
+        if ctx.data_opt::&lt;Role&gt;() == Some(&amp;self.role) {
+            Ok(())
+        } else {
+            Err(&quot;Forbidden&quot;.into())
+        }
+    }
+}</code></pre>
+
+<p>这样如果你未指定角色，则服务器将返回<code>Forbidden</code>的消息。</p>
+
+<h3 id='定义枚举'>定义枚举</h3>
+
+<p>GraphQL枚举可以通过以下方式定义：</p>
+
+<p><em>清单 31. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/satellites-service/src/graphql.rs'>定义枚举</a></em></p>
+
+<pre><code class="language-`rust">#[derive(SimpleObject)]
+struct Satellite {
+    ...
+    life_exists: LifeExists,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Enum, EnumString)]
+#[strum(serialize_all = &quot;SCREAMING_SNAKE_CASE&quot;)]
+pub enum LifeExists {
+    Yes,
+    OpenQuestion,
+    NoData,
+}</code></pre>
+
+<h4 id='日期处理'>日期处理</h4>
+
+<p><code>Async-graphql</code>支持<code>chrono</code>库中的日期/时间类型，因此你可以照常定义以下字段：</p>
+
+<p><em>清单 32. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/satellites-service/src/graphql.rs'>日期字段定义</a></em></p>
+
+<pre><code class="language-`rust">#[derive(SimpleObject)]
+struct Satellite {
+    ...
+    first_spacecraft_landing_date: Option&lt;NaiveDate&gt;,
+}</code></pre>
+
+<h3 id='支持apollofederation'>支持ApolloFederation</h3>
+
+<p><code>satellites-service</code>的目的之一是演示如何在两个（或多个）服务中解析分布式GraphQL<a href='https://www.apollographql.com/docs/federation/entities/'>实体</a>（<code>Planet</code>），然后通过Apollo Server对其进行访问。</p>
+
+<p><code>Plant</code>类型之前是通过<code>planets-service</code>定义的：</p>
+
+<p><em>清单 33. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>在`planets-service`里定义`Planet`类型</a></em></p>
+
+<pre><code class="language-`rust">#[derive(Serialize, Deserialize)]
+struct Planet {
+    id: ID,
+    name: String,
+    planet_type: PlanetType,
+}</code></pre>
+
+<p>另外，在<code>planets-service</code>中，<code>Planet</code>类型是一个实体：</p>
+
+<p>\_清单 34. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/planets-service/src/graphql.rs'>`Planet`实体定义</a></p>
+
+<pre><code class="language-`rust">#[Object]
+impl Query {
+    #[graphql(entity)]
+    async fn find_planet_by_id(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;, id: ID) -&gt; Option&lt;Planet&gt; {
+        find_planet_by_id_internal(ctx, id)
+    }
+}</code></pre>
+
+<p><code>satellites-service</code>向<code>Planet</code>对象扩展了<code>satellites</code>字段：</p>
+
+<p><em>清单 35. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/satellites-service/src/graphql.rs'>`satellites-service`中`Plant`对象的扩展</a></em></p>
+
+<pre><code class="language-`rust">struct Planet {
+    id: ID
+}
+
+#[Object(extends)]
+impl Planet {
+    #[graphql(external)]
+    async fn id(&amp;self) -&gt; &amp;ID {
+        &amp;self.id
+    }
+
+    async fn satellites(&amp;self, ctx: &amp;Context&lt;&#8217;_&gt;) -&gt; Vec&lt;Satellite&gt; {
+        let id = self.id.to_string().parse::&lt;i32&gt;().expect(&quot;Can&#8217;t get id from String&quot;);
+        repository::get_by_planet_id(id, &amp;get_conn_from_ctx(ctx)).expect(&quot;Can&#8217;t get satellites of planet&quot;)
+            .iter()
+            .map(|e| { Satellite::from(e) })
+            .collect()
+    }
+}</code></pre>
+
+<p>你还应该为扩展类型提供查找函数（此处只是创建了<code>Planet</code>的新实例）：</p>
+
+<p><em>清单 36. <code>Planet</code>对象的查找函数</em></p>
+
+<pre><code class="language-`rust">#[Object]
+impl Query {
+
+    #[graphql(entity)]
+    async fn get_planet_by_id(&amp;self, id: ID) -&gt; Planet {
+        Planet { id }
+    }
+}</code></pre>
+
+<p><code>Async-graphql</code>生成两个附加查询（<code>_service</code>和<code>_entities</code>），这些查询将由Apollo Server使用。这些查询是内部查询，也就是说Apollo Server不会公开这些查询。当然，具有Apollo Federation支持的服务仍可以独立运行。</p>
+
+<h3 id='apolloserver'>ApolloServer</h3>
+
+<p>Apollo Server和Apollo Federation可以实现两个主要目标：</p>
+
+<ul>
+<li>
+<p>创建单个端点以访问由多个服务提供的GraphQL API</p>
+</li>
+
+<li>
+<p>从分布式服务创建单个GraphQL模式</p>
+</li>
+</ul>
+
+<p>也就是说即使你不使用联合实体，前端开发人员也可以使用单个端点而不是多个端点，使用起来更加的方便。</p>
+
+<p>还有一种创建单个GraphQL模式的方法，即<a href='https://www.graphql-tools.com/docs/schema-stitching/'>模式缝合</a>，但是我没有使用这种方法。</p>
+
+<p>该模块包括以下代码：</p>
+
+<p><em>清单 37. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/apollo-server/package.json'>元信息和依赖</a></em></p>
+
+<pre><code class="language-`json">{
+  &quot;name&quot;: &quot;api-gateway&quot;,
+  &quot;main&quot;: &quot;gateway.js&quot;,
+  &quot;scripts&quot;: {
+    &quot;start-gateway&quot;: &quot;nodemon gateway.js&quot;
+  },
+  &quot;devDependencies&quot;: {
+    &quot;concurrently&quot;: &quot;5.3.0&quot;,
+    &quot;nodemon&quot;: &quot;2.0.6&quot;
+  },
+  &quot;dependencies&quot;: {
+    &quot;@apollo/gateway&quot;: &quot;0.21.3&quot;,
+    &quot;apollo-server&quot;: &quot;2.19.0&quot;,
+    &quot;graphql&quot;: &quot;15.4.0&quot;
+  }
+}</code></pre>
+
+<p>\_清单 38. <a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/apollo-server/gateway.js'>Apollo Server定义</a></p>
+
+<pre><code class="language-`javascript">const {ApolloServer} = require(&quot;apollo-server&quot;);
+const {ApolloGateway, RemoteGraphQLDataSource} = require(&quot;@apollo/gateway&quot;);
+
+class AuthenticatedDataSource extends RemoteGraphQLDataSource {
+    willSendRequest({request, context}) {
+        if (context.authHeaderValue) {
+            request.http.headers.set(&#8217;Authorization&#8217;, context.authHeaderValue);
+        }
+    }
+}
+
+let node_env = process.env.NODE_ENV;
+
+function get_service_url(service_name, port) {
+    let host;
+    switch (node_env) {
+        case &#8217;docker&#8217;:
+            host = service_name;
+            break;
+        case &#8217;local&#8217;: {
+            host = &#8217;localhost&#8217;;
+            break
+        }
+    }
+
+    return &quot;http://&quot; + host + &quot;:&quot; + port;
+}
+
+const gateway = new ApolloGateway({
+    serviceList: [
+        {name: &quot;planets-service&quot;, url: get_service_url(&quot;planets-service&quot;, 8001)},
+        {name: &quot;satellites-service&quot;, url: get_service_url(&quot;satellites-service&quot;, 8002)},
+        {name: &quot;auth-service&quot;, url: get_service_url(&quot;auth-service&quot;, 8003)},
+    ],
+    buildService({name, url}) {
+        return new AuthenticatedDataSource({url});
+    },
+});
+
+const server = new ApolloServer({
+    gateway, subscriptions: false, context: ({req}) =&gt; ({
+        authHeaderValue: req.headers.authorization
+    })
+});
+
+server.listen({host: &quot;0.0.0.0&quot;, port: 4000}).then(({url}) =&gt; {
+    console.log(`🚀 Server ready at ${url}`);
+});</code></pre>
+
+<p>如果以上代码可以简化，请随时与我联系以进行更改。</p>
+
+<p><code>apollo-service</code>中的授权工作如先前Rust服务所述（你只需指定<code>Authorization</code>标头及其值）即可。</p>
+
+<p>如果采用<a href='https://www.apollographql.com/docs/federation/federation-spec/'>Federation规范</a>，则可以将用任何语言或框架编写的应用程序作为下游服务添加到Apollo Server。这个<a href='https://www.apollographql.com/docs/federation/other-servers/'>文档</a>中提供了提供此类支持的库列表。</p>
+
+<p>在实现此模块时，我遇到了一些限制：</p>
+
+<ul>
+<li>
+<p>Apollo Gateway<a href='https://github.com/apollographql/apollo-server/issues/3357'>不支持订阅</a>（但它们仍可在独立的Rust GraphQL应用程序中使用）</p>
+</li>
+
+<li>
+<p>试图扩展GraphQL接口的服务需要<a href='https://github.com/apollographql/apollo-server/issues/2849'>了解具体的实现</a></p>
+</li>
+</ul>
+
+<h3 id='数据库交互'>数据库交互</h3>
+
+<p>持久层是使用PostgreSQL和Diesel实现的。如果你不在本地使用Docker，你应该在每个服务的文件夹中运行<code>diesel setup</code>。这将创建一个空数据库，然后将应用Migrations创建表和插入数据。</p>
+
+<h3 id='运行和api测试'>运行和API测试</h3>
+
+<p>如前面所述，对于在本地启动项目，你有两个选择。</p>
+
+<ul>
+<li>
+<p>使用Docker Compose (<a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/docker-compose.yml'>docker-compose.yml</a>)</p>
+
+<p>这里也有两个选择</p>
+
+<ul>
+<li>开发模式 （使用本地生成的镜像）</li>
+</ul>
+
+<p><code>docker-compose up</code></p>
+
+<ul>
+<li>生产模式 （使用已发布的镜像）</li>
+</ul>
+
+<p><code>docker-compose -f docker-compose.yml up</code></p>
+</li>
+
+<li>
+<p>不使用Docker</p>
+
+<p>用<code>cargo run</code>启动每个服务，然后启动Apollo Server:</p>
+
+<ul>
+<li>进入 <code>apollo-server</code> 目录</li>
+
+<li>定义 <code>NODE_ENV</code> 环境变量， 例如<code>set NODE_ENV=local</code>(Windows)</li>
+
+<li><code>npm install</code></li>
+
+<li><code>npm run start-gateway</code></li>
+</ul>
+</li>
+</ul>
+
+<p>当<code>apollo-server</code>成功运行应该输出以下信息:</p>
+
+<p><em>清单 39. Apollo Server启动日志</em></p>
+
+<pre><code class="language-`">[nodemon] 2.0.6
+[nodemon] to restart at any time, enter `rs`
+[nodemon] watching path(s): *.*
+[nodemon] watching extensions: js,mjs,json
+[nodemon] starting `node gateway.js`
+Server ready at http://0.0.0.0:4000/</code></pre>
+
+<p>你可以在浏览器中打开<code>http://localhost:4000</code>，并使用内置的Playground IDE。</p>
+
+<p><img src='playground.png' alt='playground' /></p>
+
+<p>在这里你可以执行下游服务中定义的查询、变更和订阅。另外，这些服务也都有自己的Playground IDE。</p>
+
+<h3 id='订阅测试'>订阅测试</h3>
+
+<p>要测试订阅是否正常工作，可以在GraphQL IDE中打开两个Tab，第一个请求如下。</p>
+
+<p><em>清单 40. 订阅请求</em></p>
+
+<pre><code class="language-`graphql">subscription {
+  latestPlanet {
+    name
+    type
+  }
+}</code></pre>
+
+<p>第二个请求指定如上所述的<code>Authorization</code>标头，并执行这样的变更。</p>
+
+<p><em>清单 41. 变更请求</em></p>
+
+<pre><code class="language-`graphql">mutation {
+  createPlanet(
+    planet: {
+      name: &quot;Pluto&quot;
+      type: DWARF_PLANET
+      details: { meanRadius: &quot;1188&quot;, mass: &quot;1.303e22&quot; }
+    }
+  ) {
+    id
+  }
+}</code></pre>
+
+<p>订阅的客户端会收到<code>Plant</code>创建的通知。</p>
+
+<p><img src='subscription-demo.gif' alt='subscription-demo' /></p>
+
+<h3 id='ci/cd'>CI/CD</h3>
+
+<p>CI/CD是使用GitHub Actions（<a href='https://github.com/rkudryashov/graphql-rust-demo/blob/master/.github/workflows/workflow.yml'>workflow</a>）配置的，它可以运行应用程序的测试，构建它们的Docker镜像，并在Google Cloud Platform上部署它们。</p>
+
+<p>你可以在<a href='http://graphql-rust.romankudryashov.com/'>这里</a>试试已部署的服务。</p>
+
+<p><strong>注意：</strong> 在<code>生产</code>环境下，为了防止更改初始数据，密码与前面指定的不同。</p>
+
+<h3 id='结论'>结论</h3>
+
+<p>在这篇文章中，我考虑了如何解决在Rust中开发GraphQL API时可能出现的最常见问题。此外，我还展示了如何将使用Rust开发的GraphQL微服务API结合起来，以提供统一的GraphQL接口。在这样的架构中，一个实体可以分布在几个微服务之间，它是通过Apollo Server、Apollo Federation和Async-graphql库来实现的。项目的源代码在<a href='https://github.com/rkudryashov/graphql-rust-demo'>GitHub</a>上。如果你发现文章或源代码中有任何错误，欢迎<a href='rskudryashov@gmail.com'>联系</a>我。谢谢阅读!</p>
+
+<h3 id='有用的链接'>有用的链接</h3>
+
+<ul>
+<li><a href='https://graphql.org/'>graphql.org</a></li>
+
+<li><a href='https://spec.graphql.org/'>spec.graphql.org</a></li>
+
+<li><a href='https://graphql.org/learn/best-practices/'>graphql.org/learn/best-practices</a></li>
+
+<li><a href='https://www.howtographql.com/'>howtographql.com</a></li>
+
+<li><a href='https://github.com/async-graphql/async-graphql'>Async-graphql</a></li>
+
+<li><a href='https://async-graphql.github.io/async-graphql/zh-CN/index.html'>Async-graphql使用手册</a></li>
+
+<li><a href='https://github.com/chentsulin/awesome-graphql'>Awesome GraphQL</a></li>
+
+<li><a href='https://github.com/APIs-guru/graphql-apis'>Public GraphQL APIs</a></li>
+
+<li><a href='https://github.com/apollographql/federation-demo'>Apollo Federation demo</a></li>
+</ul>
+]]></content:encoded></item><item><title>学习园地 | 图解 Rust 所有权与生命周期</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rust_ownership.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='图解_rust_所有权与生命周期'>图解 Rust 所有权与生命周期</h1>
+
+<p>作者：肖猛</p>
+
+<p>后期编辑：高宪凤</p>
+
+<h2 id=''></h2>
+
+<p>作者简介：</p>
+
+<p>肖猛</p>
+
+<p>二十年从桌面到云端到嵌入式的软件架构经验，跨通讯、游戏、金融、智能网联汽车多个行业，领域系统分析专家、全栈软件架构专家。</p>
+
+<p>目前致力于智能驾驶基础软件开发。历任吉利亿咖通自动驾驶软件平台总监，国汽智控自动驾驶软件研发总监。对在汽车领域推广 Rust 技术栈有浓厚兴趣，并有实际的量产实践。</p>
+
+<h2 id=''></h2>
+
+<h2 id='1.引言'>1.引言</h2>
+
+<p><strong>所有权</strong>与<strong>生命周期</strong>是  <code>Rust</code>  语言非常核心的内容。其实不仅仅是 <code>Rust</code> 有这两个概念，在<code>C/C++</code> 中也一样是存在的。而几乎所有的内存安全问题也源于对所有权和生命周期的错误使用。只要是不采用垃圾回收来管理内存的程序语言，都会有这个问题。只是 <code>Rust</code> 在语言级明确了这两个概念，并提供了相关的语言特性让用户可以显式控制所有权的转移与生命周期的声明。同时编译器会对各种错误使用进行检查，提高了程序的内存安全性。</p>
+
+<p>所有权和生命周期其涉及的语言概念很多，本文主要是对梳理出与“所有权与生命周期”相关的概念，并使用  <code>UML</code> 的类图表达概念间的关系，帮助更好的理解和掌握。</p>
+
+<p><strong>图例说明</strong></p>
+
+<p>本文附图都是 <code>UML</code> 类图，<code>UML</code> 类图可以用来表示对概念的分析。表达概念之间的依赖、继承、聚合、组成等关系。图中的每一个矩形框都是一个语义概念，有的是抽象的语言概念，有的是 <code>Rust</code> 库中的结构和 <code>Trait</code>。</p>
+
+<p>所有图中使用的符号也只有最基础的几个。图 1 对符号体系做简单说明，主要解释一下表达概念之间的关系的符号语言。</p>
+
+<p>&lt;div align=center&gt;</p>
+
+<pre><code>&lt;img width=&quot;544&quot; height=&quot;306&quot; src=&quot;./rust_ownership/rust_ownership_1.jpg&quot;&gt;</code></pre>
+
+<p>&lt;/div&gt; &lt;center&gt;图 1UML 符号&lt;/center&gt;</p>
+
+<p><strong>依赖关系：</strong></p>
+
+<p>依赖是 <code>UML</code> 中最基础的关系语义。 以带箭头的虚线表示，<code>A</code> 依赖与 <code>B</code> 表达如下图。直观理解可以是 <code>A</code> “看的见” <code>B</code>，而 <code>B</code> 可以对 <code>A</code> 一无所知。比如在代码中 结构体 <code>A</code> 中有 结构体 <code>B</code> 的成员变量，或者 <code>A</code> 的实现代码中有 <code>B</code> 的局部变量。这样如果找不到 <code>B</code>，<code>A</code> 是无法编译通过的。</p>
+
+<p><strong>关联关系：</strong></p>
+
+<p>一条实线连接表示两个类型直接有关联，有箭头表示单向&quot;可见&quot;,无箭头表示相互之间可见。关联关系也是一种依赖，但是更具体。有时候两个类型之间的关联关系太复杂，需要用一个类型来表达，叫做关联类型，如例图中的 <code>H</code>.</p>
+
+<p><strong>聚合与组成：</strong></p>
+
+<p>聚合与组成都是表示的是整体和部分的关系。差别在于“聚合”的整体与部分可以分开，部分可以在多个整体之间共享。而“组成”关系中整体对部分有更强的独占性，部分不能被拆开，部分与整体有相同的生命周期。</p>
+
+<p><strong>继承与接口实现：</strong></p>
+
+<p>继承与接口实现都是一种泛化关系，<code>C</code> 继承自 <code>A</code>，表示 <code>A</code> 是更泛化的概念。<code>UML</code> 中各种关系语义也可以用 <code>UML</code> 自身来表达，如图 2：“关联”和“继承”都是“依赖”的具体体现方式。</p>
+
+<p>&lt;div align=center&gt;</p>
+
+<pre><code>&lt;img width=&quot;544&quot; height=&quot;306&quot; src=&quot;./rust_ownership/rust_ownership_2.jpg&quot;&gt;</code></pre>
+
+<p>&lt;/div&gt; &lt;center&gt;图 2用 UML表达UML自身&lt;/center&gt;</p>
+
+<p><strong>总图</strong></p>
+
+<p>图 3 是本文的总图，后续各节分局部介绍。 &lt;img src=&quot;./rust<em>ownership/rust</em>ownership_3.png&quot;&gt;</p>
+
+<p>&lt;center&gt;图 3Rust 所有权与生命周期总图&lt;/center&gt;</p>
+
+<h2 id='2.所有权与生命周期期望解决的问题'>2.所有权与生命周期期望解决的问题</h2>
+
+<p>我们从图中间部分开始看起，所谓“所有权”是指对一个变量拥有了一块“内存区域”。这个内存区域，可以在堆上，可以在栈上，也可以在代码段，还有些内存地址是直接用于 <code>I/O</code> 地址映射的。这些都是内存区域可能存在的位置。</p>
+
+<p>在高级语言中，这个内存位置要在程序中要能被访问，必然就会与一个或多个变量建立关联关系（低级语言如汇编语言，可以直接访问内存地址）。也就是说，通过这一个或多个变量，就能访问这个内存地址。</p>
+
+<p>这就引出三个问题：</p>
+
+<ol type="1">
+<li>内存的不正确访问引发的内存安全问题</li>
+
+<li>由于多个变量指向同一块内存区域导致的数据一致性问题</li>
+
+<li>由于变量在多个线程中传递，导致的数据竞争的问题</li>
+</ol>
+
+<p>由第一个问题引发的内存安全问题一般有 5 个典型情况：</p>
+
+<ul>
+<li>使用未初始化的内存</li>
+
+<li>对空指针解引用</li>
+
+<li>悬垂指针(使用已经被释放的内存)</li>
+
+<li>缓冲区溢出</li>
+
+<li>非法释放内存(释放未分配的指针或重复释放指针)</li>
+</ul>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_4.jpg&quot;&gt; &lt;center&gt;图 4变量绑定与内存安全的基本概念&lt;/center&gt;</p>
+
+<p>这些问题在 <code>C/C++</code> 中是需要开发者非常小心的自己处理。 比如我们可以写一段 <code>C++</code> 代码，把这五个内存安全错误全部犯一遍。</p>
+
+<pre><code class="language-`C++">#include &lt;iostream&gt;
+
+struct Point {
+	int x;
+	int y;
+};
+
+Point* newPoint(int x,int y) {
+	Point p { .x=x,.y=y };
+	return &amp;p; //悬垂指针
+}
+
+int main() {
+	int values[3]= { 1,2,3 };
+	std::cout&lt;&lt;values[0]&lt;&lt;&quot;,&quot;&lt;&lt;values[3]&lt;&lt;std::endl; //缓冲区溢出
+
+	Point *p1 = (Point*)malloc(sizeof(Point));
+	std::cout&lt;&lt;p1-&gt;x&lt;&lt;&quot;,&quot;&lt;&lt;p1-&gt;y&lt;&lt;std::endl; //使用未初始化内存
+
+	Point *p2 = newPoint(10,10); //悬垂指针
+	delete p2; //非法释放内存
+
+	p1 = NULL;
+	std::cout&lt;&lt;p1-&gt;x&lt;&lt;std::endl; //对空指针解引用
+	return 0;
+}</code></pre>
+
+<p>这段代码是可以编译通过的，当然，编译器还是会给出警告信息。这段代码也是可以运行的，也会输出信息，直到执行到最后一个错误处“对空指针解引用时”才会发生段错误退出。</p>
+
+<p><code>Rust</code> 的语言特性为上述问题提供了解决方案，如下表所示：</p>
+
+<p>|问题|解决方案| |------|------------| |&lt;div style=&quot;width: 200px&quot;&gt;使用未初始化的内存&lt;/div&gt; |编译器禁止变量读取未赋值变量| |&lt;div style=&quot;width: 200px&quot;&gt;对空指针解引用&lt;/div&gt; |使用 Option&lt;T&gt; 枚举替代空指针| |&lt;div style=&quot;width: 200px&quot;&gt;悬垂指针&lt;/div&gt; |生命周期标识与编译器检查| |&lt;div style=&quot;width: 200px&quot;&gt;缓冲区溢出&lt;/div&gt; |编译器检查，拒绝超越缓冲区边界的数据访问| |&lt;div style=&quot;width: 200px&quot;&gt;非法释放内存&lt;/div&gt; |语言级的 RAII 机制，只有唯一的所有者才有权释放内存| |&lt;div style=&quot;width: 200px&quot;&gt;多个变量修改同一块内存区域&lt;/div&gt; |允许多个变量借用所有权，但是同一时间只允许一个可变借用| |&lt;div style=&quot;width: 200px&quot;&gt;变量在多个线程中传递时的安全问题&lt;/div&gt; |对基本数据类型用 Sync 和 Send 两个 Trait 标识其线程安全特性，即能否转移所有权或传递可变借用，把这作为基本事实。再利用泛型限定语法和 Trait impl 语法描述出类型线程安全的规则。编译期间使用类似规则引擎的机制，基于基本事实和预定义规则为用户代码中的跨线程数据传递做推理检查。|</p>
+
+<h2 id='3.变量绑定与所有权的赋予'>3.变量绑定与所有权的赋予</h2>
+
+<p><code>Rust</code> 中为什么叫“变量绑定”而不叫“变量赋值&quot;。我们先来看一段 <code>C++</code> 代码，以及对应的 <code>Rust</code> 代码。</p>
+
+<p>C++:</p>
+
+<pre><code class="language-`C++">#include &lt;iostream&gt;
+ 
+int main()
+{
+	int a = 1;
+	std::cout &lt;&lt; &amp;a &lt;&lt; std::endl;   /* 输出 0x62fe1c */
+	a = 2;
+	std::cout &lt;&lt; &amp;a &lt;&lt; std::endl;   /* 输出 0x62fe1c */
+}</code></pre>
+
+<p>Rust:</p>
+
+<pre><code class="language-`Rust">fn main() {
+	let a = 1;
+	println!(&quot;a:{}&quot;,a);     // 输出1
+	println!(&quot;&amp;a:{:p}&quot;,&amp;a); // 输出0x9cf974
+	//a=2;                  // 编译错误，不可变绑定不能修改绑定的值
+	let a = 2;              // 重新绑定
+	println!(&quot;&amp;a:{:p}&quot;,&amp;a); // 输出0x9cfa14地址发生了变化
+	let mut b = 1;          // 创建可变绑定
+	println!(&quot;b:{}&quot;,b);     // 输出1
+	println!(&quot;&amp;b:{:p}&quot;,&amp;b); // 输出0x9cfa6c
+	b = 2;
+	println!(&quot;b:{}&quot;,b);     // 输出2
+	println!(&quot;&amp;b:{:p}&quot;,&amp;b); // 输出0x9cfa6c地址没有变化
+	let b = 2;              // 重新绑定新值
+	println!(&quot;&amp;b:{:p}&quot;,&amp;b); // 输出0x9cfba4地址发生了变化
+}</code></pre>
+
+<p>我们可以看到，在 <code>C++</code> 代码中，变量 <code>a</code> 先赋值为 1，后赋值为 2，但其地址没有发生变化。<code>Rust</code> 代码中，<code>a</code> 是一个不可变绑定，执行<code>a=2</code>动作被编译器拒绝。但是可以使用 <code>let</code> 重新绑定，但这时 <code>a</code> 的地址跟之前发生了变化，说明 a 被绑定到了另一个内存地址。<code>b</code> 是一个可变绑定，可以使用<code>b = 2</code>重新给它指向的内存赋值，<code>b</code> 的地址不变。但使用 <code>let</code> 重新绑定后，<code>b</code> 指向了新的内存区域。</p>
+
+<p>可以看出，&quot;赋值&quot; 是将值写入变量关联的内存区域，&quot;绑定&quot; 是建立变量与内存区域的关联关系，<code>Rust</code> 里，还会把这个内存区域的所有权赋予这个变量。</p>
+
+<p>不可变绑定的含义是：将变量绑定到一个内存地址，并赋予所有权，通过该变量只能读取该地址的数据，不能修改该地址的数据。对应的，可变绑定就可以通过变量修改关联内存区域的数据。从语法上看，有 <code>let</code> 关键字是绑定, 没有就是赋值。</p>
+
+<p>这里我们能看出 <code>Rust</code> 与 <code>C++</code> 的一个不同之处。<code>C++</code> 里是没有“绑定”概念的。<code>Rust</code> 的变量绑定概念是一个很关键的概念，它是所有权的起点。有了明确的绑定才有了所有权的归属，同时解绑定的时机也确定了资源释放的时机。</p>
+
+<p>所有权规则：</p>
+
+<ul>
+<li>每一个值都有其所有者变量</li>
+
+<li>同一时间所有者变量只能有一个</li>
+
+<li>所有者离开作用域，值被丢弃(释放/析构)</li>
+</ul>
+
+<p>作为所有者，它有如下权利：</p>
+
+<ul>
+<li>控制资源的释放</li>
+
+<li>出借所有权</li>
+
+<li>转移所有权</li>
+</ul>
+
+<h2 id='4.所有权的转移'>4.所有权的转移</h2>
+
+<p>所有者的重要权利之一就是“转移所有权”。这引申出三个问题：</p>
+
+<ol type="1">
+<li>为什么要转移？</li>
+
+<li>什么时候转移？</li>
+
+<li>什么方式转移？</li>
+</ol>
+
+<p>相关的语言概念如下图。</p>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_5.jpg&quot;&gt; &lt;center&gt;图 5所有权转移&lt;/center&gt;</p>
+
+<p><strong>为什么要转移所有权？</strong> 我们知道，C/C++/Rust 的变量关联了某个内存区域，但变量总会在表达式中进行操作再赋值给另一个变量，或者在函数间传递。实际上期望被传递的是变量绑定的内存区域的内容，如果这块内存区域比较大，复制内存数据到给新的变量就是开销很大的操作。所以需要把所有权转移给新的变量，同时当前变量放弃所有权。所以归根结底，转移所有权还是为了性能。</p>
+
+<p><strong>所有权转移的时机总结下来有以下两种情况：</strong></p>
+
+<ol type="1">
+<li>位置表达式出现在值上下文时转移所有权</li>
+
+<li>变量跨作用域传递时转移所有权</li>
+</ol>
+
+<p>第一条规则是一个精确的学术表达，涉及到位置表达式，值表达式，位置上下文，值上下文等语言概念。它的简单理解就是各种各样的赋值行为。能明确指向某一个内存区域位置的表达式是位置表达式，其它的都是值表达式。各种带有赋值语义的操作的左侧是位置上下文，右侧是值上下文。</p>
+
+<p>当位置表达式出现在值上下文时，其程序语义就是要把这边位置表达式所指向的数据赋给新的变量，所有权发生转移。</p>
+
+<p>第二条规则是“变量跨作用域时转移所有权”。</p>
+
+<p>图上列举出了几种常见的跨作用域行为，能涵盖大多数情况，也有简单的示例代码</p>
+
+<ul>
+<li>变量被花括号内使用</li>
+
+<li>match 匹配</li>
+
+<li>if let 和 While let</li>
+
+<li>移动语义函数参数传递</li>
+
+<li>闭包捕获移动语义变量</li>
+
+<li>变量从函数内部返回</li>
+</ul>
+
+<p>为什么变量跨作用域要转移所有权？在 <code>C/C++</code> 代码中，是否转移所有权是程序员自己隐式或显式指定的。</p>
+
+<p>试想，在 <code>C/C++</code> 代码中，函数 <code>Fun1</code> 在栈上创建一个 类型 <code>A</code> 的实例 <code>a</code>， 把它的指针 <code>&amp;a</code> 传递给函数 <code>void fun2(A* param)</code> 我们不会希望 <code>fun2</code> 释放这个内存，因为 <code>fun1</code> 返回时，栈上的空间会自动被释放。</p>
+
+<p>如果 <code>fun1</code> 在堆上创建 <code>A</code> 的实例 <code>a</code>， 把它的指针 <code>&amp;a</code> 传递给函数 <code>fun2(A* param)</code>,那么关于 <code>a</code> 的内存空间的释放，<code>fun1</code> 和 <code>fun2</code> 之间需要有个商量，由谁来释放。<code>fun1</code> 可能期望由 <code>fun2</code> 来释放，如果由 <code>fun2</code> 释放，则 <code>fun2</code> 并不能判断这个指针是在堆上还是栈上。归根结底，还是谁拥有 <code>a</code> 指向内存区的所有权问题。 <code>C/C++</code> 在语言层面上并没有强制约束。<code>fun2</code> 函数设计的时候，需要对其被调用的上下文做假定，在文档中对对谁释放这个变量的内存做约定。这样编译器实际上很难对错误的使用方式给出警告。</p>
+
+<p><code>Rust</code> 要求变量在跨越作用域时明确转移所有权，编译器可以很清楚作用域边界内外哪个变量拥有所有权，能对变量的非法使用作出明确无误的检查，增加的代码的安全性。</p>
+
+<p><strong>所有权转移的方式有两种：</strong></p>
+
+<ul>
+<li>移动语义-执行所有权转移</li>
+
+<li>复制语义-不执行转移，只按位复制变量</li>
+</ul>
+
+<p>这里我把 ”复制语义“定义为所有权转移的方式之一，也就是说“不转移”也是一种转移方式。看起来很奇怪。实际上逻辑是一致的，因为触发复制执行的时机跟触发转移的时机是一致的。只是这个数据类型被打上了 <code>Copy</code> 标签 <code>trait</code>, 在应该执行转移动作的时候，编译器改为执行按位复制。</p>
+
+<p><code>Rust</code> 的标准库中为所有基础类型实现的 <code>Copy Trait</code>。</p>
+
+<p>这里要注意，标准库中的</p>
+
+<pre><code class="language-`Rust"> impl&lt;T: ?Sized&gt; Copy for &amp;T {}</code></pre>
+
+<p>为所有引用类型实现了 <code>Copy</code>, 这意味着我们使用引用参数调用某个函数时，引用变量本身是按位复制的。标准库没有为可变借用 <code>&amp;mut T</code> 实现“Copy” <code>Trait</code> , 因为可变借用只能有一个。后文讲闭包捕获变量的所有权时我们可以看到例子。</p>
+
+<h2 id='5.所有权的借用'>5.所有权的借用</h2>
+
+<p>变量拥有一个内存区域所有权，其所有者权利之一就是“出借所有权”。</p>
+
+<p>与出借所有权相关的概念关系如图 6</p>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_6.jpg&quot;&gt; &lt;center&gt;图 6出借所有权&lt;/center&gt;</p>
+
+<p>拥有所有权的变量借出其所有权有“引用”和“智能指针”两种方式：</p>
+
+<ul>
+<li>
+<p>引用（包含可变借用和不可变借用)</p>
+</li>
+
+<li>
+<p>智能指针</p>
+
+<ul>
+<li>独占式智能指针 <code>Box&lt;T&gt;</code></li>
+
+<li>非线程安全的引用计数智能指针 <code>Rc&lt;T&gt;</code></li>
+
+<li>线程安全的引用计数智能指针 <code>Arc&lt;T&gt;</code></li>
+
+<li>弱指针 <code>Weak&lt;T&gt;</code></li>
+</ul>
+</li>
+</ul>
+
+<p>引用实际上也是指针，指向的是实际的内存位置。</p>
+
+<p>借用有两个重要的安全规则：</p>
+
+<ol type="1">
+<li>代表借用的变量，其生命周期不能比被借用的变量(所有者)的生命周期长</li>
+
+<li>同一个变量的可变借用只能有一个</li>
+</ol>
+
+<p>第一条规则就是确保不出现“悬垂指针”的内存安全问题。如果这条规则被违反，例如：变量 <code>a</code> 拥有存储区域的所有权，变量 <code>b</code> 是 <code>a</code> 的某种借用形式，如果 <code>b</code> 的生命周期比 <code>a</code> 长，那么 <code>a</code> 被析构后存储空间被释放，而 <code>b</code> 仍然可以使用，则 <code>b</code> 就成为了悬垂指针。</p>
+
+<p>第二条是不允许有两个可变借用，避免出现数据一致性问题。</p>
+
+<pre><code class="language-`Rust">Struct Foo{v:i32}
+fn main(){
+    let mut f = Foo{v:10};
+    let im_ref = &amp;f;        // 获取不可变引用
+    let mut_ref = &amp; mut f;  // 获取可变引用
+    //println!(&quot;{}&quot;,f.v);
+    //println!(&quot;{}&quot;,im_ref.v);
+    //println!(&quot;{}&quot;,mut_ref.v);
+}</code></pre>
+
+<p>变量 <code>f</code> 拥有值的所有权，<code>im_ref</code> 是其不可变借用，<code>mut_ref</code> 是其可变借用。以上代码是可以编译过去的，但是这几个变量都没有被使用，这种情况下编译器并不禁止你同时拥有可变借用和不可变借用。最后的三行被注释掉的代码(6,7,8)使用了这些变量。打开一行或多行这些注释的代码，编译器会报告不同形式的错误：</p>
+
+<p>|开放注释行|编译器报告| |---------------|---------------| |6|正确| |7|第 5 行错误：不能获得 f 的可变借用，因为已经存在不可变借用| |8|正确| |6, 7|第 5 行错误：不能获得 f 的可变借用，因为已经存在不可变借用| |6,8|第 6 行错误：不能获得 f 的不可变借用，因为已经存在可变借用|</p>
+
+<p><strong>对&quot;借用&quot; 的抽象表达</strong></p>
+
+<p><code>Rust</code> 的核心包中有两个泛型 <code>trait</code> ，<a href='https://doc.rust-lang.org/beta/core/borrow/trait.Borrow.html'>core::borrow::Borrow</a> 与 <a href='https://doc.rust-lang.org/std/borrow/trait.BorrowMut.html'>core::borrow::BorrowMut</a>，可以用来表达&quot;借用&quot;的抽象含义，分别代表可变借用和不可变借用。 前面提到，“借用”有多种表达形式 <code>（&amp;T,Box&lt;T&gt;，Rc&lt;T&gt; 等等）</code>，在不同的使用场景中会选择合适的借用表达方式。它们的抽象形式就可以用 <a href='https://doc.rust-lang.org/beta/core/borrow/trait.Borrow.html'>core::borrow::Borrow</a> 来代表. 从类型关系上， <code>Borrow</code> 是&quot;借用&quot; 概念的抽象形式。从实际应用上，某些场合我们希望获得某个类型的“借用”，同时希望能支持所有可能的“借用”形式，<code>Borrow Trait</code> 就有用武之地。</p>
+
+<p>Borrow 的定义如下：</p>
+
+<pre><code class="language-`Rust">pub trait Borrow&lt;Borrowed: ?Sized&gt; {
+    fn borrow(&amp;self) -&gt; &amp;Borrowed;
+}</code></pre>
+
+<p>它只有一个方法，要求返回指定类型的引用。</p>
+
+<p><code>Borrow</code> 的文档中有提供例子</p>
+
+<pre><code class="language-`Rust">use std::borrow::Borrow;
+
+fn check&lt;T: Borrow&lt;str&gt;&gt;(s: T) {
+    assert_eq!(&quot;Hello&quot;, s.borrow());
+}
+
+fn main(){
+    let s: String = &quot;Hello&quot;.to_string(); 
+    check(s);
+
+    lets: &amp;str = &quot;Hello&quot;; 
+    check(s);
+}</code></pre>
+
+<p><code>check</code> 函数的参数表示它希望接收一个 “str”类型的任何形式的“借用”，然后取出其中的值与 “Hello”进行比较。</p>
+
+<p>标准库中为 <code>String</code> 类型实现了 <code>Borrow&lt;str&gt;</code>,代码如下</p>
+
+<pre><code class="language-`Rust">impl Borrow&lt;str&gt; for String{
+    #[inline]
+    fn borrow(&amp;self) -&gt; &amp;str{
+        &amp;self[..]
+    }
+}</code></pre>
+
+<p>所以 <code>String</code> 类型可以作为 <code>check</code> 函数的参数。</p>
+
+<p>从图上可以看出，标准库为所有类型 <code>T</code> 实现了 <code>Borrow Trait</code>, 也为 <code>&amp;T</code> 实现了 <code>Borrow Trait</code>。</p>
+
+<p>代码如下 ，这如何理解。</p>
+
+<pre><code class="language-`Rust">impl&lt;T: ?Sized&gt; Borrow&lt;T&gt; for T {
+    fn borrow(&amp;self) -&gt; &amp;T { // 是 fn borrow(self: &amp;Self）的缩写，所以 self 的类型就是 &amp;T
+        self
+    }
+}
+
+impl&lt;T: ?Sized&gt; Borrow&lt;T&gt; for &amp;T {
+    fn borrow(&amp;self) -&gt; &amp;T {
+        &amp;**self
+    }
+}</code></pre>
+
+<p>这正是 <code>Rust</code> 语言很有意思的地方，非常巧妙的体现了语言的一致性。既然 <code>Borrow&lt;T&gt;</code> 的方法是为了能获取 <code>T</code> 的引用，那么类型 <code>T</code> 和 <code>&amp;T</code> 当然也可以做到这一点。在 <code>Borrow for T</code> 的实现中，</p>
+
+<p><code>fn borrow(&amp;self)-&gt;&amp;T</code> 是 <code>fn borrow(self: &amp;Self)-&gt;&amp;T</code> 的缩写，所以 <code>self</code> 的类型就是 <code>&amp;T</code>,可以直接被返回。在 <code>Borrow for &amp;T</code> 的实现中，<code>fn borrow(&amp;self)-&gt;&amp;T</code> 是 <code>fn borrow(self: &amp;Self)-&gt;&amp;T</code> 的缩写，所以 <code>self</code> 的类型就是 <code>&amp;&amp;T</code>, 需要被两次解引用得到 <code>T</code>, 再返回其引用。</p>
+
+<p>智能指针 <code>Box&lt;T&gt;</code>,<code>Rc&lt;T&gt;</code>,<code>Arc&lt;T&gt;</code>,都实现了 <code>Borrow&lt;T&gt;</code> ，其获取 <code>&amp;T</code> 实例的方式都是两次解引用在取引用。<code>Weak&lt;T&gt;</code> 没有实现 <code>Borrow&lt;T&gt;</code>, 它需要升级成 <code>Rc&lt;T&gt;</code> 才能获取数据。</p>
+
+<h2 id='6.生命周期参数'>6.生命周期参数</h2>
+
+<p>变量的生命周期主要跟变量的作用域有关，在大部分程序语言中都是隐式定义的。<code>Rust</code> 中能显式声明变量的生命周期参数，这是非常独特的设计，其语法特性在其他语言也是不太可能见到的。以下是生命周期概念相关的图示。</p>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_7.jpg&quot;&gt; &lt;center&gt;图 7生命周期&lt;/center&gt;</p>
+
+<p><strong>生命周期参数的作用</strong></p>
+
+<p>生命周期参数的核心作用就是解决悬垂指针问题。就是让编译器帮助检查变量的生命周期，防止出现变量指向的内存区域被释放后，变量仍然可以使用的问题。那么什么情况下会让编译器无法判断生命周期，而必须引入一个特定语法来对生命周期进行标识？</p>
+
+<p>我们来看看最常见的悬垂指针问题，函数以引用方式返回函数内部的局部变量：</p>
+
+<pre><code class="language-`Rust">struct V{v:i32}
+ 
+fn bad_fn() -&gt; &amp;V{  //编译错误：期望一个命名的生命周期参数
+    let a = V{v:10};
+    &amp;a
+}
+let  res = bad_fn();</code></pre>
+
+<p>这个代码是一个典型的悬垂指针错误，<code>a</code> 是函数内的局部变量，函数返回后 <code>a</code> 就被销毁，把 <code>a</code> 的引用赋值给 <code>res</code> ，如果能执行成功，<code>res</code> 绑定的就是未定义的值。</p>
+
+<p>但编译器并不是报告悬垂指针错误，而是说返回类型 <code>&amp;V</code> 没有指定生命周期参数。<code>C++</code> 的类似代码编译器会给出悬垂指针的警告（警告内容:局部变量的地址被返回了）。</p>
+
+<p>那我们指定一个生命周期参数看看：</p>
+
+<pre><code class="language-`Rust">fn bad_fn&lt;&#8217;a&gt;() -&gt; &amp;&#8217;a V{
+    let a = V{v:10};
+    let ref_a = &amp;a;
+    ref_a   //编译错误：不能返回局部变量的引用
+}</code></pre>
+
+<p>这次编译器报告的是悬垂指针错误了。那么编译器的分析逻辑是什么？</p>
+
+<p>首先我们明确一下 &lt;font color=#fa8919&gt;&#8217;a 在这里的精确语义到底是什么？&lt;/font&gt;</p>
+
+<p>函数将要返回的引用会代表一个内存数据，这个数据有其生命周期范围，<code>&#8217;a</code> 参数是对这个生命周期范围提出的要求。就像 <code>&amp;V</code> 是对返回值类型提的要求类似，<strong>&#8217;a 是对返回值生命周期提的要求</strong>。编译器需要检查的就是实际返回的数据，其生命是否符合要求。</p>
+
+<p>那么 &lt;font color=#fa8919&gt;&#8217;a 参数对返回值的生命周期到底提出了什么要求？&lt;/font&gt;</p>
+
+<p>我们先区分一下&quot;函数上下文&quot;和“调用者上下文”，函数上下文是指函数体内部的作用域范围，调用者上下文是指该函数被调用的位置。上述的悬垂指针错误其实并不会影响函数上下文范围的程序执行，出问题的地方是调用者上下文拿到一个无效引用并使用时，会出现不可预测的错误。</p>
+
+<p>函数返回的引用会在“调用者上下文”中赋予某个变量，如：</p>
+
+<pre><code class="language-`Rust">let res = bod_fn();</code></pre>
+
+<p><code>res</code> 获得了返回的引用, 函数内的 <code>ref_a</code> 引用会按位复制给变量 <code>res</code> （标准库中 <code>impl&lt;T: ?Sized&gt; Copy for &amp;T {}</code> 指定了此规则）<code>res</code> 会指向 函数内 <code>res_a</code> 同样的数据。为了保证将来在调用者上下文不出悬垂指针，编译器真正要确保的是 <code>res</code> 所指向的数据的生命周期，不短于 <code>res</code> 变量自己的生命周期。否则如果数据的生命周期短，先被释放，<code>res</code> 就成为悬垂指针。</p>
+
+<p>可以把这里的 <code>&#8217;a</code> 参数理解为调用者上下文中接收函数返回值的变量 <code>res</code> 的生命周期，那么 <code>&#8217;a</code> 对函数体内部返回引用的要求是：<strong>返回引用所指代数据的生命周期不短于 &#8217;a ，也就是不短于调用者上下文接收返回值的变量的生命周期。</strong></p>
+
+<p>上述例子中函数内 <code>ref_a</code> 指代的数据生命周期就是函数作用域，函数返回前，数据被销毁，生命周期小于调用者上下文的 <code>res</code>, 编译器根据 返回值的生命周期要求与实际返回值做比较，发现了错误。</p>
+
+<p>实际上，返回的引用或者是静态生命周期，或者是根据函数输入的引用参数通过运算变换得来的，否则都是这个结果，因为都是对局部数据的引用。</p>
+
+<p><strong>静态生命周期</strong></p>
+
+<p>看函数</p>
+
+<pre><code class="language-`Rust">fn get_str&lt;&#8217;a&gt;() -&gt; &amp;&#8217;a str {
+    let s = &quot;hello&quot;;
+    s
+}</code></pre>
+
+<p>这个函数可以编译通过，返回的引用虽然不是从输入参数推导，不过是静态生命周期，可以通过检查。</p>
+
+<p>因为静态生命周期可以理解为“无穷大”的语义，实际是跟进程的生命周期一致，也就是在程序运行期间始终有效。</p>
+
+<p><code>Rust</code> 的字符串字面量是存储在程序代码中，程序加载后在代码空间，始终有效。可以通过一个简单试验验证这一点：</p>
+
+<pre><code class="language-`Rust">let s1=&quot;Hello&quot;;
+println!(&quot;&amp;s1:{:p}&quot;, &amp;s1);//&amp;s1:0x9cf918
+
+let s2=&quot;Hello&quot;;
+println!(&quot;&amp;s2:{:p}&quot;,&amp;s2);//&amp;s2:0x9cf978
+//s1,s2是一样的值但是地址不一样，是两个不同的引用变量
+
+let ptr1: *const u8 = s1.as_ptr();
+println!(&quot;ptr1:{:p}&quot;, ptr1);//ptr1:0x4ca0a0
+
+let ptr2: *const u8 = s2.as_ptr();
+println!(&quot;ptr2:{:p}&quot;, ptr2);//ptr2:0x4ca0a0</code></pre>
+
+<p><code>s1</code>,<code>s2</code> 的原始指针都指向同一个地址，说明编译器为 &quot;Hello&quot; 字面量只保存了一份拷贝，所有引用都指向它。</p>
+
+<p><code>get_str</code> 函数中静态生命周期长于返回值要求的<code>&#8217;a</code>，所以是合法的。</p>
+
+<p>如果把 <code>get_str</code> 改成</p>
+
+<pre><code class="language-`Rust">fn get_str&lt;&#8217;a&gt;() -&gt; &amp;&#8217;static str</code></pre>
+
+<p>即把对返回值生命周期的要求改为无穷大，那就只能返回静态字符串引用了。</p>
+
+<p><strong>函数参数的生命周期</strong></p>
+
+<p>前面的例子为了简单起见，没有输入参数，这并不是一个典型的情况。大多数情况下，函数返回的引用是根据输入的引用参数通过运算变换而来。比如下面的例子：</p>
+
+<pre><code class="language-`Rust">fn  remove_prefix&lt;&#8217;a&gt;(content:&amp;&#8217;a str,prefix:&amp;str) -&gt; &amp;&#8217;a str{
+    if content.starts_with(prefix){
+        let start:usize = prefix.len();
+        let end:usize = content.len();
+        let sub = content.get(start..end).unwrap();
+        sub
+    }else{
+        content
+    }
+}
+let  s = &quot;reload&quot;;
+let sub = remove_prefix(&amp;s0,&quot;re&quot;);
+println!(&quot;{}&quot;,sub); // 输出: load</code></pre>
+
+<p><code>remove_prefix</code> 函数从输入的 <code>content</code> 字符串中判断是否有 <code>prefix</code> 代表的前缀。 如果有就返回 <code>content</code> 不包含前缀的切片，没有就返回 <code>content</code> 本身。</p>
+
+<p>无论如何这个函数都不会返回前缀 <code>prefix</code> ，所以 <code>prefix</code> 变量不需要指定生命周期。</p>
+
+<p>函数两个分支返回的都是通过 <code>content</code> 变量变换出来的，并作为函数的返回值。所以 <code>content</code> 必须标注生命周期参数，编译器要根据 <code>content</code> 的生命周期参数与返回值的要求进行比较，判断是否符合要求。即：<strong>实际返回数据的生命周期，大于或等于返回参数要求的生命周期。</strong></p>
+
+<p>前面说到，我们把返回参数中指定的生命周期参数 <code>&#8217;a</code> 看做调用者上下文中接收返回值的变量的生命周期，在这个例子中就是字符串引用 <code>sub</code>，&lt;font color=#fa8919&gt;那么输入参数中的 &#8217;a 代表什么意思 ？&lt;/font&gt;</p>
+
+<p>这在 <code>Rust</code> 语法设计上是一个很让人困惑的地方，输入参数和输出参数的生命周期都标志为 <code>&#8217;a</code> ，似乎是要求两者的生命周期要求一致，但实际上并不是这样。</p>
+
+<p>我们先看看如果输入参数的生命周期跟输出参数期待的不一样是什么情况，例如下面两个例子：</p>
+
+<pre><code class="language-`Rust">fn echo&lt;&#8217;a, &#8217;b&gt;(content: &amp;&#8217;b str) -&gt; &amp;&#8217;a str {
+    content //编译错误：引用变量本身的生命周期超过了它的借用目标
+}
+fn longer&lt;&#8217;a, &#8217;b&gt;(s1: &amp;&#8217;a str, s2: &amp;&#8217;b str) -&gt; &amp;&#8217;a str {
+    if s1.len() &gt; s2.len()
+        { s1 }
+    else
+        { s2 }//编译错误：生命周期不匹配
+}</code></pre>
+
+<p><code>echo</code> 函数输入参数生命周期标注为 <code>&#8217;b</code> , 返回值期待的是 <code>&#8217;a</code> .编译器报错信息是典型的“悬垂指针”错误。不过内容似乎并不明确。编译器指出查阅详细信息 <a href='https://doc.rust-lang.org/error-index.html#E0312'>--explain E0312</a> ，这里的解释是&quot;借用内容的生命周期与期待的不一致&quot;。这个错误描述就与实际的错误情况是相符合的了。</p>
+
+<p><code>longer</code> 函数两个参数分别具有生命周期 <code>&#8217;a</code> 和 <code>&#8217;b</code> , 返回值期待 <code>&#8217;a</code> ,当返回 <code>s2</code> 时，编译器报告生命周期不匹配。把 <code>longer</code> 函数中的生命周期 <code>&#8217;b</code> 标识为比 <code>&#8217;a</code> 长，就可以正确编译了。</p>
+
+<pre><code class="language-`Rust">fn longer&lt;&#8217;a, &#8217;b: &#8217;a&gt;(s1: &amp;&#8217;a str, s2: &amp;&#8217;b str) -&gt; &amp;&#8217;a str {
+    if s1.len() &gt; s2.len()
+        { s1 }
+    else
+        { s2 }//编译通过
+}</code></pre>
+
+<p>回到我们前面的问题，&lt;font color=#fa8919&gt;那么输入参数中的 &#8217;a 代表什么意思 ？&lt;/font&gt;</p>
+
+<p>我们知道编译器在函数定义上下文中所做的生命周期检查就是要确保”<strong>实际返回数据的生命周期，大于或等于返参数要求的生命周期</strong>“。当输入参数给出与返回值一样的生命周期参数 <code>&#8217;a</code> 时，实际上是人为地向编译器保证：<strong>在调用者上下文中，实际给出的函数输入参数的生命周期，不小于将来用于接收返回值的变量的生命周期。</strong></p>
+
+<p>当有两个生命周期参数 <code>&#8217;a</code> <code>&#8217;b</code> , 而 <code>&#8217;b</code> 大于 <code>&#8217;a</code>，当然 也保证了在调用者上下文 <code>&#8217;b</code> 代表的输入参数生命周期也足够长。</p>
+
+<p>在函数定义中，编译器并不知道将来实际调用这个函数的上下文是怎么样的。生命周期参数相当是函数上下文与调用者上下文之间关于参数生命周期的协议。</p>
+
+<p>就像函数签名中的类型声明一样，类型声明约定了与调用者之间输入输出参数的类型，编译器编译函数时，会检查函数体返回的数据类型与声明的返回值是否一致。同样对与参数与返回值的生命周期，函数也会检查函数体中返回的变量生命周期与声明的是否一致。</p>
+
+<p>前面说的是编译器在“<strong>函数定义上下文的生命周期检查</strong>”机制，这只是生命周期检查的一部分，还有另一部分就是“<strong>调用者上下文对生命周期的检查</strong>”机制。两者检查的规则如下：</p>
+
+<p><strong>函数定义上下文的生命周期检查：</strong></p>
+
+<p>函数签名中返回值的生命周期标注可以是输入标注的任何一个，只要保证由输入参数推导出来的返回的临时变量的生命周期，比函数签名中返回值标注的生命周期相等或更长。这样保证了调用者上下文中，接收返回值的变量，不会因为输入参数失效而成为悬垂指针。</p>
+
+<p><strong>调用者上下文对生命周期的检查：</strong></p>
+
+<p>调用者上下文中，接收函数返回借用的变量 <code>res</code> ，其生命周期不能长于返回的借用的生命周期(实际是根据输入借用参数推导出来的)。否则 <code>res</code> 会在输入参数失效后成为悬垂指针。</p>
+
+<p>前面 <code>remove_prefix</code> 函数编译器已经校验合格，那么我们在调用者上下文中构建如下例子</p>
+
+<pre><code class="language-`Rust">let res: &amp;str;
+{
+    let s = String::from(&quot;reload&quot;);
+    res = remove_prefix(&amp;s, &quot;re&quot;) //编译错误：s 的生命周期不够长
+}
+println!(&quot;{}&quot;, res);</code></pre>
+
+<p>这个例子中 <code>remove_prefix</code> 被调用这一行，编译器会报错 “s 的生命周期不够长”。代码中的 大括号创建了一个新的词法作用域，导致 <code>res</code> 的生命周期比大括号内部的 <code>s</code> 更长。这不符合函数签名中对生命周期的要求。函数签名要求输入参数的生命周期不短于返回值要求的生命周期。</p>
+
+<p><strong>结构体定义中的生命周期</strong></p>
+
+<p>结构体中有引用成员时，就会有潜在的悬垂指针问题，需要标识生命周期参数来让编译器帮助检查。</p>
+
+<pre><code class="language-`Rust">struct G&lt;&#8217;a&gt;{ m:&amp;&#8217;a str}
+ 
+fn get_g() -&gt; () {
+    let g: G;
+    {
+        let  s0 = &quot;Hi&quot;.to_string();
+        let  s1 = s0.as_str();              //编译错误：借用值存活时间不够长
+        g = G{ m: s1 };
+    }
+    println!(&quot;{}&quot;, g.m);
+}</code></pre>
+
+<p>上面的例子中，结构体 <code>G</code> 包含了引用成员，不指定生命周期参数是无法编译的。函数 <code>get_g</code> 演示了在使用者上下文中如何出现生命周期不匹配的情况。</p>
+
+<p>结构体的生命周期定义就是要保证在一个结构体实例中，其引用成员的生命周期不短于结构体实例自身的生命周期。否则如果结构体实例存活期间，其引用成员的数据先被销毁，那么访问这个引用成员时就构成了对悬垂指针的访问。</p>
+
+<p>实际上结构体的生命周期参数可以和函数生命周期参数做类比，成员的生命周期相当函数的输入参数的生命周期，结构体整体的生命周期相当函数返回值的生命周期。这样所有之前对函数生命周期参数的分析一样可以适用。</p>
+
+<p>如果结构体有方法成员会返回引用参数，方法同样需要填写生命周期参数。返回的引用来源可以是方法的输入引用参数，也可以是结构体的引用成员。在做生命周期分析的时候，可以把“方法的输入引用参数”和“结构体的引用成员”都看做普通函数的输入参数，这样前面对普通函数参数和返回值的生命周期分析方法可以继续套用。</p>
+
+<p><strong>泛型的生命周期限定</strong></p>
+
+<p>前文说过生命周期参数跟类型限定很像，比如在代码</p>
+
+<pre><code class="language-`Rust">fn longer&lt;&#8217;a&gt;(s1:&amp;&#8217;a str, s2:&amp;&#8217;a str) -&gt; &amp;&#8217;a str
+ 
+struct G&lt;&#8217;a&gt;{ m:&amp;&#8217;a str }</code></pre>
+
+<p>中，<code>&#8217;a</code> 出现的位置参数类型旁边，一个对参数的静态类型做限定，一个对参数的动态时间做限定。<code>&#8217;a</code> 使用前需要先声明，声明的位置与模板参数的位置一样，在 <code>&lt;&gt;</code> 括号内，也是用来放泛型的类型参数的地方。</p>
+
+<p>那么，&lt;font color=#fa8919&gt;把类型换成泛型可以吗，语义是什么？使用场景是什么？&lt;/font&gt;</p>
+
+<p>我们看看代码例子：</p>
+
+<pre><code class="language-`Rust">use std::cmp::Ordering;
+
+#[derive(Eq, PartialEq, PartialOrd, Ord)]
+struct G&lt;&#8217;a, T:Ord&gt;{ m: &amp;&#8217;a T }
+ 
+#[derive(Eq, PartialEq, PartialOrd, Ord)]
+struct Value{ v: i32 }
+ 
+fn longer&lt;&#8217;a, T:Ord&gt;(s1: &amp;&#8217;a T, s2: &amp;&#8217;a T) -&gt; &amp;&#8217;a T {
+    if s1 &gt; s2 { s1 } else { s2 }
+}
+ 
+fn main(){
+    let v0 = Value{ v:12 };
+    let v1 = Value{ v:15 };
+    let res_v = longer(&amp;v0, &amp;v1);
+    println!(&quot;{}&quot;, res_v.v);//15
+     
+    let g0 = G{ m: &amp;v0 };
+    let g1 = G{ m: &amp;v1 };
+    let res_g = longer(&amp;g0, &amp;g1);//15
+    println!(&quot;{}&quot;, res_g.m.v);
+}</code></pre>
+
+<p>这个例子扩展了 <code>longer</code> 函数，可以对任何实现了 <code>Ord trait</code> 的类型进行操作。 <code>Ord</code> 是核心包中的一个用于实现比较操作的内置 <code>trait</code>. 这里不细说明。<code>longer</code> 函数跟前一个版本比较，只是把 <code>str</code> 类型换成了泛型参数 <code>T</code>, 并给 <code>T</code> 增加了类型限定 <code>T:Ord</code>.</p>
+
+<p>结构体 <code>G</code> 也扩展成可以容纳泛型 <code>T</code>,但要求 <code>T</code> 实现了 <code>Ord trait</code>.</p>
+
+<p>从代码及执行结果看，跟 把 <code>T</code> 当成普通类型一样，没有什么特别，生命周期参数依然是他原来的语义。</p>
+
+<p>但实际上 &quot;<code>&amp;&#8217;a T</code>&quot; 还隐含另一层语义：<strong>如果 <code>T</code> 内部含有引用成员，那么其中的引用成员的生命周期要求不短于 <code>T</code> 实例的生命周期。</strong></p>
+
+<p>老规矩，我们来构造一个反例。结构体 <code>G</code> 内部包含一个泛型的引用成员，我们将 <code>G</code> 用于 <code>longer</code> 函数，但是让 <code>G</code> 内部的引用成员生命周期短于 <code>G</code>。代码如下：</p>
+
+<pre><code class="language-`Rust">fn  main(){
+    let v0 = Value{ v:12 };
+    let v1_ref: &amp;Value;      // 将 v1 的引用定义在下面大括号之外，有意延长变量的生命周期范围
+    let res_g: &amp;G&lt;Value&gt;;
+
+    {
+        let v1 = Value{ v:15 };
+        v1_ref = &amp;v1;      //编译错误：v1的生命周期不够长。
+        let res_v = longer(&amp;v0,v1_ref);
+        println!(&quot;{}&quot;,res_v.v);
+    }
+
+    let g0 = G{ m:&amp;v0 };
+    let g1 = G{ m:v1_ref };   // 这时候 v1_ref 已经是悬垂指针
+    res_g = longer(&amp;g0, &amp;g1);
+    println!(&quot;{}&quot;, res_g.m.v);
+}</code></pre>
+
+<p>变量 <code>g1</code> 自身的生命周期是满足 <code>longer</code> 函数要求的，但是其内部的引用成员，生命周期过短。</p>
+
+<p>这个范例是在“调用者上下文”检查时触发的，对泛型参数的生命周期限定比较难设计出在“函数定义或结构体定义上下文”触发的范例。毕竟 <code>T</code> 只是类型指代，定义时还没有具体类型。</p>
+
+<p>实际上要把在 “<code>struct G&lt;&#8217;a,T&gt;{m:&amp;&#8217;a T}</code>中，<code>T</code> 的所有引用成员的生命周期不短于<code>&#8217;a</code> ”这个语义准确表达，应该写成：</p>
+
+<pre><code class="language-`Rust">struct G&lt;&#8217;a,T:&#8217;a&gt;{m:&amp;&#8217;a T}</code></pre>
+
+<p>因为 <code>T:&#8217;a</code> 才是这个语义的明确表述。但是第一种表达方式也是足够的(我用反证法证明了这一点)。所以编译器也接受第一种比较简化的表达形式。</p>
+
+<p>总而言之，泛型参数的生命周期限定是两层含义，一层是泛型类型当做一个普通类型时一样的含义，一层是对泛型内部引用成员的生命周期约束。</p>
+
+<p><strong>Trait 对象的生命周期</strong></p>
+
+<p>看如下代码</p>
+
+<pre><code class="language-`Rust">trait Foo{}
+struct Bar{v:i32}
+struct Qux&lt;&#8217;a&gt;{m:&amp;&#8217;a  i32}
+struct Baz&lt;&#8217;a,T&gt;{v:&amp;&#8217;a T}
+ 
+impl Foo for Bar{}
+impl&lt;&#8217;a&gt; Foo for Qux&lt;&#8217;a&gt;{}
+impl&lt;&#8217;a,T&gt; Foo for Baz&lt;&#8217;a,T&gt;{}</code></pre>
+
+<p>结构体 <code>Bar</code>,<code>Qux</code>,<code>Baz</code> 都实现了 <code>trait Foo</code>, 那么 <code>&amp;Foo</code> 类型可以接受这三个结构体的任何一个的引用类型。</p>
+
+<p>我们把 <code>&amp;Foo</code> 称为 <code>Trait</code> 对象。</p>
+
+<p><code>Trait</code> 对象可以理解为类似其它面向对象语言中，指向接口或基类的指针或引用。其它<code>OO</code>语言指向基类的指针在运行时确定其实际类型。<code>Rust</code> 没有类继承，指向 <code>trait</code> 的指针或引用起到类似的效果，运行时被确定具体类型。所以编译期间不知道大小。</p>
+
+<p><code>Rust</code> 的 <code>Trait</code> 不能有非静态数据成员，所以 <code>Trait</code> 本身就不会出现引用成员的生命周期小于对象自身，所以 <code>Trait</code> 对象默认的生命周期是静态生命周期。我们看下面三个函数：</p>
+
+<pre><code class="language-`Rust">fn check0() -&gt; &amp;&#8217;static Foo { // 如果不指定 &#8217;static , 编译器会报错，要求指定生命周期命参数, 并建议 &#8217;static
+    const b:Bar = Bar{v:0};
+    &amp;b
+}
+fn check1&lt;&#8217;a&gt;() -&gt; &amp;&#8217;a Foo { //如果不指定 &#8217;a , 编译器会报错
+    const b:Bar = Bar{v:0};
+    &amp;b
+}
+fn check2(foo:&amp;Foo) -&gt; &amp;Foo {//生命周期参数被省略，不要求静态生命周期
+    foo
+}
+fn check3(foo:&amp;&#8217;static Foo) -&gt; &amp;&#8217;static Foo {
+    foo
+}
+fn main(){
+    let bar= Bar{v:0};
+    check2(&amp;bar);                               //能编译通过，说明 chenk2 的输入输出参数都不是静态生命周期
+    //check3(&amp;bar);                          //编译错误：bar的生命周期不够长
+    const bar_c:Bar =Bar{v:0};
+    check3(&amp;bar_c);                         // check3 只能接收静态参数
+}</code></pre>
+
+<p><code>check0</code> 和 <code>check1</code> 说明将 <code>Trait</code> 对象的引用作为 函数参数返回时，跟返回其他引用类型一样，都需要指定生命周期参数。函数 <code>check2</code> 的生命周期参数只是被省略了(编译器可以推断)，但这个函数里的 <code>Trait</code> 对象并不是静态生命周期，这可以从 <code>main</code> 函数内能成功执行 <code>check2(bar)</code> 分析出来，因为 <code>bar</code> 不是静态生命周期.</p>
+
+<p>实际上在运行时，<code>Trait</code> 对象总会动态绑定到一个实现了该 <code>Trait</code> 的具体结构体类型(如 <code>Bar</code>,<code>Qux</code>,<code>Baz</code> 等)，这个具体类型的在其上下文中有它的生命周期，可以是静态的，更多情况下是非静态生命周期 <code>&#8217;a</code> ，那么 <code>Trait</code> 对象的生命周期也是 <code>&#8217;a</code>.</p>
+
+<p>||结构体或成员生命周期|Trait 对象生命周期| |--|------------------------------|------------------------| |Foo|无|&#8217;static| |Bar|&#8217;a|&#8217;a| |Qux\&lt;&#8217;a&gt;{m:&amp;&#8217;a str}|&#8217;a|&#8217;a| |Baz\&lt;&#8217;a,T&gt;{v:&amp;&#8217;a T}|&#8217;a|&#8217;a|</p>
+
+<pre><code class="language-`Rust">fn qux_update&lt;&#8217;a&gt;(qux: &amp;&#8217;a mut Qux&lt;&#8217;a&gt;, new_value: &amp;&#8217;a i32)-&gt;&amp;&#8217;a Foo {
+    qux.v = new_value;
+    qux
+}
+
+let value = 100;
+let mut qux = Qux{v: &amp;value};
+let new_value = 101;
+let muted: &amp;dyn Foo = qux_update(&amp; mut qux, &amp;new_value);
+qux_update 函数的智能指针版本如下：
+ 
+fn qux_box&lt;&#8217;a&gt;(new_value: &amp;&#8217;a  i32) -&gt; Box&lt;Foo +&#8217;a&gt; {
+    Box::new(Qux{v:new_value})
+}
+ 
+let new_value = 101;
+let boxed_qux:Box&lt;dyn Foo&gt; = qux_box(&amp;new_value);</code></pre>
+
+<p>返回的智能指针中，<code>Box</code> 装箱的类型包含了引用成员，也需要给被装箱的数据指定生命周期，语法形式是在被装箱的类型位置增加生命周期参数，用 &quot;+&quot; 号连接。</p>
+
+<p>这两个版本的代码其实都说明一个问题，就是 <code>Trait</code> 虽然默认是静态生命周期，但实际上，其生命周期是由具体实现这个 <code>Trait</code> 的结构体的生命周期决定，推断方式跟之前叙述的函数参数生命周期并无太大区别。</p>
+
+<h2 id='7.智能指针的所有权与生命周期'>7.智能指针的所有权与生命周期</h2>
+
+<p>如图 6，在 <code>Rust</code> 中引用和智能指针都算是“指针”的一种形态，所以他们都可以实现 <a href='https://doc.rust-lang.org/beta/core/borrow/trait.Borrow.html'>std::borrow::Borrow</a> <code>Trait</code>。一般情况下，我们对栈中的变量获取引用，栈中的变量存续时间一般比较短，当前的作用域退出时，作用域范围内的栈变量就会被回收。如果我们希望变量的生命周期能跨越当前的作用域，甚至在线程之间传递，最好是把变量绑定的数据区域创建在堆上。</p>
+
+<p>栈上的变量其作用域在编译期间就是明确的，所以编译器能够确定栈上的变量何时会被释放，结合生命周期参数生命，编译器能找到绝大部分对栈上变量的错误引用。</p>
+
+<p>堆上变量其的内存管理比栈变量要复杂很多。在堆上分配一块内存之后，编译器无法根据作用域来判断这块内存的存活时间，必须由使用者显式指定。<code>C</code> 语言中就是对于每一块通过 <code>malloc</code> 分配到的内存，需要显式的使用 <code>free</code> 进行释放。<code>C++</code>中是 <code>new / delete</code>。但是什么时候调用 <code>free</code> 或 <code>delete</code> 就是一个难题。尤其当代码复杂，分配内存的代码和释放内存的代码不在同一个代码文件，甚至不在同一个线程的时候，仅仅靠人工跟踪代码的逻辑关系来维护分配与释放就难免出错。</p>
+
+<p>智能指针的核心思想是让系统自动帮我们决定回收内存的时机。其主要手段就是“<strong>将内存分配在堆上，但指向该内存的指针变量本身是在栈上，这样编译器就可以捕捉指针变量离开作用域的时机。在这时决定内存回收动作，如果该指针变量拥有内存区的所有权就释放内存，如果是一个引用计数指针就减少计数值，计数为 0 就回收内存</strong>”。</p>
+
+<p><code>Rust</code> 的 <code>Box&lt;T&gt;</code> 为独占所有权指针，<code>Rc&lt;T&gt;</code>为引用计数指针，但其计数过程不是线程安全的，<code>Arc&lt;T&gt;</code>提供了线程安全的引用计数动作,可以跨线程使用。</p>
+
+<p>我们看 <code>Box&lt;T&gt;</code> 的定义</p>
+
+<pre><code class="language-`Rust">pub struct Box&lt;T: ?Sized&gt;(Unique&lt;T&gt;);
+pub struct Unique&lt;T: ?Sized&gt;{
+    pointer: *const T,
+    _marker: PhantomData&lt;T&gt;,
+} </code></pre>
+
+<p><code>Box</code> 本身是一个元组结构体，包装了一个 <code>Unique&lt;T&gt;</code>， <code>Unique&lt;T&gt;</code>内部有一个原生指针。</p>
+
+<p><em>(注：Rust 最新版本的 Box&lt;T&gt; 实现还可以通过泛型参数指定内存分配器，让用户可以自己控制实际内存的分配。还有为什么通过 Unique&lt;T&gt;多层封装，这涉及智能指针实现的具体问题，这里不详述。）</em></p>
+
+<p><code>Box</code> 没有实现 <code>Copy Trait</code>,它在所有权转移时会执行移动语意。</p>
+
+<p>示例代码：</p>
+
+<pre><code class="language-`Rust">Struct Foo {v:i32}
+fn inc(v:&amp; mut Foo) -&gt; &amp;Foo {//省略了生命周期参数
+    v.v = v.v + 1;
+    v
+}
+//返回Box指针不需要生命周期参数，因为Box指针拥有了所有权，不会成为悬垂指针
+fn inc_ptr(mut foo_ptr:Box&lt;Foo&gt;) -&gt; Box&lt;Foo&gt; {//输入参数和返回参数各经历一次所有权转移
+    foo_ptr.v = foo_ptr.v + 1;
+    println!(&quot;ininc_ptr：{:p}-{:p}&quot;, &amp;foo_ptr, &amp;*foo_ptr);
+    foo_ptr
+}
+fn main() {
+    let foo_ptr1 = Box::new(Foo{v:10});
+    println!(&quot;foo_ptr1：{:p}-{:p}&quot;, &amp;foo_ptr1, &amp;*foo_ptr1);
+    let mut foo_ptr2 = inc_ptr(foo_ptr1);
+    //println!(&quot;{}&quot;,foo_ptr1.v);//编译错误，f0_ptr所有权已经丢失
+    println!(&quot;foo_ptr2：{:p}-{:p}&quot;, &amp;foo_ptr2, &amp;*foo_ptr2);
+     
+    inc(foo_ptr2.borrow_mut());//获得指针内数据的引用，调用引用版本的inc函数
+    println!(&quot;{}&quot;,foo_ptr2.v);
+}</code></pre>
+
+<p><code>inc</code> 为引用版本，<code>inc_ptr</code> 是指针版本。改代码的输出为：</p>
+
+<pre><code class="language-`">foo_ptr1：0x8dfad0-0x93a5e0
+in inc_ptr：0x8df960-0x93a5e0
+foo_ptr2：0x8dfb60-0x93a5e0
+12</code></pre>
+
+<p>可以看到 <code>foo_ptr1</code> 进入函数 <code>inc_ptr</code> 时,执行了一次所有权转移，函数返回时又执行了一次。所以三个 <code>Box&lt;Foo&gt;</code> 的变量地址都不一样，但是它们内部的数据地址都是一样的，指向同一个内存区。</p>
+
+<p><code>Box</code> 类型自身是没有引用成员的，但是如果 <code>T</code> 包含引用成员，那么其相关的生命周期问题会是怎样的？</p>
+
+<p>我们把 <code>Foo</code> 的成员改成引用成员试试，代码如下：</p>
+
+<pre><code class="language-`Rust">use std::borrow::BorrowMut;
+struct Foo&lt;&#8217;a&gt;{v:&amp;&#8217;a mut i32}
+    fn inc&lt;&#8217;a&gt;(foo:&amp;&#8217;a mut Foo&lt;&#8217;a&gt;) -&gt;&amp;&#8217;a Foo&lt;&#8217;a&gt; {//生命周期不能省略
+    *foo.v=*foo.v + 1; // 解引用后执行加法操作
+    foo
+}
+fn inc_ptr(mut foo_ptr:Box&lt;Foo&gt;) -&gt; Box&lt;Foo&gt; {//输入参数和返回参数各经历一次所有权转移
+    *foo_ptr.v = *foo_ptr.v + 1; / 解引用后执行加法操作
+    println!(&quot;ininc_ptr：{:p}-{:p}&quot;, &amp;foo_ptr, &amp;*foo_ptr);
+    foo_ptr
+}
+fn main(){
+    let mut value = 10;
+    let foo_ptr1 = Box::new(Foo{v:&amp; mut value});
+    println!(&quot;foo_ptr1：{:p}-{:p}&quot;, &amp;foo_ptr1, &amp;*foo_ptr1);
+    let mut foo_ptr2 = inc_ptr(foo_ptr1);
+    //println!(&quot;{}&quot;,foo_ptr1.v);//编译错误，f0_ptr所有权已经丢失
+    println!(&quot;foo_ptr2：{:p}-{:p}&quot;, &amp;foo_ptr2, &amp;*foo_ptr2);
+     
+    let foo_ref = inc(foo_ptr2.borrow_mut());//获得指针内数据的引用，调用引用版本的inc函数
+    //println!(&quot;{}&quot;,foo_ptr2.v);//编译错误，无法获取foo_ptr2.v的不可变借用，因为已经存在可变借用
+    println!(&quot;{}&quot;, foo_ref.v);
+}</code></pre>
+
+<p>引用版本的 <code>inc</code> 函数生命周期不能再省略了。因为返回 <code>Foo</code> 的引用时，有两个生命周期值，一个是<code>Foo</code> 实例的生命周期，一个是 <code>Foo</code> 中引用成员的生命周期，编译器无法做推断，需要指定。但是智能指针版本 <code>inc_ptr</code> 函数的生命周期依然不用指定。<code>Foo</code> 的实例被智能指针包装，生命周期由 <code>Box</code> 负责管理。</p>
+
+<p>如果 <code>Foo</code> 是一个 <code>Trait</code> ，而实现它的结构体有引用成员，那么 <code>Box&lt;Foo&gt;</code> 的生命周期会有什么情况。示例代码如下：</p>
+
+<pre><code class="language-`Rust">trait Foo{
+    fn inc(&amp;mut self);
+    fn value(&amp;self)-&gt;i32;
+}
+
+struct Bar&lt;&#8217;a&gt;{v:&amp;&#8217;a mut i32}
+
+impl&lt;&#8217;a&gt; Foo for Bar&lt;&#8217;a&gt; {
+    fn inc(&amp;mut self){
+        *(self.v)=*(self.v)+1
+    }
+    fn value(&amp;self)-&gt;i32{
+        *self.v
+    }
+}
+
+fn inc(foo:&amp; mut dyn Foo)-&gt;&amp; dyn Foo {//生命周期参数被省略
+    foo.inc();
+    foo
+}
+
+fn inc_ptr(mut foo_ptr:Box&lt;dyn Foo&gt;) -&gt; Box&lt; dyn Foo&gt; {//输入参数和返回参数各经历一次所有权转移
+    foo_ptr.inc();
+    foo_ptr
+}
+
+fn main() {
+}</code></pre>
+
+<p>引用版本和智能指针版本都没生命周期参数，可以编译通过。不过 <code>main</code> 函数里是空的，也就是没有使用这些函数，只是定义编译通过了。我先试试使用引用版本：</p>
+
+<pre><code class="language-`Rust">fn main(){
+    let mut value = 10;
+    let mut foo1= Bar{v:&amp; mut value};
+    let foo2 =inc(&amp;mut foo1);
+    println!(&quot;{}&quot;, foo2.value());  // 输出 11
+}</code></pre>
+
+<p>可以编译通过并正常输出。再试智能指针版本：</p>
+
+<pre><code class="language-`Rust">fn main(){
+    let mut value = 10;
+    let foo_ptr1 = Box::new(Bar{v:&amp;mut value});   //编译错误：value生命周期太短
+    let mut foo_ptr2 = inc_ptr(foo_ptr1); //编译器提示：类型转换需要value为静态生命周期
+}</code></pre>
+
+<p>编译失败。提示的错误信息是 <code>value</code> 的生命周期太短，需要为 <code>&#8217;static</code> 。因为 <code>Trait</code> 对象（ <code>Box&lt; dyn Foo&gt;</code>）默认是静态生命周期，编译器推断出返回数据的生命周期太短。去掉最后一行 <code>inc_ptr</code> 是可以正常编译的。</p>
+
+<p>如果将 <code>inc_ptr</code> 的定义加上生命周期参数上述代码就可以编译通过。修改后的 <code>inc_ptr</code> 如下：</p>
+
+<pre><code class="language-`Rust">fn inc_ptr&lt;&#8217;a&gt;(mut foo_ptr:Box&lt;dyn Foo+&#8217;a&gt;) -&gt; Box&lt;dyn Foo+&#8217;a&gt; {
+    foo_ptr.inc();
+    foo_ptr
+}</code></pre>
+
+<p>为什么指针版本不加生命周期参数会出错，而引用版没有生命周期参数却没有问题？</p>
+
+<p>因为引用版是省略了生命周期参数，完整写法是：</p>
+
+<pre><code class="language-`Rust">fn inc&lt;&#8217;a&gt;(foo:&amp;&#8217;a mut dyn Foo)-&gt;&amp;&#8217;a dyn Foo {
+    foo.inc();
+    foo
+}</code></pre>
+
+<h2 id='8._闭包与所有权'>8. 闭包与所有权</h2>
+
+<p>这里不介绍闭包的使用，只说与所有权相关的内容。闭包与普通函数相比，除了输入参数，还可以捕获上线文中的变量。闭包还支持一个 <code>move</code> 关键字，来强制转移捕获变量的所有权。</p>
+
+<p>我们先来看 <code>move</code> 对输入参数有没有影响：</p>
+
+<pre><code class="language-`Rust">//结构 Value 没有实现Copy Trait
+struct Value{x:i32}
+ 
+//没有作为引用传递参数，所有权被转移
+let mut v = Value{x:0};
+let fun = |p:Value| println!(&quot;in closure:{}&quot;, p.x);
+fun(v);
+//println!(&quot;callafterclosure:{}&quot;,point.x);//编译错误：所有权已经丢失
+ 
+//作为闭包的可变借用入参，闭包定义没有move,所有权没有转移
+let mut v = Value{x:0};
+let fun = |p:&amp;mut Value| println!(&quot;in closure:{}&quot;, p.x);
+fun(&amp; mut v);
+println!(&quot;call after closure:{}&quot;, v.x);
+ 
+//可变借用作为闭包的输入参数，闭包定义增加move,所有权没有转移
+let mut v = Value{x:0};
+let fun = move |p:&amp; mut Value| println!(&quot;in closure:{}&quot;, p.x);
+fun(&amp; mut v);
+println!(&quot;call after closure:{}&quot;, v.x);</code></pre>
+
+<p>可以看出，变量作为输入参数传递给闭包时，所有权转移规则跟普通函数是一样的，<strong>move 关键字对闭包输入参数的引用形式不起作用，输入参数的所有权没有转移。</strong></p>
+
+<p>对于闭包捕获的上下文变量，所有权是否转移就稍微复杂一些。</p>
+
+<p>下表列出了 10 多个例子，每个例子跟它前后的例子都略有不同，分析这些差别，我们能得到更清晰的结论。</p>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_9.jpg&quot;&gt;</p>
+
+<p>首先要明确被捕获的变量是哪个，这很重要。比如例 8 中，<code>ref_v</code> 是 <code>v</code> 的不可变借用，闭包捕获的是 <code>ref_v</code> ，那么所有权转移的事情跟 <code>v</code> 没有关系，<code>v</code> 不会发生与闭包相关的所有权转移事件。</p>
+
+<p>明确了被捕获的变量后，是否转移所有权受三个因素联合影响：</p>
+
+<ol type="1">
+<li>变量被捕获的方式（值，不可变借用，可变借用）</li>
+
+<li>闭包是否有 move 限定</li>
+
+<li>被捕获变量的类型是否实现了 &quot;Copy&quot; Trait</li>
+</ol>
+
+<p>是用伪代码描述是否转移所有权的规则如下：</p>
+
+<pre><code class="language-`">if 捕获方式 == 值传递 {
+    if 被捕获变量的类型实现了 &quot;Copy&quot;
+        不转移所有权 // 例 ：9
+    else
+        转移所有权 // 例 ：1
+    }
+}
+else { // 捕获方式是借用
+    if 闭包没有 move 限定
+        不转移所有权 // 例：2,3,6,10,12
+    else { // 有 move
+        if 被捕获变量的类型实现了 &quot;Copy&quot;
+            不转移所有权 // 例: 8
+        else
+            转移所有权 // 例: 4,5,7,11,13,14
+    }
+}</code></pre>
+
+<p>先判断捕获方式，如果是值传递，相当于变量跨域了作用域，触发转移所有权的时机。<code>move</code> 是对借用捕获起作用，要求对借用捕获也触发所有权转移。是否实现 &quot;Copy&quot; 是最后一步判断。 前文提到，我们可以把 <code>Copy Trait</code> 限定的位拷贝语义当成一种转移执行的方式。<code>Copy Trait</code> 不参与转移时机的判定，只在最后转移执行的时候起作用。</p>
+
+<ul>
+<li>例 1 和(例 2、例 3) 的区别在于捕获方式不同。</li>
+
+<li>(例 2、例 3) 和例 4 的区别在于 move 关键字。</li>
+
+<li>例 6 和例 7 的区别 演示了 move 关键字对借用方式捕获的影响。</li>
+
+<li>例 8 说明了捕获不可变借用变量，无论如何都不会转移，因为不可变借用实现了 Copy.</li>
+
+<li>例 8 和例 11 的区别就在于例 11 捕获的 &quot;不可变借用&quot;没有实现 &quot;Copy&quot; Trait 。</li>
+
+<li>例 10 和例 11 是以“不可变借用的方式”捕获了一个“可变借用变量”</li>
+
+<li>例 12，13，14 演示了对智能指针的效果，判断逻辑也是一致的。</li>
+</ul>
+
+<p><code>C++11</code> 的闭包需要在闭包声明中显式指定是按值还是按引用捕获，<code>Rust</code> 不一样。<code>Rust</code> 闭包如何捕获上下文变量，不取决与闭包的声明，取决于闭包内部如何使用被捕获的变量。实际上编译器会尽可能以借用的方式去捕获变量（例，除非实在不行，如例 1.)</p>
+
+<p>这里刻意没有提及闭包背后的实现机制，即 <code>Fn</code>,<code>FnMut</code>,<code>FnOnce</code> 三个 <code>Trait</code>。因为我们只用闭包语法时是看不到编译器对闭包的具体实现的。所以我们仅从闭包语法本身去判断所有权转移的规则。</p>
+
+<h2 id='9.多线程环境下的所有权问题'>9.多线程环境下的所有权问题</h2>
+
+<p>我们把前面的例 1 再改一下，上下文与闭包的实现都没有变化，但是闭包在另一个线程中执行。</p>
+
+<pre><code class="language-`Rust">let v = Value{x:1};
+let child = thread::spawn(||{  // 编译器报错，要求添加 move 关键字
+    let p = v;
+    println!(&quot;inclosure:{}&quot;,p.x)
+});
+child.join();</code></pre>
+
+<p>这时，编译器报错，要求给闭包增加 <code>move</code> 关键字。也就是说，闭包作为线程的入口函数时，强制要求对被捕获的上下文变量执行移动语义。下面我们看看多线程环境下的所有权系统。</p>
+
+<p>前面的讨论都不涉及变量在跨线程间的共享，一旦多个线程可以访问同一个变量时，情况又复杂了一些。这里有两个问题，一个仍然是内存安全问题，即“悬垂指针”等 5 个典型的内存安全问题，另一个是线程的执行顺序导致执行结果不可预测的问题。这里我们只关注内存安全问题。</p>
+
+<p>首先，多个线程如何共享变量？前面的例子演示了启动新线程时，通过闭包捕获上下文中的变量来实现多个线程共享变量。这是一个典型的形式，我们以这个形式为基础来阐述多线程环境下的所有权问题。</p>
+
+<p>我们来看例子代码：</p>
+
+<pre><code class="language-`Rust">//结构 Value 没有实现Copy Trait
+struct Value{x:i32}
+ 
+let v = Value{x:1};
+let child = thread::spawn(move||{
+    let p = v;
+    println!(&quot;in closure:{}&quot;,p.x)
+});
+child.join();
+//println!(&quot;{}&quot;,v.x);//编译错误：所有权已经丢失</code></pre>
+
+<p>这是前面例子的正确实现，变量 <code>v</code> 被传递到另一个线程(闭包内)，执行了所有权转移</p>
+
+<pre><code class="language-`Rust">//闭包捕获的是一个引用变量，无论如何也拿不到所有权。那么多线程环境下所有引用都可以这么传递吗？
+let v = Value{x:0};
+let ref_v = &amp;v;
+let fun = move ||{
+    let p = ref_v;
+    println!(&quot;inclosure:{}&quot;,p.x)
+};
+fun();
+println!(&quot;callafterclosure:{}&quot;,v.x);//编译执行成功</code></pre>
+
+<p>这个例子中，闭包捕获的是一个变量的引用，<code>Rust</code> 的引用都是实现了 <code>Copy Trait</code>，会被按位拷贝到闭包内的变量 <code>p.p</code> 只是不可变借用，没有获得所有权，但是变量 <code>v</code> 的不可变借用在闭包内外进行了传递。那么把它改成多线程方式会如何呢？这是多线程下的实现和编译器给出的错误提示：</p>
+
+<pre><code class="language-`Rust">let  v:Value = Value{x:1};
+let ref_v = &amp;v;           // 编译错误：被借用的值 v0 生命周期不够长
+let child = thread::spawn(move||{
+    let p = ref_v;
+    println!(&quot;in closure:{}&quot;,p.x)
+});                                // 编译器提示：参数要求 v0 被借用时为 &#8217;static 生命周期
+child.join();</code></pre>
+
+<p>编译器的核心意思就是 <code>v</code> 的生命周期不够长。当 <code>v</code> 的不可变借用被传递到闭包中，并在另一个线程中使用时，主线程继续执行， <code>v</code> 随时可能超出作用域范围被回收，那么子线程中的引用变量就变成了悬垂指针。 如果 <code>v</code> 为静态生命周期，这段代码就可以正常编译执行。即把第一行改为：</p>
+
+<pre><code class="language-`Rust">const  v:Value = Value{x:1};</code></pre>
+
+<p>当然只能传递静态生命周期的引用实际用途有限，多数情况下我们还是希望能把非静态的数据传递给另一个线程。可以采用 <code>Arc&lt;T&gt;</code>来包装数据。 <code>Arc&lt;T&gt;</code> 是引用计数的智能指针，指针计数的增减操作是线程安全的原子操作，保证计数的变化是线程安全的。</p>
+
+<pre><code class="language-`Rust">//线程安全的引用计数智能指针Arc可以在线程间传递
+let v1 = Arc::new(Value{x:1});
+let arc_v = v1.clone();
+let child = thread::spawn(move||{
+    let p = arc_v;
+    println!(&quot;Arc&lt;Value&gt;in closure:{}&quot;,p.x)
+});
+child.join();
+//println!(&quot;Arc&lt;Value&gt;inclosure:{}&quot;,arc_v.x);//编译错误，指针变量的所有权丢失</code></pre>
+
+<p>如果把上面的 <code>Arc&lt;T&gt;</code> 换成 <code>Rc&lt;T&gt;</code> ,编译器会报告错误，说&quot;<code>Rc&lt;T&gt;</code> 不能在线程间安全的传递&quot;。</p>
+
+<p>通过上面的例子我们可以总结出来一点，因为闭包定义中的 <code>move</code> 关键字，以闭包启动新线程时，被闭包捕获的变量本身的所有权必然会发生转移。无论捕获的变量是 &quot;值变量&quot;还是引用变量或智能指针（上述例子中 <code>v</code>,<code>ref_v</code>,<code>arc_v</code> 本身的所有权被转移）。但是对于引用或指针，它们所指代的数据的所有权并不一定被转移。</p>
+
+<p>那么对于上面的类型 <code>struct Value{x:i32}</code>, <strong>它的值可以在多个线程间传递</strong>(转移所有权)，它的<strong>多个不可变借用可以在多个线程间同时存在</strong>。同时 <code>&amp;Value</code> 和 <code>Arc&lt;Value&gt;</code> 可以在多个线程间传递（转移引用变量或指针变量自身的所有权），但是 <code>Rc&lt;T&gt;</code> 不行。</p>
+
+<p>要知道，<code>Rc&lt;T&gt;</code> 和 <code>Arc&lt;T&gt;</code> 只是 <code>Rust</code> 标准库(<code>std</code>)实现的，甚至不在核心库(<code>core</code>)里。也就是说，它们并不是 <code>Rust</code> 语言机制的一部分。那么，&lt;font color=#fa8919&gt;编译器是如何来判断 Arc&lt;T&gt; 可以安全的跨线程传递，而 Rc&lt;T&gt; 不行呢？&lt;/font&gt;</p>
+
+<p><code>Rust</code> 核心库 的 <code>marker.rs</code> 文件中定义了两个标签 <code>Trait</code>:</p>
+
+<pre><code class="language-`Rust">pub unsafe auto trait Sync{}
+pub unsafe auto trait Send{}</code></pre>
+
+<p>标签 <code>Trait</code> 的实现是空的，但编译器会分析某个类型是否实现了这个标签 <code>Trait</code>.</p>
+
+<ul>
+<li>如果一个类型 <code>T</code>实现了“<strong>Sync</strong>”，其含义是 <code>T</code> 可以安全的通过引用可以在多个线程间被共享。</li>
+
+<li>如果一个类型 <code>T</code>实现了“<strong>Send</strong>”，其含义是 <code>T</code> 可以安全的跨线程边界被传递。</li>
+</ul>
+
+<p>那么上面的例子中的类型，<code>Value</code> ，<code>&amp;Value</code>，<code>Arc&lt;Value&gt;</code> 类型一定都实现了“<code>Send</code>”<code>Trait</code>. 我们看看如何实现的。</p>
+
+<p><code>marker.rs</code> 文件还定义了两条规则：</p>
+
+<pre><code class="language-`Rust">unsafe impl&lt;T:Sync + ?Sized&gt; Send for &amp;T{}
+unsafe impl&lt;T:Send + ?Sized&gt; Send for &amp; mut T{}</code></pre>
+
+<p>其含义分别是：</p>
+
+<ul>
+<li>如果类型 T 实现了“<strong>Sync</strong>”，则自动为类型 <code>&amp;T</code> 实现“<strong>Send</strong>”.</li>
+
+<li>如果类型 T 实现了“<strong>Send</strong>”，则自动为类型 <code>&amp;mut T</code> 实现“<strong>Send</strong>”.</li>
+</ul>
+
+<p>这两条规则都可以直观的理解。比如：对第一条规则 <code>T</code> 实现了 “<strong>Sync</strong>”, 意味则可以在很多个线程中出现同一个 <code>T</code> 实例的 <code>&amp;T</code> 类型实例。如果线程 <code>A</code> 中先有 <code>&amp;T</code> 实例，线程 <code>B</code> 中怎么得到 <code>&amp;T</code> 的实例呢？必须要有在线程 <code>A</code> 中通过某种方式 <code>send</code> 过来，比如闭包的捕获上下文变量。而且 <code>&amp;T</code> 实现了 &quot;<code>Copy</code>&quot; <code>Trait</code>, 不会有所有权风险，数据是只读的不会有数据竞争风险，非常安全。逻辑上也是正确的。&lt;font color=#fa8919&gt;那为什么还会别标记为 unsafe ?&lt;/font&gt; 我们先把这个问题暂时搁置，来看看为智能指针设计的另外几条规则。</p>
+
+<pre><code class="language-`Rust">impl &lt;T:?Sized&gt;!marker::Send for Rc&lt;T&gt;{}
+impl &lt;T:?Sized&gt;!marker::Sync for Rc&lt;T&gt;{}
+impl&lt;T:?Sized&gt;!marker::Send for Weak&lt;T&gt;{}
+impl&lt;T:?Sized&gt;!marker::Sync for Weak&lt;T&gt;{}
+unsafe impl&lt;T:?Sized+Sync+Send&gt;Send  for Arc&lt;T&gt;{}
+unsafe impl&lt;T:?Sized+Sync+Send&gt;Sync for Arc&lt;T&gt;{}</code></pre>
+
+<p>这几条规则明确指定 <code>Rc&lt;T&gt;</code> 和 <code>Weak&lt;T&gt;</code> 不能实现 “<strong>Sync</strong>”和 “<strong>Send</strong>”。</p>
+
+<p>同时规定如果类型 <code>T</code> 实现了 “<strong>Sync</strong>”和 “<strong>Send</strong>”，则自动为 <code>Arc&lt;T&gt;</code> 实现 “<strong>Sync</strong>”和 “<strong>Send</strong>”。<code>Arc&lt;T&gt;</code> 对引用计数增减是原子操作，所以它的克隆体可以在多个线程中使用(即可以为 <code>Arc&lt;T&gt;</code> 实现”<strong>Sync</strong>”和“<strong>Send</strong>”)，但为什么其前提条件是要求 <code>T</code> 也要实现&quot;<strong>Sync</strong>”和 “<strong>Send</strong>”呢。</p>
+
+<p>我们知道，<code>Arc&lt;T&gt;</code>实现了 <code>std::borrow</code>，可以通过 <code>Arc&lt;T&gt;</code>获取 <code>&amp;T</code> 的实例，多个线程中的 <code>Arc&lt;T&gt;</code> 实例当然也可以获取到多个线程中的 <code>&amp;T</code> 实例，这就要求 <code>T</code> 必须实现“<strong>Sync</strong>”。<code>Arc&lt;T&gt;</code> 是引用计数的智能指针，任何一个线程中的 <code>Arc&lt;T&gt;</code>的克隆体都有可能成为最后一个克隆体，要负责内存的释放，必须获得被 <code>Arc&lt;T&gt;</code>指针包装的 <code>T</code> 实例的所有权，这就要求 <code>T</code> 必须能跨线程传递，必须实现 “<strong>Send</strong>”。</p>
+
+<p><code>Rust</code> 编译器并没有为 <code>Rc&lt;T&gt;</code>或 <code>Arc&lt;T&gt;</code> 做特殊处理，甚至在语言级并不知道它们的存在，编译器本身只是根据类型是否实现了 “<strong>Sync</strong>”和 “<strong>Send</strong>”标签来进行推理。实际上可以认为编译器实现了一个检查变量跨线程传递安全性的规则引擎，编译器为基本类型直接实现 “<strong>Sync</strong>”和 “<strong>Send</strong>”，这作为“公理”存在，然后在标准库代码中增加一些“定理”，也就是上面列举的那些规则。用户自己实现的类型可以自己指定是否实现 “<strong>Sync</strong>”和 “<strong>Send</strong>”，多数情况下编译器会根据情况默认选择是否实现。代码编译时编译器就可以根据这些公理和规则进行推理。这就是 <code>Rust</code> 编译器支持跨线程所有权安全的秘密。</p>
+
+<p>对于规则引擎而言，&quot;公理&quot;和&quot;定理&quot;是不言而喻无需证明的，由设计者自己声明，设计者自己保证其安全性，编译器只保证只要定理和公理没错误，它的推理也没错误。所以的&quot;公理&quot;和&quot;定理&quot;都标注为 <code>unsafe</code>,提醒声明着检查其安全性，用户也可以定义自己的&quot;定理&quot;，有自己保证安全。反而否定类规则 （实现 <code>!Send</code> 或 <code>!Sync</code>）不用标注为 <code>unsafe</code> , 因为它们直接拒绝了变量跨线程传递，没有安全问题。</p>
+
+<p>当编译器确定 “<strong>Sync</strong>”和 “<strong>Send</strong>”适合某个类型时，会自动为其实现此。</p>
+
+<p>比如编译器默认为以下类型实现了 <code>Sync</code> ：</p>
+
+<ul>
+<li>
+<p>\[u8] 和 \[f64] 这样的基本类型都是 \[Sync]，</p>
+</li>
+
+<li>
+<p>包含它们的简单聚合类型（如元组、结构和名号）也是\[Sync] 。</p>
+</li>
+
+<li>
+<p>&quot;不可变&quot; 类型（如 &amp;T）</p>
+</li>
+
+<li>
+<p>具有简单继承可变性的类型，如 Box &lt;T&gt;、Vec&lt;T&gt;</p>
+</li>
+
+<li>
+<p>大多数其他集合类型（如果泛型参数是 \[Sync]，其容器就是 \[Sync]。</p>
+</li>
+</ul>
+
+<p>用户也可以手动使用 <code>unsafe</code> 的方式直接指定。</p>
+
+<p>下图是与跨线程所有权相关的概念和类型的 <code>UML</code> 图。</p>
+
+<p>&lt;img src=&quot;./rust<em>ownership/rust</em>ownership_8.jpg&quot;&gt; &lt;center&gt;图 8与多线程相关的所有权转移&lt;/center&gt;</p>
+
+<h2 id=''></h2>
+
+<p>编辑简介：</p>
+
+<p>高宪凤(.nil?)，软件开发工程师，Rust 语言爱好者，喜欢有计划、有条理、有效率的工作，热爱开源文化，愿意为 Rust 中文社区的发展尽绵薄之力。</p>
+]]></content:encoded></item><item><title>嵌入式领域的Rust语言</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/embedded_rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='嵌入式领域的rust语言'>嵌入式领域的Rust语言</h1>
+
+<p>作者：洛佳</p>
+
+<h2 id=''></h2>
+
+<p>Rust语言是二十一世纪的语言新星。Rust被人广泛承认的一点，就是因为它能运行在多样的目标上， 从桌面和服务器设备，到资源有限的嵌入式设备。</p>
+
+<p>我们可以用适合来评价一门语言和技术。Rust非常适合开发嵌入式应用，它是一种和C相仿的、 能应用于嵌入式设备开发的编程语言。</p>
+
+<p>操作系统都是从裸机设备开始运行的，Rust语言的这一点也意味着，它能很好地用于编写操作系统。 无论是应用层还是内核本身，Rust都是极富竞争力、值得投入时间的技术选项。</p>
+
+<h2 id='裸机上的rust语言'>裸机上的Rust语言</h2>
+
+<p>开发裸机应用时，通常希望使用的语言速度快、可靠性强。此外们还希望语言的生态较好， 有利于提高生产效率，而且适用范围较广。Rust语言能满足以上的要求，适合裸机应用的开发。</p>
+
+<p>运用在裸机场合时，Rust语言拥有许多优点。除了效率和安全，Rust还将传统上不用于裸机开发的编程技术引入到裸机， 让开发者有更多的选择，更灵活、高效地编写裸机应用代码。</p>
+
+<h3 id='二十一世纪的裸机编程语言'>二十一世纪的裸机编程语言</h3>
+
+<p>在这个互联网全面普及、性价比设备应用更广的时代，安全和可靠性成为一门语言必须考虑的因素。 Rust语言采用移动语义，拥有严格的代数类型系统以及生命周期、所有权模型； 相比传统的编程语言，这些模型能在合适的时候释放所用资源，减少漏洞的出现。 此外，通过语义检查，Rust能在编译期有效寻找内存和线程安全问题，降低开发和测试的负担。</p>
+
+<p>Rust语言是的运行效率高、开发效率好、适用范围广。作为一门编译型语言，它直接编译输出到汇编代码， 通常公认裸机的Rust语言性能在C语言级别，拥有较高的运行效率。 Rust语言的开发效率很高，文档完善、编译器提示有帮助，能节省软件开发所需的时间。 它能应用在多个平台和指令集中，这包括裸机平台；处理核、操作系统厂家还可以提供自己的编译目标， 无需厂家自己重新开发、提供工具链。</p>
+
+<p>Rust语言出彩的地方在于，它向嵌入式平台引入了大量新的编程技术。 这包括了闭包、过程宏等传统上用于函数式编程的技术，和多态、虚函数表等面向对象语言的技术。 新编程技术的引入，扩充了开发者的选择。即使彻底理解Rust的编程概念有一定难度，但这些易用的新技术， 让开发者只需阅读实例代码，便可快速进入开发状态。这些新技术的引入，是嵌入式平台从未有过的， Rust能提高开发者的工作效率，降低平台间迁移的学习时间和成本。</p>
+
+<h3 id='裸机上的过程宏'>裸机上的过程宏</h3>
+
+<p>传统用于嵌入式平台的编程，我们加快开发速度使用的宏，常常基于语法字符串的替换和修改。 Rust语言扩充了宏的概念，提出了基于语法树的“过程宏”编程方法，让宏语法更容易使用、编写更方便。</p>
+
+<p>“过程宏”是接收Rust代码作为输入，操作这些代码，然后产生另一些代码的过程。 它和字符串的替换不同，是从语法树到语法树的替换。开发一个过程宏，可以使用简单的定义过程， 或者有工作量的属性宏定义过程。简单的定义中，我们编写代码，给出宏的输入有哪些，要翻译到哪些输出代码， 这样就完成了一个宏的定义。属性宏定义则允许完成语法树分析、代码生成甚至代码优化的过程， 就需要编写专门的“属性宏库”，借用Rust编译器的一部分，完成宏代码的转化和输出。</p>
+
+<p>过程宏是基于语法树的分析过程，借助“树”的结构我们能理解它的一些特点。因为Rust语法树的子树也是Rust代码， 所以宏的定义内也可以完成语法分析，这就为代码编辑器的提示和补全提供了便利。 一个语法项目不可能同时属于两颗不是亲子关系的子树，因为如果属于两颗子树，将和语法树的树根产生环， 就和语法树的定义相违背，所以语法项目都是独立的，宏内代码的解析不会影响外界代码的解析。</p>
+
+<p>这样的独立性也就是“卫生宏”思想的提出，Rust的过程宏可以理解为代码的“内部展开”，不影响代码的上下文。 正因为Rust过程宏产生完整的语法子树，它的定义不需要额外的界符，因此只需要满足Rust语法就可以了。</p>
+
+<p>在过程宏的定义之外，Rust语言提供了大量便于嵌入式开发的标签。“align”标签定义内存对齐的方式， “link_section”标签给定代码要链接到的段或区。这样，过程宏可以包装各种各样的标签， Rust语言的用户可以方便地使用，而不需要深入宏了解代码的具体要求。 Rust语言定义的过程宏可以导出到包外，给其它的库使用，这有利于嵌入式Rust生态的搭建和共享。 Rust语言宏灵活的特性，让宏在更多的领域有可用之处，更好地服务嵌入式平台的开发工作。</p>
+
+<h3 id='嵌入式中的模块化编程'>嵌入式中的模块化编程</h3>
+
+<p>Rust语言拥有很好的模块化编程概念。传统平台的Rust语言中，社区总结出了“模块-包-项目”的模型。 这个模型也适用于嵌入式平台，增加协作开发的效率，更好地共享生态。</p>
+
+<p>Rust的模块化编程分为模块、包、项目三级。模块是Rust语言可见性分划的最小单位， 语言中提供了专门的关键字，来区分不同模块的代码和可见性，是由Rust语言本身确定的。 在Rust语法中，“mod”是定义模块的关键字，“pub”是定义可见性的关键字。</p>
+
+<p>包是Rust项目的二进制目标，这个等级是由Rust工具链给定的。每个包有版本号、作者和许可协议等元数据， 要依赖和使用的库也要登记到包中，以便共同编译。库的特性有点像传统语言的条件编译， 也是以包为单位规定的，每个包使用的库可以开启不同的特性，但库在同一个包中开启的特性是相同的。</p>
+
+<p>“项目”这一层并非由Rust语言给定；人们开发软件时，发现一个解决方案中包含多个二进制目标是非常好的， 总结之后就出现了项目的抽象模型。项目由核心和外围包组成，或者是功能相近的一组包， 它通常由同一个团队组织和维护，可以在项目上添加扩展。项目在习惯上由核心包到功能包，以依赖的形式构成。 实践中，“项目”可以放在同一个工作空间里，以统一管理和发布编译版本。</p>
+
+<p>Rust将模块化编程引入到嵌入式开发中，也可以方便地编写测试和性能检测代码。 模块化编程能提高Rust嵌入式开发者的工作效率，适应现代化嵌入式软件的需求。</p>
+
+<h2 id='搭建rust嵌入式生态'>搭建Rust嵌入式生态</h2>
+
+<p>生态是软件不可或缺的一部分。从编译器到软件支持，嵌入式Rust目前已经拥有良好的基础生态。 此外，操作系统内核也是嵌入式编程的重要部分，嵌入式Rust和内核开发也有较好的相容度。</p>
+
+<p><img src='embedded_rust/ecosystem.png' alt='截至2020年12月的嵌入式生态架构图' /></p>
+
+<h3 id='你的架构和指令集'>你的架构和指令集</h3>
+
+<p>嵌入式Rust的应用支持分为两个部分：一个是目标处理核的支持，一个是芯片外设的支持。</p>
+
+<p>针对目标处理核，首先我们要编译Rust到这个指令集架构。Rust语言提供丰富的编译目标， 主流的编译目标都有很好的支持；此外，如果有自主研发的指令集架构，可以为Rust添加自己的编译目标。 编译完成后，还需要编写微架构支持库和微架构运行时。微架构运行时提供最小的启动代码实现， 能搭建一个适合Rust代码运行的环境。微架构支持库简单包装汇编代码，允许应用代码操作寄存器、运行特殊的指令， 作为编译器系统的补充。这之后，Rust对这个指令集架构的代码运行支持就完成了。</p>
+
+<p>嵌入式应用定义了各有特点的中断控制器，有些是指令集架构定义的，有些是芯片设计厂家自己定义的。 嵌入式Rust要支持这些中断控制器，需要在微架构运行时中添加处理和封装部分，或者作为通用架构的补充， 在专用架构的支持库中添加专有架构的中断运行时。架构虽然定义了标准，但基地址、中断数量等配置可能相互不同。 这些元数据配置可以放在外设访问库的中断部分，和架构支持库共同构成中断控制器的支持。</p>
+
+<p>目标的处理核定义了调试接口和闪存烧写算法，我们需要在调试器软件中编写这些算法。 社区通用的软件“probe-rs”是很好的调试器实现，可以替代OpenOCD，作为非常好的Rust语言调试软件。 如果自己的操作系统有软件调试接口，可以添加操作系统调试器的载荷，共同完成调试软件的部分。 只要处理器厂商实现了调试接口，提供相关的文档，配套的Rust软件可以尽快完成，方便各种技术的开发者调试和使用。</p>
+
+<h3 id='嵌入式生态的标准'>嵌入式生态的标准</h3>
+
+<p>起初嵌入式开发者会为每个芯片都编写一次代码。随着生态的发展，大家认识到，需要提供一个基本的抽象， 大家都围绕着抽象去编写，就能剩下大量外设反复操作的时间。embedded-hal就是这样的标准， 它是Rust语言的嵌入式外设抽象，支持大量的片内和片外外设，包括传感器等，很好地扩充了嵌入式的生态。</p>
+
+<p>embedded-hal是统一的Rust语言标准，它是针对外设功能本身的抽象，是抽象的集合，具体实现由实现库去完成。 它的扩展性很好，比如“SPI-GPIO扩展器”外设输入SPI接口抽象，输出GPIO的抽象，很多模块都是抽象到抽象的过程， 就可以方便的极联、衔接和嵌套，整合更多的项目；这就非常容易为新的芯片编写支持库。</p>
+
+<p>市场上海量的芯片都支持embedded-hal标准。K210、GD32V和BL602系列的芯片都提供很好的embedded-hal实现库。 要编写embedded-hal标准的支持库，只需要机器生成外设库，然后编写中间层库，就能完成对此标准的原厂支持。</p>
+
+<h3 id='rust与操作系统内核'>Rust与操作系统内核</h3>
+
+<p>操作系统也是嵌入式应用。常见的操作系统如按是否包含虚拟内存区分，有不含虚拟内存的实时系统， 和包含虚拟内存传统操作系统。基于微架构的支持库和运行时库，操作系统内核可以很方便地编写。</p>
+
+<p>社区中提供了大量成熟的操作系统运行时。 如rCore系列操作系统是第一个基于RISC-V架构的完整Rust操作系统，尤其适合教学使用。 RTIC框架是中断驱动的异步实时系统，完全针对应用使用Rust的宏语法生成，拥有极高的效率。 Tock系统是针对微处理器的安全实时系统，已经用于手表、智能路标和加密狗等产品。</p>
+
+<p>针对操作系统和应用程序开发，Rust是适合编写硬件驱动的语言。 如果使用有产权的代码，可以以混合链接的形式，与Rust代码联合编译为二进制使用。 系统模块、插件和动态链接库等等都能受益于Rust语言内存安全的特性，适合现在对安全敏感的开发需求。</p>
+
+<p>物联网系统要求嵌入式的操作系统能够连上网络。Rust嵌入式社区也在探索射频连接的技术标准， 包括蓝牙、WiFi等硬件标准。smoltcp是社区提供的非常好的TCP协议栈实现，它可以代替lwip， 在嵌入式系统领域高效、安全地完成网络传输。搭配缓冲区和协议库，物联网操作系统就可以连上网了。</p>
+
+<h2 id='rustsbi：新型操作系统引导软件'>RustSBI：新型操作系统引导软件</h2>
+
+<p>我们在开发操作系统内核时，有的内核直接运行在裸机上，有的还依托于一个运行环境。 在RISC-V上，“SBI”就是这样的运行环境。它除了引导启动内核，还将常驻后台，提供操作系统需要的实用功能。</p>
+
+<p>RISC-V标准中，“SBI”意味着“操作系统二进制接口”，运行在其上的操作系统会通过环境调用“ecall”指令， 陷入到二进制接口的实现中，由其调用具体硬件的实现功能。这种实现被称作“SBI实现”，社区常用的实现有开源的OpenSBI。 RustSBI是鹏城实验室“rCore代码之夏-2020”活动提出的SBI实现，它是全新的操作系统引导软件。</p>
+
+<h3 id='实现与模块组成'>实现与模块组成</h3>
+
+<p>RustSBI由几个功能模块组成。硬件环境接口实现了RISC-V SBI v0.2版本的接口，能运行支持此版本的操作系统。 硬件运行时则是SBI实现运行在裸机环境的必要模块，它将由硬件启动，开始运行所有的RustSBI模块。 SBI的初始化完成后，将进入引导启动模块，这里将发挥SBI标准“引导启动”的功能，最终启动操作系统内核。 另外，兼容性模块能完成硬件到硬件间的支持，能模拟旧版硬件不存在的指令、寄存器，进一步延长操作系统的生命周期。</p>
+
+<p>去年12月，RustSBI的0.1版本在深圳的Rust中国社区2020年年会上发布。使用目前最新的0.1.1版本， RustSBI已经支持大量SBI标准提出的功能，支持大量自定义的扩展功能；完全使用安全的Rust语言编写，提高开发效率。 开发Rust语言的操作系统内核，可以统一编译工具链。另外，RustSBI已经被RISC-V组织收录入RISC-V SBI标准， 它的实现编号为4。</p>
+
+<p>RustSBI是一个库，它以库的形式设计的初衷是，便于平台开发者“积木”式地引入库的模块，为自己的硬件目标开发SBI支持。 虽然RustSBI提供了QEMU、K210平台的参考实现，但应用开发者不应当将自己的目标也加入参考实现中， 而是在自己的仓库里引用RustSBI的模块，可以选择参考这些实现的内容，最终完成完全可控的开发过程。 这两个平台的使用范围较广，参考实现也会长期维护，以发现RustSBI本身可能的少量问题，并及时修补完善。</p>
+
+<p>为什么用Rust开发RustSBI呢？我们认为，相比使用C语言，嵌入式Rust的生态圈在协调发展阶段，它容易支持新硬件， Rust语言较强的编译约束也提高了硬件代码的安全性。</p>
+
+<h3 id='硬件到硬件的兼容性'>硬件到硬件的兼容性</h3>
+
+<p>RISC-V是快速更迭的指令集规范。我们为新版RISC-V硬件编写软件，会遇到与旧版硬件不兼容的情况。 硬件和硬件之间的兼容性，也能通过软件完成——这是RustSBI提供的功能与亮点之一。</p>
+
+<p>RustSBI实现的硬件兼容性，是靠捕获指令异常完成的。例如，K210平台实现的是1.9.1版本的RISC-V特权级标准， 它规定了旧版的页表刷新指令；而目前最新的1.11版标准，规定的是新版的刷新指令。为新标准编写的操作系统内核， 使用新版刷新指令，会因为K210硬件无法找到新版指令，抛出非法指令异常。这个非法指令异常被RustSBI捕获， 它解析后，发现是新版的页表刷新指令，便直接在硬件上运行旧版的指令，完成指令的页表刷新功能。</p>
+
+<p>这种硬件兼容性，目前能支持新增的指令和寄存器。一切情况下，指令、寄存器在仍然存在，但新版中修改了它们的功能和意义。 只靠RustSBI软件本身，就不足以提供兼容性支持了。如果RISC-V芯片实现提供特定的兼容性外设， 比如这个外设能拦截特定CSR寄存器的访问指令，就可以在功能修改的寄存器访问时，产生一个可供软件捕获的中断。 这样的外设设计之后，使用RustSBI软件，将能支持功能修改的指令和寄存器，将进一步提升操作系统内核的硬件兼容性。</p>
+
+<p>兼容旧硬件，也是兼容未来新硬件的过程。未来的RISC-V标准快速发展，将与目前的硬件标准产生一定的差异； 在硬件不变的前提下，未来软件能对当前的硬件兼容，就能延长软件的生命周期。 或许，我们未来升级RISC-V上的操作系统，只需要更换硬件中的RustSBI固件，就能完美兼容最新标准的操作系统了。 升级原有系统的硬件也非常容易，替换RustSBI固件就能达到升级效果。</p>
+
+<p>另外，硬件兼容性也意味着实现硬件上缺少的指令集。当这些指令集运行时，就会陷入到软件中，由RustSBI软件模拟这些指令， 最终返回，这个过程应用软件不会有感知。当然，这种软件模拟过程可以满足正确性，效率不如新版的硬件， 但临时运行一个新版的软件、体验新版的指令集还是足够的。当模拟指令的过程多到影响性能时，也就是硬件该升级的时候了。</p>
+
+<h3 id='rustsbi与嵌入式rust生态'>RustSBI与嵌入式Rust生态</h3>
+
+<p>在RustSBI的实现中，多次使用“embedded-hal”的实现完成编写过程。“embedded-hal”是Rust嵌入式的外设规范， 它对大量厂家的外设提供了软件支持。只要厂家的硬件支持“embedded-hal”，只需要编写部分抽象接口代码， RustSBI支持就可以快速地开发完成。</p>
+
+<p>硬件处理核和SoC系统的开发也受益于设计好的RustSBI软件架构。“RustSBI很快速地实现了仿真环境的双核测试，” 华中科技大学的社区贡献者车春池说，“这能为处理核提供丰富的测试环境，在开发高性能RISC-V处理核中非常重要。”</p>
+
+<p>无论硬件和软件，我们都乐于看到各个应用领域积极互动，嵌入式Rust生态的发展过程得到加快。 “embedded-hal”本是裸机外设的标准，RustSBI将这个标准运用在引导软件上，能加速裸机外设的开发和建设， 也能更快适配SBI标准到平台上。</p>
+
+<p>借这个项目，我们很高兴能参与嵌入式领域Rust语言的建设，希望这些微小的技术更新和迭代，最终能回馈到我们美好的生活中去。</p>
+
+<h2 id=''></h2>
+
+<p>作者简介：</p>
+
+<p><strong>洛佳</strong></p>
+
+<p>华中科技大学网络空间安全学院本科生，热爱操作系统、嵌入式开发。RustSBI项目作者，3年Rust语言开发经验，社区活跃贡献者。目前致力于向产业、教学等更多的领域推广Rust语言。</p>
+]]></content:encoded></item><item><title>用Rust写操作系统 | rCore OS 教程介绍 </title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rcore_intro.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='用_rust_写操作系统_|_清华_rcore_os_教程介绍'>用<code>Rust</code>写操作系统 | 清华 rCore OS 教程介绍</h1>
+
+<p>编辑：张汉东</p>
+
+<h2 id='rcore_os_教程简介'>rCore OS 教程简介</h2>
+
+<p>众所周知，清华大学的操作系统课程是国家级精品课程。清华大学也是是国内首个使用 Rust 进行操作系统教学的高校。目前，陈渝教授和他的学生吴一凡正在编写新的操作系统教材。该教材相关的文档都是网络公开的，教程地址：<a href='https://rcore-os.github.io/rCore-Tutorial-Book-v3/'>https://rcore-os.github.io/rCore-Tutorial-Book-v3/</a>。</p>
+
+<p>这本教程旨在一步一步展示如何 <strong>从零开始</strong> <strong>用 Rust 语言写一个基于 RISC-V 架构的类 Unix 内核</strong>。值得注意的是， 本项目不仅支持模拟器环境（如 Qemu/terminus 等），还支持在真实硬件平台 Kendryte K210 上运行。</p>
+
+<p>该教程目前已经发布了近 20 万字，每一章都是一个能完整运行的内核。目前已经完成了前四章分别可以让内核能在裸机打印字符、支持系统调用和特权级切换、任务切换和虚拟存储。后面还会依次支持进程、进程间通信和数据持久化，代码已经写完，有待更新教程文档。陈渝教授和吴一凡也希望能够通过该教程吸引更多对 Rust 和 OS 感兴趣的读者，可以在教程的基础上自己从头实现一遍或者能做一些拓展，也能提供一些反馈，让教程的质量越来越高。</p>
+
+<p>以教程目前的内容进度，正是大家从零开始学习编写操作系统的最佳时期。</p>
+
+<h2 id='为什么要学习操作系统？'>为什么要学习操作系统？</h2>
+
+<p>一名程序员的绝大部分工作都是在操作系统上面进行的。学习操作系统，深入了解操作系统原理，是每个合格的程序员必须要经历的。</p>
+
+<p>很多人学习 Rust 语言感到很吃力，基本上就是因为操作系统基础知识薄弱造成的。</p>
+
+<p>通过自己实现一个操作系统，可以让你对操作系统的理解不仅仅是停留在概念上。而且用 Rust 实现操作系统，对于 Rust 爱好者来说，更有意思。</p>
+
+<p>希望社区的朋友可以根据该教程实现自己的操作系统，如果需要交流，可以联系我（张汉东），我们可以一起建立学习小组，并且可以直接向陈渝教授和吴一凡反馈学习中的问题。</p>
+
+<p><strong>以下内容节选自rCore OS 教程第零章</strong>。</p>
+
+<h2 id='目前常见的操作系统内核都是基于c语言的，为何要推荐rust语言？'>目前常见的操作系统内核都是基于C语言的，为何要推荐Rust语言？</h2>
+
+<p>没错，C语言就是为写UNIX而诞生的。Dennis Ritchie和KenThompson没有期望设计一种新语言能帮助高效简洁地开发复杂的应用业务逻辑，只是希望用一种简洁的方式抽象出计算机的行为，便于编写控制计算机硬件的操作系统，最终的结果就是C语言。</p>
+
+<p>C语言的指针的天使与魔鬼，且C语言缺少有效的并发支持，导致内存和并发漏洞成为当前操作系统的噩梦。</p>
+
+<p>Rust语言具有与C一样的硬件控制能力，且大大强化了安全编程。从某种角度上看，新出现的Rust语言的核心目标是解决C的短板，取代C。所以用Rust写OS具有很好的开发和运行的体验。</p>
+
+<p>用 Rust 写 OS 的代价仅仅是学会用 Rust 编程。</p>
+
+<h2 id='目前常见的cpu是x86和arm，为何要推荐risc-v？'>目前常见的CPU是x86和ARM，为何要推荐RISC-V？</h2>
+
+<p>没错，最常见的的CPU是x86和ARM，他们已广泛应用在服务器，台式机，移动终端和很多嵌入式系统中。它们需要支持非常多的软件系统和应用需求，导致它们越来越复杂。</p>
+
+<p>x86的向过去兼容的策略确保了它的江湖地位，但导致其丢不掉很多已经比较过时的硬件设计，让操作系统疲于适配这些硬件特征。</p>
+
+<p>x86和ARM都很成功，这主要是在商业上，其广泛使用是的其CPU硬件逻辑越来越复杂，且不够开放，不能改变，不是开源的，提高了操作系统开发者的学习难度。</p>
+
+<p>从某种角度上看，新出现的RISC-V的核心目标是灵活适应未来的AIoT场景，保证基本功能，提供可配置的扩展功能。其开源特征使得学生都可以方便地设计一个RISC-V CPU。</p>
+
+<p>写面向RISC-V的OS的代价仅仅是你了解RISC-V的Supevisor特权模式，知道OS在Supevisor特权模式下的控制能力。</p>
+
+<h2 id='清华大学为何要写这本操作系统书?'>清华大学为何要写这本操作系统书?</h2>
+
+<p>现在国内外已有一系列优秀的操作系统教材,例如 William Stallings 的《Operating Systems Internals and Design Principles》，Avi Silberschatz、Peter Baer Galvin 和 Greg Gagne 的《Operating System Concepts》，Remzi H. Arpaci-Dusseau 和 Andrea C. Arpaci-Dusseau 的《Operating Systems: Three Easy Pieces》等。然而,从我们从2000年以来的教学实践来看,某些经典教材对操作系统的概念和原理很重视，但还有如下一些问题有待改进：</p>
+
+<p>原理与实践脱节：缺乏在操作系统的概念/原理与操作系统的设计/实现之间建立联系的桥梁，导致学生发现操作系统实现相关的实验与操作系统的概念相比，有较大的鸿沟。</p>
+
+<p>缺少历史发展的脉络：操作系统的概念和原理是从实际操作系统设计与实现过程中，从无到有逐步演进而产生的，有其发展的历史渊源和规律。但目前的大部分教材只提及当前主流操作系统的概念和原理，有“凭空出现”的感觉，学生并不知道这些内容出现的前因后果。</p>
+
+<p>忽视硬件细节或用复杂硬件：很多教材忽视或抽象硬件细节，是的操作系统概念难以落地。部分教材把 x86 作为的操作系统实验的硬件参考平台，缺乏对当前快速发展的RISC-V等体系结构的实验支持，使得学生在操作系统实验中可能需要花较大代价了解相对繁杂的x86硬件细节，影响操作系统实验的效果。</p>
+
+<p>这些问题增加了学生学习和掌握操作系统的难度。我们想通过尝试解决上面三个问题，来缓解学生学习操作系统的压力，提升他们的兴趣，让他们能够在一个学期内比较好地掌握操作系统。为应对“原理与实践脱节”的问题，我们强调了实践先行，实践引领原理的理念。MIT教授 Frans Kaashoek等师生设计实现了基于UNIX v6的xv6教学操作系统用于每年的本科操作系统课的实验中，并在课程讲解中把原理和实验结合起来，在国际上得到了广泛的认可。这些都给了我们很好的启发，经过十多年的实践，对一个计算机专业的本科生而言，设计实现一个操作系统（包括CPU）有挑战但可行，前提是实际操作系统要小巧并能体现操作系统的核心思想。这样就能够让学生加深对操作系统原理和概念的理解，能让操作系统原理和概念落地。</p>
+
+<p>为应对“缺少历史发展的脉络”的问题，我们重新设计操作系统实验和教学内容，按照操作系统的历史发展过程来建立多个相对独立的小实验，每个实验体现了操作系统的一个微缩的历史，并从中归纳总结出操作系统相关的概念与原理，并在教学中引导学生理解这些概念和原理是如何一步一步演进的。</p>
+
+<p>为应对“忽视硬件细节或用复杂硬件”的问题，我们在硬件（x86, ARM, MIPS, RISC-V等）和编程语言（C, C++, Go, Rust等）选择方面进行了多年尝试。在2017年引入了RISC-V CPU作为操作系统实验的硬件环境，在2018年引入Rust编程语言作为开发操作系统的编程语言，使得学生以相对较小的开发和调试代价能够用Rust语言编写运行在RISC-V上的操作系统。而且方便和简化了让操作系统的概念和原理形象化，可视化的过程。学生可以吧操作系统的概念和原理直接对应到程序代码、硬件规范和操作系统的实际执行中，加强了学生对操作系统内涵的实际体验和感受。</p>
+
+<p>所以本书的目标是以简洁的RISC-V CPU为底层硬件基础，根据上层应用从小到大的需求，按OS发展的历史脉络，逐步讲解如何设计并实现满足这些需求的“从小到大”的多个“小”操作系统。并在设计实现操作系统的过程中，逐步解析操作系统各种概念与原理的知识点，对应的做到有“理”可循和有“码”可查，最终让读者通过主动的操作系统设计与实现来深入地掌握操作系统的概念与原理。</p>
+
+<p>在具体撰写过程中，第零章是对操作系统的一个概述，让读者对操作系统的历史、定义、特征等概念上有一个大致的了解。后面的每个章节体现了操作系统的一个微缩的历史发展过程，即从对应用由简到繁的支持的角度出发，每章会讲解如何设计一个可运行应用的操作系统，满足应用的阶段性需求。从而读者可以通过对应配套的操作系统设计实验，了解如何从一个微不足道的“小”操作系统，根据应用需求，添加或增强操作系统功能，逐步形成一个类似UNIX的相对完善的“小”操作系统。每一步都小到足以让人感觉到易于掌控，而在每一步结束时，你都有一个可以工作的“小”操作系统。另外，通过足够详尽的测试程序 ，可以随时验证读者实现的操作系统在每次更新后是否正常工作。由于实验的代码规模和实现复杂度在一个逐步递增的可控范围内，读者可以结合对应于操作系统设计实验的进一步的原理讲解，来建立操作系统概念原理和实际实现的对应关系，从而能够通过操作系统实验的实践过程来加强对理论概念的理解，通过理论概念来进一步指导操作系统实验的实现与改进。</p>
+
+<p>在你开始阅读与实践本书讲解的内容之前，你需要决定用什么编程语言来完成操作系统实验。你可以用任何你喜欢的编程语言和你喜欢的CPU上来实现操作系统。我们推荐的编程语言是Rust，我们推荐的CPU是RISC-V。</p>
+]]></content:encoded></item><item><title>Rust Security 专题 | Rust生态安全漏洞总结系列 | Part 1</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rust_security_part1.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rust_生态安全漏洞总结系列_|_part_1'><code>Rust</code>生态安全漏洞总结系列 | Part 1</h1>
+
+<p>作者：张汉东 后期编辑：张汉东</p>
+
+<p>本系列主要是分析<a href='https://rustsec.org/advisories/'>`RustSecurity` 安全数据库库</a>中记录的<code>Rust</code>生态社区中发现的安全问题，从中总结一些教训，学习<code>Rust</code>安全编程的经验。</p>
+
+<h2 id=''></h2>
+
+<p>作为本系列文章的首篇文章，我节选了<a href='https://rustsec.org/advisories/'>`RustSecurity` 安全数据库库</a>中 2021 年 1 月份记录的前五个安全漏洞来进行分析。</p>
+
+<p><img src='./rust_security/0.png' alt='img' /></p>
+
+<h2 id='01_|_mdbook_xss_漏洞_(rustsec-2021-0001)'>01 | Mdbook XSS 漏洞 (RUSTSEC-2021-0001)</h2>
+
+<p><img src='./rust_security/1.png' alt='img' /></p>
+
+<p>正好《Rust 中文精选（RustMagazine）》也用了 mdbook，不过读者朋友不用害怕，本刊用的 mdbook 是修补了该漏洞的版本。</p>
+
+<p>该漏洞并非 Rust 导致，而是生成的网页中 JS 函数使用错误的问题。</p>
+
+<p>漏洞描述：</p>
+
+<p>问题版本的 mdBook 中搜索功能（在版本<code>0.1.4</code>中引入）受到跨站点脚本漏洞的影响，该漏洞使攻击者可以通过诱使用户键入恶意搜索查询或诱使用户进入用户浏览器来执行任意<code>JavaScript</code>代码。</p>
+
+<p>漏洞成因分析：</p>
+
+<p>XSS的漏洞主要成因是后端接收参数时未经过滤，导致参数改变了HTML的结构。而<code>mdbook</code>中提供的<code>js</code>函数<code>encodeURIComponent</code>会转义除<code>&#8217;</code>之外的所有可能允许<code>XSS</code>的字符。 因此，还需要手动将<code>&#8217;</code>替换为其<code>url</code>编码表示形式（％27）才能解决该问题。</p>
+
+<p><a href='https://github.com/rust-lang/mdBook/commit/648c9ae772bec83f0a5954d17b4287d5bb1d6606'>修复 PR</a> 也很简单。</p>
+
+<h2 id='02_|_暴露裸指针导致段错误_(rustsec-2021-0006)'>02 | 暴露裸指针导致段错误 (RUSTSEC-2021-0006)</h2>
+
+<p><img src='./rust_security/2.png' alt='img' /></p>
+
+<p>该漏洞诞生于第三方库<a href='https://crates.io/crates/cache'>cache</a>，该库虽然已经两年没有更新了，但是它里面出现的安全漏洞的警示作用还是有的。该库<a href='https://github.com/krl/cache/issues/2'>问题`issue`</a>中说明了具体的安全漏洞。</p>
+
+<p>该安全漏洞的特点是，因为库接口中将裸指针（raw pointer) 公开了出来，所以该裸指针可能被用户修改为空指针，从而有段错误风险。因为这个隐患是导致 Safe Rust 出现 UB，所以是不合理的。</p>
+
+<p>以下代码的注释分析了漏洞的产生。</p>
+
+<pre><code class="language-`rust">use cache;
+
+
+/**
+
+    `cache crate` 内部代码：</code></pre>
+
+<pre><code>pub enum Cached&lt;&#8217;a, V: &#8217;a&gt; {
+    /// Value could not be put on the cache, and is returned in a box
+    /// as to be able to implement `StableDeref`
+    Spilled(Box&lt;V&gt;),
+    /// Value resides in cache and is read-locked.
+    Cached {
+        /// The readguard from a lock on the heap
+        guard: RwLockReadGuard&lt;&#8217;a, ()&gt;,
+        /// A pointer to a value on the heap
+        // 漏洞风险
+        ptr: *const ManuallyDrop&lt;V&gt;,
+    },
+    /// A value that was borrowed from outside the cache.
+    Borrowed(&amp;&#8217;a V),
+}</code></pre>
+
+<pre><code>```</code></pre>
+
+<p>**/ fn main() {</p>
+
+<pre><code>let c = cache::Cache::new(8, 4096);
+c.insert(1, String::from(&quot;test&quot;));
+let mut e = c.get::&lt;String&gt;(&amp;1).unwrap();</code></pre>
+
+<pre><code>match &amp;mut e {
+    cache::Cached::Cached { ptr, .. } =&gt; {
+        // 将 ptr 设置为 空指针，导致段错误
+        *ptr = std::ptr::null();
+    },
+    _ =&gt; panic!(),
+}
+// 输出：3851，段错误
+println!(&quot;Entry: {}&quot;, *e);</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">启示：
+
+所以，这里我们得到一个教训，就是不能随便在公开的 API 中暴露裸指针。值得注意的是，该库处于失去维护状态，所以这个漏洞还没有被修正。
+
+## 03 | 读取未初始化内存导致`UB` (RUSTSEC-2021-0008)
+
+![img](./rust_security/3.png)
+
+该漏洞诞生于 [bra](https://crates.io/crates/bra) 库。该库这个安全漏洞属于逻辑 Bug 。因为错误使用 标准库 API，从而可能让用户读取未初始化内存导致 UB。
+
+披露该漏洞的[issue](https://github.com/Enet4/bra-rs/issues/1)。目前该漏洞已经被修复。
+
+以下代码注释保护了对漏洞成因对分析：</code></pre>
+
+<p>// 以下是有安全风险的代码示例： impl&lt;R&gt; BufRead for GreedyAccessReader&lt;R&gt;</p>
+
+<pre><code>where
+    R: Read,</code></pre>
+
+<p>{</p>
+
+<pre><code>fn fill_buf(&amp;mut self) -&gt; IoResult&lt;&amp;[u8]&gt; {
+    if self.buf.capacity() == self.consumed {
+        self.reserve_up_to(self.buf.capacity() + 16);
+    }</code></pre>
+
+<pre><code>    let b = self.buf.len();
+    let buf = unsafe {
+        // safe because it&#8217;s within the buffer&#8217;s limits
+        // and we won&#8217;t be reading uninitialized memory
+        // 这里虽然没有读取未初始化内存，但是会导致用户读取
+        std::slice::from_raw_parts_mut(
+            self.buf.as_mut_ptr().offset(b as isize),
+            self.buf.capacity() - b)
+    };</code></pre>
+
+<pre><code>    match self.inner.read(buf) {
+        Ok(o) =&gt; {
+            unsafe {
+                // reset the size to include the written portion,
+                // safe because the extra data is initialized
+                self.buf.set_len(b + o);
+            }</code></pre>
+
+<pre><code>            Ok(&amp;self.buf[self.consumed..])
+        }
+        Err(e) =&gt; Err(e),
+    }
+}</code></pre>
+
+<pre><code>fn consume(&amp;mut self, amt: usize) {
+    self.consumed += amt;
+}</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">`GreedyAccessReader::fill_buf`方法创建了一个未初始化的缓冲区,并将其传递给用户提供的Read实现（`self.inner.read（buf）`）。这是不合理的，因为它允许`Safe Rust`代码表现出未定义的行为（从未初始化的内存读取）。
+
+在标准库`Read` trait 的 `read` 方法文档中所示：
+
+ &gt; 
+ &gt; 您有责任在调用`read`之前确保`buf`已初始化。
+ &gt; 用未初始化的`buf`（通过`MaybeUninit &lt;T&gt;`获得的那种）调用`read`是不安全的，并且可能导致未定义的行为。
+ &gt; https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read
+
+解决方法：
+
+在`read`之前将新分配的`u8`缓冲区初始化为零是安全的，以防止用户提供的`Read`读取新分配的堆内存的旧内容。
+
+修正代码：</code></pre>
+
+<p>// 修正以后的代码示例，去掉了未初始化的buf： impl&lt;R&gt; BufRead for GreedyAccessReader&lt;R&gt;</p>
+
+<pre><code>where
+    R: Read,</code></pre>
+
+<p>{</p>
+
+<pre><code>fn fill_buf(&amp;mut self) -&gt; IoResult&lt;&amp;[u8]&gt; {
+    if self.buf.capacity() == self.consumed {
+        self.reserve_up_to(self.buf.capacity() + 16);
+    }</code></pre>
+
+<pre><code>    let b = self.buf.len();
+    self.buf.resize(self.buf.capacity(), 0);
+    let buf = &amp;mut self.buf[b..];
+    let o = self.inner.read(buf)?;</code></pre>
+
+<pre><code>    // truncate to exclude non-written portion
+    self.buf.truncate(b + o);</code></pre>
+
+<pre><code>    Ok(&amp;self.buf[self.consumed..])
+}</code></pre>
+
+<pre><code>fn consume(&amp;mut self, amt: usize) {
+    self.consumed += amt;
+}</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">启示：
+
+该漏洞给我们对启示是，要写出安全的 Rust 代码，还必须掌握每一个标准库里 API 的细节。否则，逻辑上的错误使用也会造成`UB`。
+
+## 04 | 读取未初始化内存导致`UB`  (RUSTSEC-2021-0012)
+
+![img](./rust_security/4.png)
+
+该漏洞诞生于第三方库\[cdr-rs]中，漏洞相关[issue](https://github.com/hrektts/cdr-rs/issues/10)中。
+
+该漏洞和 RUSTSEC-2021-0008 所描述漏洞风险是相似的。
+
+`cdr-rs` 中的 `Deserializer::read_vec`方法创建一个未初始化的缓冲区，并将其传递给用户提供的`Read`实现（self.reader.read_exact）。
+
+这是不合理的，因为它允许安全的`Rust`代码表现出未定义的行为（从未初始化的内存读取）。
+
+漏洞代码：</code></pre>
+
+<p>fn read_vec(&amp;mut self) -&gt; Result&lt;Vec&lt;u8&gt;&gt; {</p>
+
+<pre><code>let len: u32 = de::Deserialize::deserialize(&amp;mut *self)?;
+// 创建了未初始化buf
+let mut buf = Vec::with_capacity(len as usize);
+unsafe { buf.set_len(len as usize) }
+self.read_size(u64::from(len))?;
+// 将其传递给了用户提供的`Read`实现
+self.reader.read_exact(&amp;mut buf[..])?;
+Ok(buf)</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">修正：</code></pre>
+
+<p>fn read_vec(&amp;mut self) -&gt; Result&lt;Vec&lt;u8&gt;&gt; {</p>
+
+<pre><code>let len: u32 = de::Deserialize::deserialize(&amp;mut *self)?;
+// 创建了未初始化buf
+let mut buf = Vec::with_capacity(len as usize);
+// 初始化为 0；
+buf.resize(len as usize, 0);
+self.read_size(u64::from(len))?;
+// 将其传递给了用户提供的`Read`实现
+self.reader.read_exact(&amp;mut buf[..])?;
+Ok(buf)</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">启示：同上。
+
+## 05 | Panic Safety &amp;&amp; Double free (RUSTSEC-2021-0011)
+
+![img](./rust_security/5.png)
+
+该漏洞诞生于[ocl](https://crates.io/crates/ocl)库，漏洞相关[issue](https://github.com/cogciprocate/ocl/issues/194)。该库已经处于不再维护状态，但是这个漏洞背后的成因需要引起我们重视。
+
+该库中使用了`ptr::read`，并且没有考虑好`Panic Safety`的情况，所以会导致双重释放（double free)。
+
+以下两段代码是漏洞展示，注意注释部分都解释：</code></pre>
+
+<p>//case 1 macro<em>rules! from</em>event<em>option</em>array<em>into</em>event_list(</p>
+
+<pre><code>($e:ty, $len:expr) =&gt; (
+    impl&lt;&#8217;e&gt; From&lt;[Option&lt;$e&gt;; $len]&gt; for EventList {
+            fn from(events: [Option&lt;$e&gt;; $len]) -&gt; EventList {
+                let mut el = EventList::with_capacity(events.len());
+                for idx in 0..events.len() {
+                // 这个 unsafe 用法在 `event.into()`调用panic的时候会导致双重释放
+                    let event_opt = unsafe { ptr::read(events.get_unchecked(idx)) };
+                    if let Some(event) = event_opt { el.push::&lt;Event&gt;(event.into()); }
+                }
+                // 此处 mem::forget 就是为了防止 `dobule free`。
+                // 因为 `ptr::read` 也会制造一次 drop。
+                // 所以上面如果发生了panic，那就相当于注释了 `mem::forget`，导致`dobule free`
+                mem::forget(events);
+                el
+            }
+    }
+)</code></pre>
+
+<p>);</p>
+
+<p>// case2</p>
+
+<p>impl&lt;&#8217;e, E&gt; From&lt;[E; $len]&gt; for EventList where E: Into&lt;Event&gt; {</p>
+
+<pre><code>fn from(events: [E; $len]) -&gt; EventList {
+    let mut el = EventList::with_capacity(events.len());
+    for idx in 0..events.len() {
+    // 同上
+        let event = unsafe { ptr::read(events.get_unchecked(idx)) };
+        el.push(event.into());
+    }
+    // Ownership has been unsafely transfered to the new event
+    // list without modifying the event reference count. Not
+    // forgetting the source array would cause a double drop.
+    mem::forget(events);
+    el
+}</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">以下是一段该漏洞都复现代码（我本人没有尝试过，但是提交issue都作者试过了），注意下面注释部分的说明：</code></pre>
+
+<p>// POC:以下代码证明了上面两个case会发生dobule free 问题</p>
+
+<p>use fil_ocl::{Event, EventList}; use std::convert::Into;</p>
+
+<p>struct Foo(Option&lt;i32&gt;);</p>
+
+<p>impl Into&lt;Event&gt; for Foo {</p>
+
+<pre><code>fn into(self) -&gt; Event {
+    /*
+    根据文档，`Into &lt;T&gt;`实现不应出现 panic。但是rustc不会检查Into实现中是否会发生恐慌，
+    因此用户提供的`into（）`可能会出现风险
+    */
+    println!(&quot;LOUSY PANIC : {}&quot;, self.0.unwrap()); // unwrap 是有 panic 风险</code></pre>
+
+<pre><code>    Event::empty()
+}</code></pre>
+
+<p>}</p>
+
+<p>impl Drop for Foo {</p>
+
+<pre><code>fn drop(&amp;mut self) {
+    println!(&quot;I&#8217;m dropping&quot;);
+}</code></pre>
+
+<p>}</p>
+
+<p>fn main() {</p>
+
+<pre><code>let eventlist: EventList = [Foo(None)].into();
+dbg!(eventlist);</code></pre>
+
+<p>}</p>
+
+<pre><code class="language-`">以下是 Fix 漏洞的代码，使用了`ManuallyDrop`，注意注释说明：</code></pre>
+
+<p>macro<em>rules! from</em>event<em>option</em>array<em>into</em>event_list(</p>
+
+<pre><code>($e:ty, $len:expr) =&gt; (
+    impl&lt;&#8217;e&gt; From&lt;[Option&lt;$e&gt;; $len]&gt; for EventList {
+        fn from(events: [Option&lt;$e&gt;; $len]) -&gt; EventList {
+            let mut el = ManuallyDrop::new(
+                EventList::with_capacity(events.len())
+            );</code></pre>
+
+<pre><code>            for idx in 0..events.len() {
+                let event_opt = unsafe {
+                    ptr::read(events.get_unchecked(idx))
+                };</code></pre>
+
+<pre><code>                if let Some(event) = event_opt {
+                    // Use `ManuallyDrop` to guard against
+                    // potential panic within `into()`.
+                    // 当 into 方法发生 panic 当时候，这里 ManuallyDrop 可以保护其不会`double free`
+                    let event = ManuallyDrop::into_inner(
+                        ManuallyDrop::new(event)
+                        .into()
+                    );
+                    el.push(event);
+                }
+            }
+            mem::forget(events);
+            ManuallyDrop::into_inner(el)
+        }
+    }
+)</code></pre>
+
+<p>);</p>
+
+<p><code>`</code>` 启示：</p>
+
+<p>在使用 <code>std::ptr</code> 模块中接口需要注意，容易产生 UB 问题，要多多查看 API 文档。</p>
+]]></content:encoded></item><item><title>Rust编译器专题 | Rust Dev Guide 中文翻译启动招募</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rustc_dev_guide_zh.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rustc_dev_guide_中文翻译启动'>Rustc Dev Guide 中文翻译启动</h1>
+
+<p>作者：张汉东</p>
+
+<h2 id=''></h2>
+
+<p><a href='https://github.com/rust-lang/rustc-dev-guide'>Rust编译器开发指南（Rustc Dev Guide）</a> 的中文翻译已经启动。因为原项目还在变动期，为了翻译方便，所以此翻译项目组织结构就不和原项目保持一致了。</p>
+
+<ul>
+<li><a href='https://rustc-dev-guide.rust-lang.org/'>官方原文在线阅读</a></li>
+
+<li><a href='https://rustcrustc.github.io/rustc-dev-guide-zh/'>中文版在线阅读</a></li>
+
+<li><a href='https://github.com/RustcRustc/rustc-dev-guide-zh'>中文版翻译仓库地址</a></li>
+</ul>
+
+<h4 id='志愿者招募要求：'>志愿者招募要求：</h4>
+
+<ul>
+<li>热爱 Rust，对 Rust 已经有一定了解</li>
+
+<li>想深入了解 Rust 编译器</li>
+
+<li>想为 Rust 编译器做贡献</li>
+
+<li>业余时间充足</li>
+</ul>
+
+<h4 id='如何参与'>如何参与</h4>
+
+<ol type="1">
+<li>认领感兴趣到章节</li>
+
+<li>找到对应到 markdown 文件</li>
+
+<li>直接发 PR</li>
+
+<li>或者帮忙审校别人的 PR</li>
+</ol>
+
+<h3 id='q_&_a:'>Q &amp; A:</h3>
+
+<ol type="1">
+<li>
+<p>如何避免每个人翻译上的冲突呢，需要提前pr说翻译哪一章节吗？</p>
+
+<p>其实没必要怕冲突，对于参与翻译的来说，翻译本身也是一次学习过程，是有收获的。了解编译器工作原理对理解 Rust 概念也有帮助的。如果同一篇有多个翻译，那我这边选翻译更好的就可以了。</p>
+
+<p>这个项目倡导参与者自组织，但为了更加方便大家协作，还是来设置一个规则避免大家冲突。为了大家认领方便，特别创建了认领打卡的 issues，都去这里打一下卡：<a href='https://github.com/RustcRustc/rustc-dev-guide-zh/issues/1'>【翻译认领】避免翻译冲突，来此打卡</a>。</p>
+
+<p>如果你想发一个自己专属的「认领issue」也没问题，可以给该issue打上「已认领」标签。开一个独立的issue好处是可以有一个专属的地方讨论你翻译章节内容里的各种问题。</p>
+</li>
+
+<li>
+<p>为什么要翻译 《Rust 编译器开发指南》  ？</p>
+
+<p>年初的时候，我立下一个五年的 Flag ： 五年内要为 Rust 语言发 1000 个 PR。</p>
+
+<p>然后社区里的朋友就帮我做了一个计算：五年 1000 个，那么每年 200 个，那么一天就得 0.5 个。也有朋友说，Rust 的 PR 每次 Review 周期都很长，就算你能一年提 200 个 PR，官方也不可能给你合并那么多。</p>
+
+<p>这样的计算，确实很有道理。这个目标，确实很难完成。但其实这个 Flag 我并没有打算个人完成，而是想推动社区对 Rust 感兴趣对朋友一起完成。如果五年内，我能推动 1000 个人参与，那么每个人只提交一个 PR，那么这个 1000 个 PR 的 Flag 就轻松完成了。</p>
+
+<p>所以，翻译 《Rust 编译器开发指南》就成了我完成这个 Flag 的第一步。希望大家踊跃参与。</p>
+</li>
+</ol>
+]]></content:encoded></item><item><title>Rust编译器专题 | 图解 Rust 编译器与语言设计 Part 1</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/rustc_part1.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='图解_rust_编译器与语言设计_|_part_1_：rust_编译过程与宏展开'>图解 Rust 编译器与语言设计 | Part 1 ：Rust 编译过程与宏展开</h1>
+
+<p>作者：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='说明'>说明</h2>
+
+<p>《图解 Rust 编译器与语言设计》系列文章特点：</p>
+
+<ol type="1">
+<li>重在图解。图解的目的，是为了帮助开发者从整体结构、语义层面来掌握 Rust 编译器与语言设计。</li>
+
+<li>边实践边总结，不一定会每月都有，但争取吧。</li>
+
+<li>希望是众人合力编写，我只是抛砖引玉。硬骨头，一起啃。</li>
+</ol>
+
+<h2 id='引子'>引子</h2>
+
+<p>想必读者朋友们都已经看到了 《Rust 日报》里的消息：微软、亚马逊、Facebook等巨头，都在组建自己的 Rust 编译器团队，都在战略性布局针对 Rust 语言。并且 Rust 基金会也已经进入了最后都流程，由此可以猜想，这些巨头很可能已经加入了基金会。</p>
+
+<p>我在 RustChinaConf 2020 年大会分享《Rust 这五年》中盘点了 Rust 这五年多都发展，虽然 Rust 势头很好，但大部分贡献其实都是国外社区带来的，国内社区则是处于学习和观望的状态，等待着所谓的杀手级应用出现来引领 Rust 的“走红”。为什么国内社区不能为 Rust 多做点实质性的贡献呢？</p>
+
+<p>因此，2020 新年到来的时候，我立下一个五年的 Flag ： 五年内要为 Rust 语言发 1000 个 PR。</p>
+
+<p>然后社区里的朋友就帮我做了一个计算：五年 1000 个，那么每年 200 个，那么一天就得 0.5 个。也有朋友说，Rust 的 PR 每次 Review 周期都很长，就算你能一年提 200 个 PR，官方也不可能给你合并那么多。</p>
+
+<p>这样的计算，确实很有道理。这个目标，确实很难完成。但其实这个 Flag 我并没有打算个人完成，而是想推动社区对 Rust 感兴趣对朋友一起完成。如果五年内，我能推动 1000 个人参与，那么每个人只提交一个 PR，那么这个 1000 个 PR 的 Flag 就轻松完成了。</p>
+
+<p>所以，为了完成这个 Flag ，我把未来五年划分成三个阶段：</p>
+
+<ol type="1">
+<li>第一阶段：2021 年。该阶段的目标是「上道」。</li>
+
+<li>第二阶段：2022 ～ 2023 年。该阶段的目标是「进阶」。</li>
+
+<li>第三阶段：2024 ~ 2025 年。该阶段目标是「达标」。</li>
+</ol>
+
+<p>也就是说，今年是想要「上道」的一年。那么要达成这个目标，我做了以下计划：</p>
+
+<ol type="1">
+<li>组织社区力量来翻译官方的《Rust 编译器开发指南》。</li>
+
+<li>组织 Rust 编译器小组，开始为 Rust 语言做点贡献，并且将在此过程中自己的学习和经验沉淀为《图解 Rust 编译器与语言设计》系列文章。</li>
+</ol>
+
+<p>通过这两份文档，希望可以帮助和影响到更多的人，来为 Rust 语言做贡献。</p>
+
+<p>我知道，编译器作为程序员的三大浪漫之一，水很深。你也可能会说，人家搞编译器的都是 PL 出生，一般人哪有那种本事。诚然如你所想，编译器很难。但幸亏，难不等于不可能。不会，我们可以学。况且，也不是让你从零开始去实现一个 Rust 编译器。</p>
+
+<p>为 Rust 语言做贡献，并不是 KPI 驱动，而是兴趣驱动。可能你看完了编译原理龙书虎书鲸书三大经典，也可能你实现过自己的一门语言。但其收获可能永远也比不上实际参与到 Rust 这样一个现代化语言项目中来。</p>
+
+<p>所以，《图解 Rust 编译器与语言设计》系列文章，不仅仅会记录我自己学习 Rust 编译器的沉淀，还会记录你的沉淀，如果你愿意投稿的话。在这浮躁的世界，给自己一片净土，找回技术初心。</p>
+
+<h2 id=''></h2>
+
+<h2 id='图解_rust_编译过程'>图解 Rust 编译过程</h2>
+
+<p>对于学习，我通常习惯先从整体和外围下手，去了解一个东西的全貌和结构之后，再逐步深入细节。否则的话，很容易迷失到细节中。</p>
+
+<p>所以，必须先来了解 Rust 编译过程。如下图：</p>
+
+<p><img src='./rustc/rust-complie-process.png' alt='rust-complie-process' /></p>
+
+<p>上图中间部分为 Rust 代码的整体编译过程，左右两边分别为过程宏和声明宏的解释过程。</p>
+
+<p>Rust 语言是基于 LLVM 后端实现的编程语言。在编译器层面来说，Rust编译器仅仅是一个编译器前端，它负责从文本代码一步步编译到<code>LLVM</code>中间码(<code>LLVM IR</code>)，然后再交给<code>LLVM</code>来最终编译生成机器码，所以<code>LLVM</code>就是编译后端。</p>
+
+<h3 id='rust_语言编译整体流程'>Rust 语言编译整体流程</h3>
+
+<ol type="1">
+<li>Rust 文本代码首先要经过「词法分析」阶段。</li>
+</ol>
+
+<p>将文本语法中的元素，识别为对 Rust 编译器有意义的「词条」，即<code>token</code>。</p>
+
+<ol type="2">
+<li>
+<p>经过词法分析之后，再通过语法分析将词条流转成「抽象语法树（AST）」。</p>
+</li>
+
+<li>
+<p>在得到 AST 之后，Rust 编译器会对其进行「语义分析」。</p>
+</li>
+</ol>
+
+<p>一般来说，语义分析是为了检查源程序是否符合语言的定义。在 Rust 中，语义分析阶段将会持续在两个中间码层级中进行。</p>
+
+<ol type="4">
+<li>语义分析 HIR 阶段。</li>
+</ol>
+
+<p>HIR 是抽象语法树（AST）对编译器更友好的表示形式，很多 Rust 语法糖在这一阶段，已经被脱糖（desugared）处理。比如 <code>for</code> 循环在这个阶段会被转为<code>loop</code>，<code>if let</code> 被转为<code>match</code>，等等。HIR 相对于 AST 更有利于编译器的分析工作，它主要被用于 「类型检查（type check）、推断（type inference）」。</p>
+
+<ol type="5">
+<li>语义分析 MIR 阶段。</li>
+</ol>
+
+<p>MIR 是 Rust 代码的中级中间代表，基于 HIR 进一步简化构建。MIR 是在<code>RFC 1211</code>中引入的。</p>
+
+<p>MIR 主要用于借用检查。早期在没有 MIR 的时候，借用检查是在 HIR 阶段来做的，所以主要问题就是生命周期检查的粒度太粗，只能根据词法作用域来进行判断，导致很多正常代码因为粗粒度的借用检查而无法通过编译。Rust 2018 edition 中引入的 非词法作用域生命周期（NLL）就是为来解决这个问题，让借用检查更加精细。NLL 就是因为 MIR 的引入，将借用检查下放到 MIR 而出现的一个术语，这个术语随着 Rust 的发展终将消失。</p>
+
+<p>MIR 这一层其实担负的工作很多，除了借用检查，还有代码优化、增量编译、Unsafe 代码中 UB 检查、生成<code>LLVM IR</code>等等。关于 MIR 还需要了解它的三个关键特性：</p>
+
+<p>&gt; &gt; * 它是基于控制流图（编译原理：Control Flow Graph）的。 &gt; * 它没有嵌套表达式。 &gt; * MIR 中的所有类型都是完全明确的，不存在隐性表达。人类也可读，所以在 Rust 学习过程中，可以通过查看 MIR 来了解 Rust 代码的一些行为。</p>
+
+<ol type="6">
+<li>
+<p>图中没有画出来的，还有一个从 HIR 到 MIR 的一个过渡中间代码表示 THIR（Typed HIR） 。THIR 是对 HIR 的进一步降级简化，用于更方便地构建 MIR 。在源码层级中，它属于 MIR 的一部分。</p>
+</li>
+
+<li>
+<p>生成 <code>LLVM IR</code> 阶段。<code>LLVM IR</code>是<code>LLVM</code>中间语言。<code>LLVM</code>会对<code>LLVM IR</code>进行优化，再生成为机器码。</p>
+</li>
+</ol>
+
+<p>后端为什么要用 <code>LLVM</code> ？不仅仅是 Rust 使用 <code>LLVM</code>，还有很多其他语言也使用它，比如 Swift 等。 <code>LLVM</code> 的优点：</p>
+
+<p>&gt; &gt; * LLVM后端支持的平台很多，我们不需要担心CPU、操作系统的问题（运行库除外）。 &gt; * LLVM后端的优化水平较高，我们只需要将代码编译成LLVM IR，就可以由LLVM后端作相应的优化。 &gt; * LLVM IR本身比较贴近汇编语言，同时也提供了许多ABI层面的定制化功能。</p>
+
+<p>Rust 核心团队也会帮忙维护 <code>LLVM</code>，发现了 Bug 也会提交补丁。虽然<code>LLVM</code>有这么多优点，但它也有一些缺点，比如编译比较慢。所以，Rust 团队在去年引入了新的后端 Cranelift ，用于加速 Debug 模式的编译。Rust 编译器内部组件 <code>rustc_codegen_ssa</code> 会生成后端无关的中间表示，然后由 Cranelift 来处理。从2021年1月开始，通过<code>rustc_codegen_ssa</code> 又为所有后端提供了一个抽象接口以实现，以允许其他代码源后端（例如 Cranelift），这意味着，Rust 语言将来可以接入多个编译后端（如果有的话）。</p>
+
+<p>以上是 Rust 整体编译流程。但 Rust 语言还包含来强大的元编程：「宏（Macro）」，宏代码是如何在编译期展开的呢？请继续往下看。</p>
+
+<h3 id='rust_宏展开'>Rust 宏展开</h3>
+
+<p>Rust 本质上存在两类宏：<strong>声明宏（Declarative Macros）</strong> 与 <strong>过程宏（Procedural Macros）</strong> 。很多人可能搞不清楚它们的差异，也许看完这部分内容就懂了。</p>
+
+<p><strong>声明宏</strong></p>
+
+<p>回头再看看上面的图右侧部分。我们知道，Rust 在最初解析文本代码都时候会将代码进行词法分析生成词条流（TokenStream）。在这个过程中，如果遇到了宏代码（不管是声明宏还是过程宏），则会使用专门的「宏解释器（Macro Parser）」 来解析宏代码，将宏代码展开为 TokenStream，然后再合并到普通文本代码生成的 TokenSteam 中。</p>
+
+<p>你可能会有疑问，其他语言的宏都是直接操作 AST ，为什么 Rust 的宏在 Token 层面来处理呢？</p>
+
+<p>这是因为 Rust 语言还在高速迭代期，内部 AST 变动非常频繁，所以无法直接暴露 AST API 供开发者使用。而词法分析相对而言很稳定，所以目前 Rust 宏机制都是基于词条流来完成的。</p>
+
+<p>那么声明宏，就是完全基于词条流（TokenStream)。声明宏的展开过程，其实就是根据指定的匹配规则（类似于正则表达式），将匹配的 Token 替换为指定的 Token 从而达到代码生成的目的。因为仅仅是 Token 的替换（这种替换依然比 C 语言里的那种宏强大），所以你无法在这个过程中进行各种类型计算。</p>
+
+<p><strong>过程宏</strong></p>
+
+<p>声明宏非常方便，但因为它只能做到替换，所以还是非常有局限的。所以后来 Rust 引入了过程宏。过程宏允许你在宏展开过程中进行任意计算。但我们不是说，Rust 没有暴露 AST API 吗？为什么过程宏可以做到这么强大？</p>
+
+<p>其实，过程宏也是基于 TokenSteam API的，只不过由第三方库作者 dtolnay 设计了一套语言外的 AST ，经过这一层 AST 的操作，就实现了想要的结果。</p>
+
+<p>没有什么问题不是可以通过加一层解决的，如果解决不了那就加两层。</p>
+
+<p>dtolnay 在社区内被誉为最佳 API 设计天才。他创造了不少库，比如 Serde，是 Rust 生态中被应用最多的一个库。</p>
+
+<p>话说回来。过程宏的工作机制就如上面图中左侧展示的那样。主要是利用三个库，我称之为 「过程宏三件套」：</p>
+
+<ol type="1">
+<li>proc<em>macro2。该库是对 proc</em>macro 的封装，是由 Rust 官方提供的。</li>
+
+<li>syn。该库是 dtolnay 实现的，基于 proc_macro2 中暴露的 TokenStream API 来生成 AST 。该库提供来方便的 AST 操作接口。</li>
+
+<li>quote。该库配合 syn，将 AST 转回 TokenSteam，回归到普通文本代码生成的 TokenSteam 中。</li>
+</ol>
+
+<p>过程宏的整个过程，就像是水的生态循环。 蒸汽从大海（TokenSteam）中来，然后通过大雨(Syn)，降到地上(Quote)，形成涓涓细流(proc_macro2::TokenStream)最终汇入大海（TokenSteam）。</p>
+
+<p>理解过程宏的展开原理，将有助于你学习过程宏。</p>
+
+<h2 id='小结'>小结</h2>
+
+<p>本篇文章主要介绍了 Rust 代码的编译过程，以及 Rust 宏代码的展开机制，学习这些内容，将有助于你深入理解 Rust 的概念。不知道这篇内容是否激发起你对 Rust 编译器对兴趣呢？编译器是一个深坑，让我们慢慢挖掘它。</p>
+
+<p>感谢阅读。</p>
+]]></content:encoded></item><item><title>一月刊（January）</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_1/toc.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='一月刊'>一月刊</h1>
+
+<p><img src='../image/rust_magazine3.png' alt='logo' /></p>
+
+<h3 id='本月社区动态简报'>本月社区动态简报</h3>
+
+<p>精选自《Rust日报》</p>
+
+<ul>
+<li><a href='./lang.md'>Rust官方动态</a></li>
+
+<li><a href='./hots.md'>社区热点</a></li>
+
+<li><a href='./projects.md'>推荐项目</a></li>
+
+<li><a href='./learns.md'>学习资源</a></li>
+
+<li><a href='./rust_laoke.md'>Rust 唠嗑室本月汇总</a></li>
+</ul>
+
+<h3 id='rustchinaconf_2020_专题'>RustChinaConf 2020 专题</h3>
+
+<ul>
+<li><a href='./jit.md'>RustChinaConf2020 精选 | 用Rust设计高性能JIT执行引擎</a></li>
+
+<li><a href='./rust_async.md'>RustChinaConf2020 精选 | Rust 异步与并发</a></li>
+</ul>
+
+<h3 id='rust_in_production'>Rust in Production</h3>
+
+<ul>
+<li><a href='./1password.md'>「翻译」1password 的 Rust 实践</a></li>
+
+<li><a href='./cita_protobuf-ext.md'>溪塔科技: 用Rust写Protobuf扩展</a></li>
+</ul>
+
+<h3 id='学习园地'>学习园地</h3>
+
+<ul>
+<li><a href='./rust-design-patterns/builder.md'>「系列」Rust设计模式</a></li>
+
+<li><a href='./io_uring_and_rust.md'>关于 io_uring 与 Rust 的思考</a></li>
+
+<li><a href='./graphql_in_rust/graphql_in_rust.md'>GraphQL in Rust</a></li>
+
+<li><a href='./rust_ownership.md'>图解 Rust 所有权与生命周期</a></li>
+</ul>
+
+<h3 id='嵌入式_rust_专题'>嵌入式 Rust 专题</h3>
+
+<ul>
+<li><a href='./embedded_rust.md'>嵌入式领域的Rust语言</a></li>
+</ul>
+
+<h3 id='操作系统专题'>操作系统专题</h3>
+
+<ul>
+<li><a href='./rcore_intro.md'>用`Rust`写操作系统 | 清华 rCore OS 教程介绍 </a></li>
+</ul>
+
+<h3 id='rust_security_专题'>Rust Security 专题</h3>
+
+<ul>
+<li><a href='./rust_security_part1.md'>`Rust`生态安全漏洞总结系列 | Part1</a></li>
+</ul>
+
+<h3 id='rust_编译器专题'>Rust 编译器专题</h3>
+
+<ul>
+<li><a href='./rustc_dev_guide_zh.md'>Rustc Dev Guide 中文翻译启动</a></li>
+
+<li><a href='./rustc_part1.md'>图解 Rust 编译器与语言设计 | Part 1</a></li>
+</ul>
+]]></content:encoded></item><item><title>发刊通告</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/announce.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='二月发刊通告'>二月发刊通告</h1>
+
+<p>时光易逝，转眼二月即将过去，春暖花开的三月即将到来。过年的余味犹在，但我们不得不继续踏上征途。</p>
+
+<p>《 RustMagazine 中文精选 》2021 年第二期发布了，后续也期待大家投稿。</p>
+
+<h3 id='本刊_mdbook_模版功能改进'>本刊 mdbook 模版功能改进</h3>
+
+<p><strong>mdbook 模版功能新增：</strong></p>
+
+<ul>
+<li>增加评论功能。评论会自动同步到 RustMagazine GitHub 仓库 与文章同名的 issues 下（文章下有评论就自动创建）。</li>
+
+<li>增加画图功能。利用 mermaid 来画图。参考：<a href='https://mermaid-js.github.io/mermaid-live-editor/'>mermaid 在线使用指南</a>。</li>
+</ul>
+
+<p>画图示例：</p>
+
+<p>&lt;pre class=&quot;mermaid&quot;&gt;graph TD</p>
+
+<pre><code>A[RustMagazine] --&amp;gt;|每月最后一天| B(发刊)
+B --&amp;gt; C{阅读渠道}
+C --&amp;gt; |GitHub Page| D[GitHub]
+C --&amp;gt;|Rustcc| E[Rust中文论坛/公众号]
+C --&amp;gt;|Rust视界| F[Telegram]
+C --&amp;gt;|掘金| G[技术社区]
+C --&amp;gt;|语雀| H[在线文档]</code></pre>
+
+<p>&lt;/pre&gt;</p>
+
+<p>欢迎大家直接使用本刊 mdbook 模版进行创作投稿发PR！</p>
+
+<h3 id='上期（一月刊）访问数据统计小结'>上期（一月刊）访问数据统计小结</h3>
+
+<p><strong>浏览量：</strong></p>
+
+<ul>
+<li>网页浏览量 ：3,678</li>
+
+<li>唯一身份浏览量 ：2,889</li>
+</ul>
+
+<p><strong>读者访问最多时段：</strong></p>
+
+<ul>
+<li>每天上午 8点 到 下午 6点。</li>
+
+<li>周四 和 周五 阅读量相对更多。</li>
+</ul>
+
+<p><strong>读者分布地区排名：</strong></p>
+
+<ul>
+<li>中国</li>
+
+<li>北美（美国/加拿大）</li>
+
+<li>澳洲</li>
+</ul>
+
+<p><strong>一月份比较受欢迎的文章 Top 5（按访问量依次排名）：</strong></p>
+
+<ul>
+<li>《图解 Rust 所有权》，作者：肖猛</li>
+
+<li>《用 Rust 写操作系统 | rCore 教程介绍》，作者：清华大学</li>
+
+<li>《RustChinaConf2020 精选 | Rust 异步开发》，作者：赖智超</li>
+
+<li>《关于 io_uring 与 Rust 的思考》，作者：王徐旸</li>
+
+<li>《图解 Rust 编译器 | Part 1》，作者：张汉东</li>
+</ul>
+
+<p>阅读量最低为：</p>
+
+<ul>
+<li>《Rust 生态安全漏洞总结系列 | Part 1》，作者：张汉东</li>
+
+<li>《Rustc Dev Guide 中文翻译启动》，作者：张汉东</li>
+</ul>
+
+<p><strong>简报关注分类依次为：</strong></p>
+
+<ul>
+<li>Rust 官方动态</li>
+
+<li>学习资源</li>
+
+<li>推荐项目</li>
+
+<li>社区热点</li>
+
+<li>Rust 唠嗑室</li>
+</ul>
+
+<p><strong>读者阅读渠道依次为：</strong></p>
+
+<ul>
+<li>直接访问</li>
+
+<li>GitHub</li>
+
+<li>百度</li>
+
+<li>⾕歌</li>
+
+<li>rustcc</li>
+
+<li>其他</li>
+</ul>
+]]></content:encoded></item><item><title>本月简报 | Rust官方动态</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/lang.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_rust官方动态'>本月简报 | Rust官方动态</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：张汉东</li>
+</ul>
+
+<hr><h2 id='官宣，rust基金会正式成立！'>官宣，Rust基金会正式成立！</h2>
+
+<p>基金会初创白金成员包括：</p>
+
+<p>AWS，Google, HUAWEI（华为）, Microsoft, Mozilla</p>
+
+<p>官网地址：https://foundation.rust-lang.org/</p>
+
+<p>相关阅读：</p>
+
+<ul>
+<li><a href='./huawei_rust.md'>华为 | 可信编程 -- 华为引领Rust语言开发的实践和愿景</a></li>
+
+<li><a href='https://www.zhihu.com/question/443595816'>Rust 语言圆桌年话 | 关于 Rust 语言基金会成立，你有什么想说的呢？</a></li>
+</ul>
+
+<h2 id='rust_1.50_稳定版发布'>Rust 1.50 稳定版发布</h2>
+
+<p>关于 Rust 1.50 详细解读，请跳转自 <a href='./rust_1.50.md'>解读 Rust 1.50 稳定版</a> 一文阅读。</p>
+
+<h2 id='rust语言团队二月份第一次会议'>Rust语言团队二月份第一次会议</h2>
+
+<p>Rust 语言团队2月3号第一次召开了规划会议，并总结了会议纪要。从今以后，语言团队计划每个月的第一个星期三举行这样的会议。</p>
+
+<p>举行规划会议的目的：检查我们正在进行的项目的状态，计划本月剩余时间的design meeting。</p>
+
+<p>本次会议的主要内容：</p>
+
+<ol type="1">
+<li>async foundations: 异步基础</li>
+</ol>
+
+<p>continued progress on polish, new traits (继续改进优化新的trait)</p>
+
+<p>making plans to stabilize async functions in traits (制定稳定Trait中async函数的规划)</p>
+
+<p>working on a vision document that lays out a multi-year vision for how async I/O should look/feel in Rust (编写一份愿景文档规划未来几年Rust 异步IO的愿景)</p>
+
+<ol type="2">
+<li>
+<p>const generics 常量泛型</p>
+</li>
+
+<li>
+<p>rfc 2229 (&quot;minimal closure capture&quot;) continued progress on the implementation, things are going well</p>
+</li>
+</ol>
+
+<p>we will likely add a capture! macro to use for migration; it would force the capture of a particular local variable (and not some subpath of it)</p>
+
+<p>链接：<a href='https://blog.rust-lang.org/inside-rust/2021/02/03/lang-team-feb-update.html'>https://blog.rust-lang.org/inside-rust/2021/02/03/lang-team-feb-update.html</a></p>
+
+<p>会议纪要：<a href='https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2021-02-03-Planning-Meeting.md#project-updates-and-discussion'>https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2021-02-03-Planning-Meeting.md#project-updates-and-discussion</a></p>
+
+<h2 id='关于_const_generics_mvp_你需要知道的'>关于 Const Generics MVP 你需要知道的</h2>
+
+<p>自从最初的 const 泛型 RFC 被接受以来已有3年多的时间了，Rust beta 现已提供 const 泛型的第一个版本！ 它将在<code>1.51</code> 版本中提供，该版本预计将于2021年3月25日发布。Const泛型是Rust最受期待的功能之一。</p>
+
+<p><strong>什么是常量泛型</strong></p>
+
+<p>常量泛型功能在 <a href='./rust_1.50.md'>解读 Rust 1.50 稳定版</a> 一文中也有介绍。</p>
+
+<p>一个典型的示例：</p>
+
+<pre><code class="language-`rust">struct ArrayPair&lt;T, const N: usize&gt; {
+    left: [T; N],
+    right: [T; N],
+}
+
+impl&lt;T: Debug, const N: usize&gt; Debug for ArrayPair&lt;T, N&gt; {
+    // ...
+}</code></pre>
+
+<p>其中，<code>[T; N]</code>就是常量泛型的应用。</p>
+
+<p>即将在 1.51 稳定版发布的 const 泛型是一个受限制的版本，换句话说，此版本是 const 泛型的 MVP（最小可行产品）版本。因为做一个通用版本的 const 泛型十分复杂，目前还在完善中。</p>
+
+<p><strong>MVP 版本限制如下：</strong></p>
+
+<ol type="1">
+<li>
+<p>目前唯一可以用作 const 泛型参数类型的类型是整数（即有符号和无符号整数，包括<code>isize</code>和<code>usize</code>）以及<code>char</code>和<code>bool</code>的类型。 这已经可以涵盖 const 泛型的主要用例，即对数组进行抽象。 将来会取消此限制，以允许使用更复杂的类型，例如<code>＆str</code>和 用户定义的类型。</p>
+</li>
+
+<li>
+<p>const 参数中不能有复杂的泛型表达式。当前，只能通过以下形式的 const 参数实例化 const 参数：</p>
+
+<ul>
+<li>一个独立的常量参数。</li>
+
+<li>一个字面量。</li>
+
+<li>一个没有泛型参数的具体常量表达式（用{}括起来）。 示例：</li>
+</ul>
+
+<pre><code class="language-`rust">fn foo&lt;const N: usize&gt;() {}
+
+fn bar&lt;T, const M: usize&gt;() {
+   foo::&lt;M&gt;(); // ok: `M` 是常量参数
+   foo::&lt;2021&gt;(); // ok: `2021` 是字面量
+   foo::&lt;{20 * 100 + 20 * 10 + 1}&gt;(); // ok: 常量表达式不包括泛型
+   
+   foo::&lt;{ M + 1 }&gt;(); // error: 常量表达式包括泛型参数 `M`
+   foo::&lt;{ std::mem::size_of::&lt;T&gt;() }&gt;(); // error: 常量表达式包括泛型参数 `T`
+   
+   let _: [u8; M]; // ok: `M` 是常量参数
+   let _: [u8; std::mem::size_of::&lt;T&gt;()]; // error: 常量表达式包括泛型参数 `T`
+}</code></pre>
+</li>
+</ol>
+
+<p><strong>标准库内部利用常量泛型的改进</strong></p>
+
+<p>伴随常量泛型在 1.51 稳定的还有 <a href='https://doc.rust-lang.org/nightly/std/array/struct.IntoIter.html'>`array::IntoIter`</a> ，它允许通过值而不是通过引用来迭代数组，从而解决了一个重大缺陷。 尽管仍然存在必须解决的向后兼容性问题，但仍在继续讨论是否可以直接为数组实现<code>IntoIterator</code>的可能性。 <code>IntoIter::new</code>是一种临时解决方案，可大大简化数组的处理。</p>
+
+<p>还有很多 API 在基于常量泛型改进，但还不会在 1.51 中稳定。</p>
+
+<pre><code class="language-`rust">use std::array;
+fn needs_vec(v: Vec&lt;i32&gt;) {
+   // ...
+}
+
+let arr = [vec![0, 1], vec![1, 2, 3], vec![3]];
+for elem in array::IntoIter::new(arr) {
+   needs_vec(elem);
+}</code></pre>
+
+<p><strong>未来计划</strong></p>
+
+<ol type="1">
+<li>解决默认参数和常量泛型位置冲突的问题。</li>
+</ol>
+
+<p>Rust 目前的泛型参数必须按特定顺序排列：生命周期（lifetime），类型（type），常量（const）。 但是，这会在尝试将默认参数与const参数一起使用时造成困难。为了使编译器知道哪个泛型参数，任何默认参数都必须放在最后。 接下来将解决这个问题。</p>
+
+<ol type="2">
+<li>为自定义类型支持常量泛型</li>
+</ol>
+
+<p>从理论上讲，要使一个类型有效作为const参数的类型，我们必须能够在编译时比较该类型的值。所以在 const泛型 RFC 中引入了结构相等的概念：本质上，它包括任何带有<code>＃[derive（PartialEq，Eq）]</code>且其成员也满足结构相等的类型。</p>
+
+<ol type="3">
+<li>为复杂类型支持常量泛型</li>
+</ol>
+
+<p>Nightly Rust 提供了一个<code>feature(const_evaluatable_checked)</code>，该特性门启用了对 const 泛型的复杂表达式支持。</p>
+
+<p>目前的困难：</p>
+
+<pre><code class="language-`rust">// 下面代码中两个表达式中的`N+1`是不同的，如果需要将它们看作相同，则需要检查的方法。这是面对复杂表达式中的一个难点。
+fn foo&lt;const N: usize&gt;() -&gt; [u8; N + 1] {
+   [0; N + 1]
+}
+
+// 还需要处理常量泛型操作中存在的潜在错误的方法
+// 如果没有办法在此处限制M的可能值，则在计算`0-1`时（在声明时未捕获），调用`generic_function::&lt;0&gt;()`会导致错误，因此对于下游用户可能会意外失败。
+fn split_first&lt;T, const N: usize&gt;(arr: [T; N]) -&gt; (T, [T; N - 1]) {
+   // ...
+}
+
+fn generic_function&lt;const M: usize&gt;(arr: [i32; M]) {
+   // ...
+   let (head, tail) = split_first(arr);
+   // ...
+}</code></pre>
+
+<p>原文： <a href='https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta'>https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta</a></p>
+
+<h2 id='rust_错误处理工作组计划将error_trait迁移至_core_模块'>Rust 错误处理工作组计划将Error trait迁移至 core 模块</h2>
+
+<p>如果迁移之后，在no_std模式下也可以使用Error trait了。</p>
+
+<p>链接：<a href='https://github.com/rust-lang/rust/pull/77384#issuecomment-772835929'>https://github.com/rust-lang/rust/pull/77384#issuecomment-772835929</a></p>
+]]></content:encoded></item><item><title>本月简报 |社区热点</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/hots.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|社区热点'>本月简报 |社区热点</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：张汉东</li>
+</ul>
+
+<h2 id='curl_支持_rustls'>CURL 支持 RUSTLS</h2>
+
+<p>Rustls 是一个用 Rust 写的现代 TLS（安全传输协议） 库。目前已经被纳入了为 CURL 的一个 backend</p>
+
+<p>curl 对以下这些 features 都有一些可替换的 backends ：</p>
+
+<ul>
+<li>International Domain Names</li>
+
+<li>Name resolving</li>
+
+<li>TLS</li>
+
+<li>SSH</li>
+
+<li>HTTP/3</li>
+
+<li>HTTP content encoding</li>
+
+<li>HTTP</li>
+</ul>
+
+<p><a href='https://daniel.haxx.se/blog/2021/02/09/curl-supports-rustls/'>https://daniel.haxx.se/blog/2021/02/09/curl-supports-rustls/</a></p>
+
+<h2 id='rust__全栈框架_moonzoon_计划'>Rust  全栈框架 MoonZoon 计划</h2>
+
+<ul>
+<li><a href='https://github.com/MoonZoon/MoonZoon'>仓库链接</a></li>
+</ul>
+
+<p>这是 Seed  作者新开的一个项目，目标是做一个纯 Rust 的全栈框架。</p>
+
+<ul>
+<li>NO Javascript</li>
+
+<li>NO CSS</li>
+
+<li>NO HTML</li>
+
+<li>NO REST</li>
+
+<li>NO GraphQL</li>
+
+<li>NO SQL</li>
+
+<li>NO Analysis Paralysis</li>
+
+<li>NO Wheel Reinventing</li>
+
+<li>NO Passwords\*</li>
+</ul>
+
+<p>目标比较大，目前是草案阶段，感兴趣的可以关注参与。</p>
+
+<p>个人看法：Rust 其实并不需要全栈框架。对于上面的一堆 NO XXX ，个人理解应该是指这个框架不太限定用户去使用什么，想用啥可以用啥，给予最大自由。</p>
+
+<h2 id='vscode_修补了关于_rust_工作流中的一个怪异的_bug'>VSCode 修补了关于 Rust 工作流中的一个怪异的 bug</h2>
+
+<p>最新的VSCode版本中有一个 PR，以防止提示弹出窗口过度滚动。 以前你将鼠标悬停在符号上来阅读相应文档，如果继续向下滚动至底部，则滚动将继续并将从文档窗口弹出。 现在，此问题已得到解决。🎉</p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/lgccv5/ysk_vscodes_most_recent_update_fixed_a_quirk_in/'>https://www.reddit.com/r/rust/comments/lgccv5/ysk_vscodes_most_recent_update_fixed_a_quirk_in/</a></p>
+
+<h2 id='google资助项目以使用新的rust组件保护apache_web服务器的安全'>Google资助项目以使用新的Rust组件保护Apache Web服务器的安全</h2>
+
+<p>根据ZDNet报道，由Google资助并由Internet Security Research Group领导的Apache Web服务器将设置为接收新的基于Rust的mod_ssl模块（以将Apache HTTP Web服务器项目的关键组件从容易出错的C编程语言移植到一种更安全的替代品Rust中），该模块将基于 Rustls ; 开发了Rust开源库，以 替代基于C的OpenSSL项目。</p>
+
+<p>阅读原文: <a href='https://www.zdnet.com/article/google-funds-project-to-secure-apache-web-server-project-with-new-rust-component/'>https://www.zdnet.com/article/google-funds-project-to-secure-apache-web-server-project-with-new-rust-component/</a></p>
+
+<h2 id='rust-analyzer_内部体系结构文档更新！'>rust-analyzer 内部体系结构文档更新！</h2>
+
+<p>rust-analyzer是一个用于IDE的实验性Rust编译器前端。</p>
+
+<p>阅读原文: <a href='https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/architecture.md'>https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/architecture.md</a></p>
+
+<h2 id='微软的rust课程将在下月开课'>微软的Rust课程将在下月开课</h2>
+
+<p>据几天前的消息微软正在组建一支Rust团队。现在，微软 Reactor 将在3月份将举办两次Rust课程，以下是课程预告。</p>
+
+<p>课前准备：</p>
+
+<p>不需要具有 Rust 经验，但是如果您有使用其他编程语言的经验会更佳。</p>
+
+<p>适合人群：</p>
+
+<p>该研讨会面向想要学习 Rust 的开发人员。不需要具有 Rust 经验，不过如果您有使用其他编程语言的经验会帮助你更快的学习 Rust 语言。</p>
+
+<p>参与本次分享，你将收获：</p>
+
+<p>如果您想更熟悉更多的 Rust 相关知识，包括：变量，数据类型，函数，集合类型和控制流，则应该参加此研讨会。</p>
+
+<p>主办方：</p>
+
+<p>微软 Reactor 上海 是微软为构建开发者社区而提供的一个社区空间。</p>
+
+<p>原文：<a href='https://mp.weixin.qq.com/s/TS3R8MNF_t09HmYNHMMHTg'>https://mp.weixin.qq.com/s/TS3R8MNF_t09HmYNHMMHTg</a></p>
+
+<h2 id='coreos_的rpm-ostree用rust重写部分功能'>CoreOS 的rpm-ostree用Rust重写部分功能</h2>
+
+<p>rpm-ostree 是一个CoreOS上的包管理器，最近使用Rust重写部分功能。该团队说更多氧化项目（比如/etc/{passwd,group}）正在进行中。</p>
+
+<p>链接：<a href='https://github.com/coreos/rpm-ostree/releases/tag/v2021.2'>https://github.com/coreos/rpm-ostree/releases/tag/v2021.2</a></p>
+
+<h2 id='《rust用于web开发的2年后感悟》'>《Rust用于web开发的2年后感悟》</h2>
+
+<p>原文地址：<a href='https://kerkour.com/blog/rust-for-web-development-2-years-later/'>https://kerkour.com/blog/rust-for-web-development-2-years-later/</a></p>
+
+<p>大约2年前，我开始使用Rust开发Web服务（JSON API），我认为是时候可以摆脱先入为主的观念并分享我学到的知识了。</p>
+
+<p>偏见:</p>
+
+<ul>
+<li>Rust代码很丑陋：Rust是显式的。不可否认。但是，当我编写代码时，我的IDE可以帮到我很多，而不必按下那么多键。当我阅读代码时，这种明确性真是太棒了！没有隐藏的惊喜，没有奇怪的事情。</li>
+
+<li>内存管理令人分心：实际上呢，没有。我没有使用那么多的词法生命周期，而是使用了智能指针。是的，因此我理解了Box，Rc和Arc之间的差异，与之同时和Node.JS、Golang语言相比，我的生产率没有因此受到影响。</li>
+
+<li>编译器很麻烦：一开始是的。但是几个月后，我能够立即理解错误，并能立刻解决这些错误。今天，我真的没有花太多时间在编译器上。相反，它成为了我最好的朋友，尤其是在重构大部分代码或升级依赖项时。</li>
+
+<li>缓慢的编译时间:我给这个说明。在Node.JS或Golang中，一个中等大小的服务的Docker image大约需要3到10分钟来构建和部署，在Rust中大约需要30分钟。</li>
+
+<li>生态系统还不存在：不可否认，的确是这样。缺少一些组件，例如官方的Stripe和AWS开发工具包，但是社区确实很活跃，并构建了所有这些缺少的组件。</li>
+</ul>
+
+<p>我特别值得点赞的几件事</p>
+
+<ul>
+<li>静态链接非常简单：创建小的Docker images 一件令人愉快的事情。。</li>
+
+<li>Rust会让你成为一个更好的程序员：Rust很复杂，如果你不了解它的详细工作原理，它不会放过你。掌握它需要时间和耐心，但是一旦你这样做了，你就会学到很多你永远不会像以前那样接近编程的东西。在学习Tokio的工作原理时，我了解了Golang的运行时是如何工作的。(心智模型学习)</li>
+
+<li>一旦它编译，通常它就可以正常工作:这是关于Rust我最喜欢的地方。当我的程序编译时，它按我的计划工作。注意：只要记住不要阻塞事件循环，编译器就会处理剩下的事情。您不再需要花时间为语言的怪癖编写测试。</li>
+
+<li>Rust具有很高的生产力：由于Rust是多种范式，因此在编写复杂的业务逻辑时，由于其功能方面，它的确非常出色。</li>
+</ul>
+
+<p>当前我正在使用的一些crates</p>
+
+<ul>
+<li>actix-web 用于HTTP层.</li>
+
+<li>sqlx 用于数据库PostgreSQL.</li>
+
+<li>rusoto AWS接口服务（S3、SQS、SES）</li>
+
+<li>tera 用于电子邮件模板</li>
+
+<li>thiserror 用于错误类型处理</li>
+
+<li>sentry 用于错误监控</li>
+</ul>
+
+<p>结论</p>
+
+<p>Rust非常适合用于web开发，在此我强烈建议尝试一下。</p>
+
+<p>取得成功是一次漫长的旅程，但完全值得，即使您不是每天都在使用它，也一定会通过学习它而成为一名更好的程序员，如果失去了，那就重新去发现编程的乐趣🤗。</p>
+
+<p>一句话总结：Rust生而平静。凌晨3点不再有不好的惊喜，因为依赖项更新了它的API使得不再有bug。没有更多恼人的配置自动缩放或什么。而且响应时间非常短，您的用户因此会爱上您的产品。</p>
+]]></content:encoded></item><item><title>本月简报 | 推荐项目</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/projects.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_推荐项目'>本月简报 | 推荐项目</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：杨楚天（yct21）</li>
+</ul>
+
+<h2 id='rust-sqlite'>Rust-SQLite</h2>
+
+<ul>
+<li><a href='https://github.com/joaoh82/rust_sqlite'>仓库链接</a></li>
+</ul>
+
+<p>Rust-SQLite (SQLRite) 是一个 SQLite clone。SQLRite 有很完善的文档，代码质量非常高，而且有非常丰富的单元测试用例。</p>
+
+<h2 id='tauri'>Tauri</h2>
+
+<ul>
+<li><a href='https://github.com/tauri-apps/tauri'>仓库链接</a></li>
+
+<li><a href='https://tauri.studio/en/'>项目主页</a></li>
+</ul>
+
+<p>Tauri 是一个桌面应用开发框架，包含了 JavaScript API，可以结合各种主流前端框架进行开发。</p>
+
+<p><a href='https://twitter.com/victorhqc/status/1356990383792791555'>有 Twitter 网友分享</a>， 他把自己的 Electron 写的应用迁移至 Rust 的 Tauri， 内存使用从 300M 降低至 6M，二进制大小从 195M 降至 7M。</p>
+
+<h2 id='rustpython'>RustPython</h2>
+
+<ul>
+<li><a href='https://github.com/RustPython/RustPython'>仓库链接</a></li>
+
+<li><a href='https://www.youtube.com/watch?v=nJDY9ASuiLc'>FOSDEM 2019 上的相关演讲</a></li>
+</ul>
+
+<p>RustPython 是用 Rust 实现的 Python 3（CPython &gt;= 3.8.0） 解释器。 RustPython 可以将 Python 嵌入到 Rust 程序中；也可以将 RustPython 编译为 WebAssembly，这样开发者可以在浏览器中运行其 Python 代码。此外，RustPython 也包含一个实验性的 JIT 编译器。</p>
+
+<h2 id='thirtyfour'>Thirtyfour</h2>
+
+<ul>
+<li><a href='https://github.com/stevepryde/thirtyfour'>仓库链接</a></li>
+</ul>
+
+<p>Thirtyfour 是一个 Selenium WebDriver 客户端，可以用于自动化 UI 测试。Thirtyfour 完全支持 W2C WebDriver spec，可以搭配 tokio 或者 async-std 使用。</p>
+
+<h2 id='lunatic'>Lunatic</h2>
+
+<ul>
+<li><a href='https://github.com/lunatic-solutions/lunatic'>仓库链接</a></li>
+
+<li><a href='https://lunatic.solutions/'>项目主页</a></li>
+</ul>
+
+<p>Lunatic 是一个服务端的 WebAssembly 运行时，有以下特点：</p>
+
+<ul>
+<li>受到 Erlang 的启发，有一个抢占式调度的运行时, 生成占用资源极少的用户态线程。</li>
+
+<li>借助 wasm 虚拟机，保证隔离和安全性。</li>
+
+<li>会在未来完全兼容 WASI</li>
+</ul>
+
+<h2 id='postage'>Postage</h2>
+
+<ul>
+<li><a href='https://github.com/austinjones/postage-rs'>仓库链接</a></li>
+
+<li><a href='https://implaustin.hashnode.dev/announcing-postage'>文章链接</a></li>
+</ul>
+
+<p>Postage 是一个异步通道库，提供了丰富的通道集，并在 Sink/Stream 上有很多实用的组合子，方便了异步程序的开发。</p>
+
+<p>作者同时也是 <a href='https://github.com/austinjones/tab-rs/'>tab</a> 的作者。</p>
+
+<h2 id='rustsbi'>RustSBI</h2>
+
+<ul>
+<li><a href='https://github.com/luojia65/rustsbi'>仓库链接</a></li>
+</ul>
+
+<p>RustSBI 是洛佳老师开发的一个 RISC-V SBI 实现，支持常见的硬件核心和模拟器，能够引导启动符合 RISC-V SBI 标准的操作系统，包括 Linux、rCore 等。</p>
+
+<h2 id='similar'>Similar</h2>
+
+<ul>
+<li><a href='https://github.com/mitsuhiko/similar'>仓库链接</a></li>
+</ul>
+
+<p>similar 是一个现代化的 diff 库，借鉴了 <a href='https://pijul.org/'>pijul</a> 实现的耐心排序算法，并结合了 Myer 的 diff 算法。</p>
+
+<h2 id='tantivy'>tantivy</h2>
+
+<ul>
+<li><a href='https://github.com/tantivy-search/tantivy'>仓库链接</a></li>
+</ul>
+
+<p>tantivy 是一个全文搜索引擎库, 类似于 Apache Lucene。</p>
+
+<h2 id='xh'>xh</h2>
+
+<ul>
+<li><a href='https://github.com/ducaale/xh'>仓库链接</a></li>
+</ul>
+
+<p>xh 是一个 Httpie clone。</p>
+
+<p><img src='https://github.com/ducaale/xh/raw/master/assets/xh-demo.gif' alt='ht' /></p>
+
+<h2 id='meio'>meio</h2>
+
+<ul>
+<li><a href='https://github.com/rillrate/meio'>仓库链接</a></li>
+</ul>
+
+<p>meio 是一个异步 actor 框架，其设计受 Erlang/OTP 启发，并可以很好地结合 rust 中的异步生态系统使用。作者正在尝试使其能 WebAssembly 兼容。</p>
+
+<h2 id='message-io'>message-io</h2>
+
+<ul>
+<li><a href='https://github.com/lemunozm/message-io'>仓库链接</a></li>
+</ul>
+
+<p>message-io 是一个是事件驱动的消息库，可轻松快速地构建网络应用程序。message-io 可以管理和处理套接字数据流，以便向用户提供简单的事件消息 API。作为通用网络管理器，它允许你遵循一些规则来实现自己的协议，而繁琐的异步和线程管理则由 message-io 帮你管理。</p>
+
+<h2 id='cranelift'>Cranelift</h2>
+
+<ul>
+<li><a href='https://github.com/bytecodealliance/wasmtime/tree/main/cranelift'>仓库链接</a></li>
+
+<li><a href='https://blog.benj.me/2021/02/17/cranelift-codegen-primer/'>文章链接</a></li>
+</ul>
+
+<p>Cranelift 是用 Rust 编程语言实现的代码生成器，旨在成为快速的代码生成器，其输出以合理速度运行的机器代码。 如今，它被用于包括 Wasmtime 和 Wasmer 在内的几种不同的 WebAssembly 运行时中，并且还可以作为 Rust 调试编译的替代后端。</p>
+
+<h2 id='voyager'>Voyager</h2>
+
+<ul>
+<li><a href='https://github.com/mattsse/voyager'>仓库链接</a></li>
+</ul>
+
+<p>voyager 是一个用 Rust 实现的爬虫库。</p>
+
+<h2 id='starlight'>Starlight</h2>
+
+<ul>
+<li><a href='https://github.com/Starlight-JS/Starlight'>仓库链接</a></li>
+
+<li><a href='https://github.com/Starlight-JS/Starlight'>reddit 链接</a></li>
+</ul>
+
+<p>Starlight 是一个 JavaScript 的运行时，其设计重点放在运行速度上，已经通过了 2k+test262 测试。Starlight 比 Boa（另一个Rust写的JS引擎）更快，其目标是和V8一样快。</p>
+
+<h2 id='lettre'>Lettre</h2>
+
+<ul>
+<li><a href='https://github.com/lettre/lettre'>仓库链接</a></li>
+</ul>
+
+<p>Lettre 是一个可以用于发送 email 的库。</p>
+
+<h2 id='optic：使用实际流量来记录和测试您的api'>Optic：使用实际流量来记录和测试您的API</h2>
+
+<ul>
+<li><a href='https://github.com/opticdev/optic'>仓库链接</a></li>
+</ul>
+
+<p>说明：</p>
+
+<ul>
+<li>Optic观察开发流量并了解您的API行为</li>
+
+<li>Optic通过将流量与当前规范相区别来检测API更改</li>
+
+<li>Optic为每个拉取请求添加准确的API更改日志</li>
+</ul>
+
+<h2 id='rust_web_模板项目'>Rust Web 模板项目</h2>
+
+<ul>
+<li><a href='https://github.com/svenstaro/rust-web-boilerplate'>仓库链接</a></li>
+</ul>
+
+<p>前些日子 Rust 不适合 Web 一文引起了热议，今天就有热心群友推荐了一个 Rust Web 模板项目：</p>
+
+<ul>
+<li>使用 .env 文件管理环境变量</li>
+
+<li>使用 diesel 来处理数据库迁移</li>
+
+<li>配合 cargo-watch 监控开发时程序修改，方便调试</li>
+
+<li>支持 cargo-tarpaulin 做测试覆盖率</li>
+</ul>
+
+<h2 id='termchat：一个终端聊天软件'>termchat：一个终端聊天软件</h2>
+
+<ul>
+<li><a href='https://github.com/lemunozm/termchat'>仓库链接</a></li>
+</ul>
+
+<p>最近Clubhouse因为Elon Musk突然大火，使用termchat可以在终端进行聊天。</p>
+
+<h2 id='yatta:_用于_windows10_的_bsp_平铺窗口管理器'>Yatta: 用于 Windows10 的 BSP 平铺窗口管理器</h2>
+
+<ul>
+<li><a href='https://github.com/LGUG2Z/yatta'>仓库链接</a></li>
+</ul>
+
+<p>作者最近因为从之前的mac环境由于一些原因需要切换到windows环境下工作，但是没有找到之前使用mac时的桌面分割工具（窗口排放管理工具），于是自己花了几天，研究了不少其它类似的工具，捣鼓出了这个。</p>
+
+<h2 id='nlprule，rust_实现的_nlp_库'>nlprule，Rust 实现的 NLP 库</h2>
+
+<ul>
+<li><a href='https://github.com/bminixhofer/nlprule'>仓库链接</a></li>
+</ul>
+
+<p>nlprule 使用 LanguageTool 中的资源为NLP实现了基于规则和查找的方法。</p>
+
+<h2 id='firestorm：_代码分析器'>firestorm： 代码分析器</h2>
+
+<ul>
+<li><a href='https://github.com/That3Percent/firestorm'>仓库链接</a></li>
+</ul>
+
+<p>作者扎克·伯恩斯发布了这款侵入式代码分析器。“火旋风”分析器能帮助代码作者测试Rust代码的性能；它能分析项目中的时间敏感部分，输出到时间轴图、合并的火焰图或其它的表现形式。这是一款侵入式分析器，也就意味着在代码编写的过程中，用户就需要使用分析器提供的宏，帮助分析器的记录过程。项目文档指出，这款分析器能通过编译特性来启用或禁用；未被启用时，所有的记录操作都被编译为空操作，这将不会影响生产程序的运行性能。</p>
+
+<p>我们常用的性能分析器，常常基于系统提供的“perf”指令，它就像是一个调试器，在合适的时候暂停进程，读取此时所有的线程和有关信息，从间隔的采样过程记录，从而得到运行性能输出。这种采样不需要重新添加和编译代码，但较可能漏掉时间短的函数。合理使用侵入式代码分析器，可以精细记录运行性能的细节，也能更少地影响待测程序的运行性能。</p>
+
+<p>friestorm 分析器已经在GitHub上开源，并配有丰富的使用文档。</p>
+
+<h2 id='rkyv_0.4：共享指针和自定义序列化程序'>rkyv 0.4：共享指针和自定义序列化程序</h2>
+
+<ul>
+<li><a href='https://github.com/djkoloski/rkyv'>仓库链接</a></li>
+</ul>
+
+<p>大家好，大约又工作了一个月，RKYV0.4终于推出了新特性和重大变化。</p>
+
+<p>如果你还没听说过的话，rkyv是一个针对Rust的零拷贝反序列化框架，类似于Cap&#8217;n Proto和FlatBuffers。它主要是为游戏开发而构建的，但也适用于广泛的其他应用程序。</p>
+
+<p>文章链接，<a href='https://www.reddit.com/r/rust/comments/lniraj/rkyv_04_shared_pointers_and_custom_serializers/'>https://www.reddit.com/r/rust/comments/lniraj/rkyv_04_shared_pointers_and_custom_serializers/</a></p>
+
+<h2 id='rg3d_游戏引擎'>rg3d 游戏引擎</h2>
+
+<ul>
+<li><a href='https://github.com/mrDIMAS/StationIapetus。'>仓库链接</a></li>
+</ul>
+
+<p>在过去的三个月中，rg3d 和 rusty-editor取得了很多重要的功能和改进。并开始使用引擎制作了新游戏，Station lapetus，一款 Sci-Fi 3D射击游戏。</p>
+
+<p>近3个月的进展报告: <a href='https://rg3d.rs/general/2021/02/26/progress.html'>https://rg3d.rs/general/2021/02/26/progress.html</a></p>
+
+<h2 id='lam:_actor模式的vm'>LAM: Actor模式的VM</h2>
+
+<ul>
+<li><a href='https://github.com/AbstractMachinesLab/lam'>仓库链接</a></li>
+</ul>
+
+<p>LAM，针对 WebAssembly和 Native 的 Actor VM。</p>
+
+<p>访谈链接： <a href='https://notamonadtutorial.com/lam-an-actor-model-vm-for-webassembly-and-native-d7939362e1b8'>https://notamonadtutorial.com/lam-an-actor-model-vm-for-webassembly-and-native-d7939362e1b8</a></p>
+
+<p>项目链接： <a href='https://abstractmachines.dev/'>https://abstractmachines.dev/</a></p>
+]]></content:encoded></item><item><title>本月简报 | 学习资源</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/learns.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_学习资源'>本月简报 | 学习资源</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：苏胤榕（DaviRain）</li>
+</ul>
+
+<h2 id='使用_rust_创建一个模拟器'>使用 Rust 创建一个模拟器</h2>
+
+<p>这是 Learning to Fly: Let&#8217;s create a simulation in Rust!。</p>
+
+<p>在这一系列的文章中,作者会从头到尾带领大家使用 Rust 实现一个基本 feed-forward 的神经网络。</p>
+
+<p><a href='https://pwy.io/en/posts/learning-to-fly-pt2/'>链接</a></p>
+
+<h2 id='使用rust和webassembly创建爆炸性的markdown编辑器'>使用Rust和WebAssembly创建爆炸性的Markdown编辑器</h2>
+
+<p>&gt; &gt; 摘录： 让我们快速准备WebAssembly的开发环境</p>
+
+<p>Rust通常cargo使用命令构建，但是WebAssembly有一个叫做wasm-pack的工具，它可以很方便地完成很多事情，所以让我们安装它。</p>
+
+<p><a href='https://zenn.dev/beijaflor/articles/da789ea779c005'>链接</a></p>
+
+<h2 id='improving_texture_atlas_allocation_in_webrender'>Improving texture atlas allocation in WebRender</h2>
+
+<p>作者花费大量篇幅解读了如何改进WebRender中Texture atlas分配的问题。</p>
+
+<p><a href='https://nical.github.io/posts/etagere.html'>链接</a></p>
+
+<h2 id='新书：《black_hat_rust》'>新书：《Black Hat Rust》</h2>
+
+<p>《Black Hat Rust》是一本基于Rust编程语言深入研究攻击性、安全性的书。最终出版预计2021年7月，书篇预估320页。如果你是一名安全的从业者，应该会对此书非常感兴趣。</p>
+
+<p><a href='https://academy.kerkour.com/black-hat-rust'>链接</a></p>
+
+<h2 id='emacs_配置_rust_开发环境'>Emacs 配置 Rust 开发环境</h2>
+
+<p>喜欢使用 Emacs 的小伙伴如果想开发 Rust，可以参考这篇文章进行详细的设置。</p>
+
+<p><a href='https://robert.kra.hn/posts/2021-02-07_rust-with-emacs/'>链接</a></p>
+
+<h2 id='rust_知识精炼'>Rust 知识精炼</h2>
+
+<p>该文是作者将自己的所学的 Rust 知识整理到这里，感兴趣的同学的可以看一下。</p>
+
+<p><a href='https://www.greyblake.com/blog/2021-02-07-rust-knowledge-refinement/'>链接</a></p>
+
+<h2 id='exercism\[.]io：一个在线编程训练的平台'>exercism\[.]io：一个在线编程训练的平台</h2>
+
+<p>exercism\[.]io 是一个在线编程训练平台支持Rust语言。</p>
+
+<p><a href='https://exercism.io'>链接</a></p>
+
+<h2 id='【视频】1password_开发者炉边谈话：介绍_rust_宏'>【视频】1Password 开发者炉边谈话：介绍 Rust 宏</h2>
+
+<p><a href='https://youtu.be/Lh262L63asA'>视频链接</a></p>
+
+<h2 id='比较_rust_async_与_linux_线程上下文切换时间'>比较 Rust async 与 Linux 线程上下文切换时间</h2>
+
+<p>作者写了一些代码，试图比较 Linux 线程上下文切换所需时间和Rust async任务调度切换所需时间及其各自在使用时的内存使用总量，并且还做出了总结。</p>
+
+<p><a href='https://github.com/jimblandy/context-switch'>Github</a></p>
+
+<h2 id='使用_tokio_直接构建_actors'>使用 Tokio 直接构建 Actors</h2>
+
+<p>本文使用Tokio直接构建 Actors，而不是使用任何现有的actor库。</p>
+
+<p>感兴趣的同学可以阅读一下。</p>
+
+<p><a href='https://ryhl.io/blog/actors-with-tokio/'>链接</a></p>
+
+<p>Rust 从零到生产: 可维护的测试套件的骨架和原则</p>
+
+<h2 id='这是_\<\<rust_从零到生产>>_系列的第七章_part_1.'>这是 \&lt;\&lt;Rust 从零到生产&gt;&gt; 系列的第七章 part 1.</h2>
+
+<p>该章节主要侧重于测试，整个书基本上都是使用 test-driven的方式来编写新的功能。当代码变的庞大之后，一个良好的测试框架可以更好的支撑更复杂的特性和日渐增多的测试用例。</p>
+
+<p><a href='https://www.lpalmieri.com/posts/skeleton-and-principles-for-a-maintainable-test-suite/'>链接</a></p>
+
+<h2 id='for_the_love_of_macros'>For the Love of Macros</h2>
+
+<p>宏是一种超越 more power的存在，他赋予了我们超越源代码的抽象能力，但是，同时，你也会放弃表层语法。例如，在一个拥有强大的宏的语言中，重命名基本上是不太可能 100% 工作的。</p>
+
+<p>本文尽力探索Rust中宏的使用方式， 目的是为了找到一种不放弃源代码推断的解决方案。</p>
+
+<p><a href='https://matklad.github.io/2021/02/14/for-the-love-of-macros.html'>链接</a></p>
+
+<h2 id='使用rust从零重写一个sqlite'>使用Rust从零重写一个SQLite</h2>
+
+<p>作者计划使用Rust重新复制一个SQLite数据库，目前正在进行中。</p>
+
+<p>SQLite有很完善的文档，代码质量非常高，而且有非常丰富的单元测试用例，终于有人尝试使用Rust重写一个SQLite了，感兴趣的朋友可以一起参与！</p>
+
+<p><a href='https://github.com/joaoh82/rust_sqlite'>Github</a></p>
+
+<p><a href='https://medium.com/the-polyglot-programmer/what-would-sqlite-look-like-if-written-in-rust-part-1-4a84196c217d'>链接</a></p>
+
+<h2 id='微软的员工发布的windows用户rust视频'>微软的员工发布的Windows用户Rust视频</h2>
+
+<p>主要介绍怎样在Windows平台使用windows-rs这个crate构建Rust程序。</p>
+
+<p><a href='https://kennykerr.ca/2021/02/18/rust-for-windows-getting-started/'>链接</a></p>
+
+<h2 id='如何使用_webassembly_构建一个_telnet_聊天服务器'>如何使用 webassembly 构建一个 telnet 聊天服务器</h2>
+
+<p>相信有大批的人喜欢 terminals这种审美， 作者也是其中之一。</p>
+
+<p>作者使用 webassembly + Rust 构建了一个 telnet 聊天服务器。 你可以使用下面的命令来尝试一下。</p>
+
+<pre><code class="language-`"># US
+&gt; telnet lunatic.chat
+# EU
+&gt; telnet eu.lunatic.chat</code></pre>
+
+<p><a href='https://lunatic.solutions/blog/lunatic-chat/'>链接</a></p>
+
+<h2 id='easyrust_现在有视频了'>EasyRust 现在有视频了</h2>
+
+<p>EasyRust 是一个非常好的 Rust 入门教程，现在，他不仅有文档,还有视频了。</p>
+
+<p>下面是第一期视频,未来至少还有 70 期。想学习的小伙伴可以跟着视频了解一下。</p>
+
+<p><a href='https://dhghomon.github.io/easy_rust/Chapter_0.html'>EasyRust地址</a></p>
+
+<p><a href='https://www.youtube.com/watch?v=-lYeJeQ11OI&amp;list=PLfllocyHVgsRwLkTAhG0E-2QxCf-ozBkk'>油管视频</a></p>
+
+<h2 id='经典_rust_面试题六道'>经典 Rust 面试题六道</h2>
+
+<p>在电报群由 @wayslog 提出的六道面试题目，wayslog 老师称之为“经典六道”：</p>
+
+<ol type="1">
+<li>
+<p>RwLock&lt;T&gt; 对想要在多线程下正确使用，T的约束是？</p>
+</li>
+
+<li>
+<p>如下代码：</p>
+
+<pre><code class="language-`">trait A{ fn foo(&amp;self) -&gt; Self; }
+Box&lt;Vec&lt;dyn A&gt;&gt;;</code></pre>
+
+<p>是否可以通过编译？为什么？</p>
+</li>
+
+<li>
+<p>Clone与 Copy 的区别是什么？</p>
+</li>
+
+<li>
+<p>deref 的被调用过程？</p>
+</li>
+
+<li>
+<p>Rust里如何实现在函数入口和出口自动打印一行日志？</p>
+</li>
+
+<li>
+<p>Box\&lt;dyn (Fn() + Send +&#8217;static)&gt; 是什么意思?</p>
+</li>
+</ol>
+
+<p>@wayslog 提供的答案：</p>
+
+<ol type="1">
+<li>The type parameter T represents the data that this lock protects. It is required that T satisfies Send to be shared across threads and Sync to allow concurrent access through readers。</li>
+
+<li>不可以，参考object safe 三条规则。</li>
+
+<li>Copy是marker trait，告诉编译器需要move的时候copy。Clone表示拷贝语义，有函数体。不正确的实现Clone可能会导致Copy出BUG。</li>
+
+<li>Deref 是一个trait，由于rust在调用的时候会自动加入正确数量的 <em>表示解引用。则，即使你不加入\</em>也能调用到Deref。</li>
+
+<li>调用处宏调用、声明时用宏声明包裹、proc_macro包裹函数、邪道一点用compiler plugin、llvm插桩等形式进行。（Go:我用snippet也行）</li>
+
+<li>一个可以被Send到其他线程里的没有参数和返回值的callable对象，即 Closure，同时是 ownershiped，带有static的生命周期，也就说明没有对上下文的引用。</li>
+</ol>
+
+<p>读者们又会几道呢~</p>
+
+<p><a href='https://rustcc.cn/article?id=0b0afa3e-db03-428e-9fc5-b06347997d41'>讨论链接</a></p>
+
+<h2 id='rust_for_web_development'>Rust for web development</h2>
+
+<p>本篇blog作者是今年七月要出的rust新书Black Hat Rust的作者，在两年前作者就已经开始尝试用Rust去进行web开发，这篇blog谈的是他开发的一些感受，一些经验，同时提到了他开发中用到了哪些crate。</p>
+
+<p><a href='https://kerkour.com/blog/rust-for-web-development-2-years-later/'>链接</a></p>
+
+<h2 id='笨方法学习rust所有权机制'>笨方法学习Rust所有权机制</h2>
+
+<p>为了真正了解Rust，我们需要了解其关键的区别于其它语言的特性: 所有权。本篇blog用了笨方法的方式来讲解Rust的所有权。</p>
+
+<p><a href='https://chrismorgan.info/blog/rust-ownership-the-hard-way/'>链接</a></p>
+
+<h2 id='好文推荐：《rust和lora》'>好文推荐：《Rust和LoRa》</h2>
+
+<p>Drogue IoT 是一个试图将可重用和高效的组件引入嵌入式Rust的团队，本文讲述了“如何在Rust中开始使用LoRa“。</p>
+
+<p>ps: LoRa是一种低功率远程无线协议</p>
+
+<p>阅读原文: <a href='https://blog.drogue.io/rust-and-lora/'>https://blog.drogue.io/rust-and-lora/</a></p>
+
+<p>Repo: <a href='https://github.com/drogue-iot/drogue-device'>https://github.com/drogue-iot/drogue-device</a></p>
+
+<h2 id='rust_循环优化'>Rust 循环优化</h2>
+
+<p><img src='https://rustcc-1252416178.cos.ap-nanjing.myqcloud.com/rust_loop_opt.jpeg' alt='1' /> <img src='https://rustcc-1252416178.cos.ap-nanjing.myqcloud.com/rust_loop_opt_2.jpeg' alt='2' /> <img src='https://rustcc-1252416178.cos.ap-nanjing.myqcloud.com/rust_loop_opt_2.jpeg' alt='3' /></p>
+
+<h2 id='cranelift_代码生成入门'>Cranelift 代码生成入门</h2>
+
+<p>Cranelift 是用 Rust 编程语言编写的代码生成器，旨在成为快速的代码生成器，其输出以合理速度运行的机器代码。如今，它被用于包括 Wasmtime 和 Wasmer 在内的几种不同的 WebAssembly 运行时中，并且还可以作为 Rust 调试编译的替代后端。</p>
+
+<p>更多见博客原文：<a href='https://blog.benj.me/2021/02/17/cranelift-codegen-primer/'>https://blog.benj.me/2021/02/17/cranelift-codegen-primer/</a></p>
+
+<p>Cranelift 仓库地址：<a href='https://github.com/bytecodealliance/wasmtime/tree/main/cranelift#cranelift-code-generator'>https://github.com/bytecodealliance/wasmtime/tree/main/cranelift#cranelift-code-generator</a></p>
+
+<h2 id='rtic_book'>Rtic book</h2>
+
+<p><a href='https://github.com/rtic-rs/cortex-m-rtic'>RTIC 框架</a> 是中断驱动的异步实时系统，完全针对应用使用Rust的宏语法生成，拥有极高的效率。</p>
+
+<p>RTIC Book ：<a href='https://rtic.rs/0.5/book/en/by-example.html'>https://rtic.rs/0.5/book/en/by-example.html</a></p>
+
+<h2 id='国外_rust_咨询公司_ferrous_system_的嵌入式课程资料'>国外 Rust 咨询公司 Ferrous System 的嵌入式课程资料</h2>
+
+<p>链接：<a href='https://embedded-trainings.ferrous-systems.com/preparations.html'>https://embedded-trainings.ferrous-systems.com/preparations.html</a></p>
+]]></content:encoded></item><item><title>本月简报 | Rust唠嗑室本月汇总</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_laoke.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_rust_唠嗑室本月汇总'>本月简报 | Rust 唠嗑室本月汇总</h1>
+
+<ul>
+<li>来源：<a href='https://space.bilibili.com/25566598'>Rust 唠嗑室</a></li>
+
+<li>主持人：MikeTang</li>
+
+<li>后期编辑：高宪凤</li>
+</ul>
+
+<hr><h2 id='《rust_唠嗑室》第_18_期_-_剖析_rust_的引用'>《Rust 唠嗑室》第 18 期 - 剖析 Rust 的引用</h2>
+
+<p><strong>时间</strong>: 2021/02/02 20:30-21:30</p>
+
+<p><strong>主讲人</strong>：舒乐之（Andy）</p>
+
+<p>一网网络工程师，2018 年开始写 Rust，参与 ImmuxDB 不可变数据库和 ImmuxCompute 计算引擎的设计开发；曾用 C 开发比特币节点 tinybtc；曾任 Matters Lab 首席工程师，Web 前后端都写过。</p>
+
+<p><strong>内容</strong>：</p>
+
+<p>这次的主要内容，是从零开始，解释 Rust 中「引用」的概念，以及一批与引用相关的概念：地址、指针、借用、切片、智能指针、胖指针、裸指针、所有权、生命周期、作用域等。</p>
+
+<p>还会谈到一些关于 Rust 引用的问题，比如：</p>
+
+<ul>
+<li>生命周期与作用域的关系是什么？</li>
+
+<li>为什么 str 不会单独出现，总是以要靠引用（比如&amp;str）使用？</li>
+
+<li><a href='https://doc.rust-lang.org/std/vec/struct.Vec.html'>Vec</a> 有一个 <a href='https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_boxed_slice'>into_boxed_slice()</a>方法 —— boxed slice 是什么，与 Vec 有什么区别？</li>
+
+<li><a href='https://doc.rust-lang.org/std/cell/struct.RefCell.html'>RefCell</a>、<a href='https://doc.rust-lang.org/core/cell/struct.Cell.html'>Cell</a>、<a href='https://doc.rust-lang.org/core/cell/struct.UnsafeCell.html'>UnsafeCell</a> 的区别是什么？什么时候用什么？</li>
+</ul>
+
+<p><a href='https://www.bilibili.com/video/BV15N411o7e4'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<ul>
+<li>
+<p>官方文档</p>
+
+<ul>
+<li>https://doc.rust-lang.org/stable/reference/types/pointer.html</li>
+
+<li>https://doc.rust-lang.org/stable/reference/types/function-pointer.html</li>
+
+<li>https://doc.rust-lang.org/nomicon/ownership.html</li>
+
+<li>https://github.com/rust-lang/rfcs/blob/master/text/2094-nll.md</li>
+
+<li>http://rust-lang.github.io/rfcs/1558-closure-to-fn-coercion.html</li>
+
+<li>https://prev.rust-lang.org/en-US/faq.html#ownership</li>
+
+<li>https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html</li>
+</ul>
+</li>
+
+<li>
+<p>博客</p>
+
+<ul>
+<li>http://smallcultfollowing.com/babysteps/blog/2014/05/13/focusing-on-ownership/</li>
+
+<li>https://ricardomartins.cc/2016/06/25/interior-mutability-thread-safety</li>
+
+<li>https://limpet.net/mbrubeck/2019/02/07/rust-a-unique-perspective.html</li>
+
+<li>https://internals.rust-lang.org/t/function-pointers-are-inconsistent-with-other-language-features/12439</li>
+</ul>
+</li>
+</ul>
+
+<hr><h2 id='rust_牛年春晚'>Rust 牛年春晚</h2>
+
+<p><strong>时间</strong>：2021/02/14 16:00 - 24:00</p>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p1【4_点场】_rust1.50_最新改动讲解'>P1【4 点场】 Rust1.50 最新改动讲解</h3>
+
+<p><strong>嘉宾</strong>：张汉东</p>
+
+<p>张汉东老师以一段 <code>Rust</code> 宏代码开启欢乐的 Rust 牛年春晚。随后汉东老师着重讲解了这次 <a href='https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html'>Rust1.50 版本</a>更新的主要内容。这次更新主要包括： <code>语言级特性</code>、<code>编译器</code>， <code>标准库</code>、 <code>稳定的 API</code>、<code>Cargo 相关</code>、<code>其他</code>、<code>兼容性提示</code>几个方面。</p>
+
+<p>&lt;!-- - 语言级特性方面</p>
+
+<ul>
+<li>常量泛型<code>[CONST; N]</code>进一步得到完善</li>
+
+<li>将共用体(union)中<code>ManualDrop</code>类型字段的分配视为安全</li>
+
+<li>
+<p>编译器方面</p>
+
+<ul>
+<li>添加对<code>armv5te-unknown-linux-uclibcgnueabi</code>目标的内置支持</li>
+
+<li>在ARM Mac上添加对Arm64 Catalyst的支持</li>
+
+<li>修复 FreeBSD 上的链接问题</li>
+</ul>
+</li>
+
+<li>
+<p>标准库方面</p>
+
+<ul>
+<li>为<code> proc_macro::Punct </code>增加 <code>PartialEq</code></li>
+
+<li>Unix 平台优化：Option&lt;File&gt; 大小等价于 File</li>
+</ul>
+</li>
+
+<li>
+<p>兼容性变更</p>
+
+<ul>
+<li>过期 compare<em>and</em>swap 方法</li>
+
+<li>放弃对所有 cloudabi target 的支持 --&gt;</li>
+</ul>
+</li>
+</ul>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=1'>查看回放</a></p>
+
+<p><strong>扩展资料</strong></p>
+
+<ol type="1">
+<li>暖场代码</li>
+</ol>
+
+<pre><code class="language-`Rust">macro_rules! m {
+    ($($s:stmt)*) =&gt; {
+        $(
+            { stringify!($s); 1 }
+        )&lt;&lt;*
+    };
+}
+
+fn main() {
+    print!(
+        &quot;{}{}{}&quot;,
+        m! { return || true },
+        m! { (return) || true },
+        m! { {return} || true },
+    );
+}</code></pre>
+
+<ol type="2">
+<li><a href='https://mp.weixin.qq.com/s/s7MCqwJWk_Kh77tvLRCKwA'>Rust 1.50 稳定版发布解读</a></li>
+</ol>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p2【5_点场】_delay-timer_分享'>P2【5 点场】 Delay-Timer 分享</h3>
+
+<p><strong>嘉宾</strong>：炮炮</p>
+
+<p><a href='https://github.com/BinChengZhao/delay-timer'>Delay-Timer</a> 是一个类似于管理周期性任务的库，目前支持同步、异步任务进行周期化交付，支持一些任务在调度过程中动态添加和动态提交任务的操作。炮炮老师分享了开发过程中的心路历程。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=2'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<ol type="1">
+<li>暖场代码</li>
+</ol>
+
+<pre><code class="language-`Rust">fn main() {
+    let a = 4;
+    println!(&quot;{},{}&quot;, --a, --a);
+}</code></pre>
+
+<ol type="2">
+<li><a href='https://github.com/BinChengZhao/delay-timer'>Delay-Timer</a></li>
+</ol>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p3【5_点场】libra_代码分析讲解'>P3【5 点场】Libra 代码分析讲解</h3>
+
+<p><strong>嘉宾</strong>：Shara</p>
+
+<p><a href='https://developers.diem.com/docs/welcome-to-diem/'>Libra</a> Facebook 开发的一个 Rust 区块链项目，它的使命是为全球数十亿人建立一个简单的全球货币和金融基础设施。Share 老师分享了分析 Libra 代码的思路。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=3'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>： <a href='https://developers.diem.com/docs/welcome-to-diem/'>Libra</a></p>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p4【6_点场】rust_开发嵌入式烂苹果'>P4【6 点场】Rust 开发嵌入式烂苹果</h3>
+
+<p><strong>嘉宾</strong>：王 Mono</p>
+
+<p>王老师现场撸代码，使用 Rust 一步一步完成开发嵌入式烂苹果。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=4'>查看回放</a></p>
+
+<p><strong>扩展资料</strong></p>
+
+<ol type="1">
+<li>暖场代码</li>
+</ol>
+
+<pre><code class="language-`Rust">trait Trait {
+    fn f(self);
+}
+
+impl&lt;T&gt; Trait for fn(T) {
+    fn f(self) {
+        print!(&quot;1&quot;);
+    }
+}
+
+impl&lt;T&gt; Trait for fn(&amp;T) {
+    fn f(self) {
+        print!(&quot;2&quot;);
+    }
+}
+
+fn main() {
+    let a: fn(_) = |_: u8| {};
+    let b: fn(_) = |_: &amp;u8| {};
+    let c: fn(&amp;_) = |_: &amp;u8| {};
+    a.f();
+    b.f();
+    c.f();
+}</code></pre>
+
+<ol type="2">
+<li><a href='https://longan.sipeed.com/zh/'>Longan 文档</a></li>
+</ol>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p5【8_点场】来自_go_社区大佬的视角'>P5【8 点场】来自 go 社区大佬的视角</h3>
+
+<p><strong>嘉宾</strong>：云喝酒</p>
+
+<p>Go 和 Rust 作为两门新生语言，Go 的开发者人数大约是 Rust 的64倍。几位来自 Go 社区大佬以不同的视角一起聊聊。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=5'>查看回放</a></p>
+
+<p><strong>扩展资料</strong></p>
+
+<ol type="1">
+<li>Cloubhouse</li>
+</ol>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p6【9_点场】程序员的吉他课'>P6【9 点场】程序员的吉他课</h3>
+
+<p><strong>嘉宾</strong>：MiskoLee</p>
+
+<p>MiskoLee 老师现场教授弹吉他，妥妥的程序员吉他速成班。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=6'>查看回放</a></p>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p7【9_点场】snｍp_项目介绍'>P7【9 点场】SNＭP 项目介绍</h3>
+
+<p><strong>嘉宾</strong>：Robin</p>
+
+<p>SNMP 是专门设计用于在 IP 网络管理网络节点（服务器、工作站、路由器、交换机及HUBS等）的一种标准协议，它是一种应用层协议。 SNMP 使网络管理员能够管理网络效能，发现并解决网络问题以及规划网络增长。通过 SNMP 接收随机消息（及事件报告）网络管理系统获知网络出现问题。Robin 老师分享 SNMP 在自己工作中实际应用。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=7'>查看回放</a></p>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p8【10_点场】maya-rs_分享'>P8【10 点场】Maya-rs 分享</h3>
+
+<p><strong>嘉宾</strong>：JungWoo</p>
+
+<p>在 Maya 中运用 Rust 实现噪声效果的案例。原理：使用 Rust 调用 Python API，然后再将结果给到 Python API。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=8'>查看回放</a></p>
+
+<p><strong>扩展资料</strong></p>
+
+<ol type="1">
+<li><a href='https://github.com/Choi-Jungwoo/maya_poly_noise_rs'>Maya PolyNoise</a></li>
+
+<li><a href='http://help.autodesk.com/view/MAYAUL/2019/ENU/'>Maya帮助</a></li>
+</ol>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p9【10_点场】关于数据库研究和开发的一些话'>P9【10 点场】关于数据库研究和开发的一些话</h3>
+
+<p><strong>嘉宾</strong>：金明剑</p>
+
+<p>金明剑老师结合自己实际经验聊了聊对 Rust 的理解，既有深度又有广度。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=9'>查看回放</a></p>
+
+<p>&lt;center&gt;&lt;font color=#f56c6c&gt;----------&gt; Rust 牛年春晚 &lt;----------&lt;/font&gt;&lt;/center&gt;</p>
+
+<h3 id='p10【11_点场】wasm_与_rust_及_vitejs-rs_分享'>P10【11 点场】wasm 与 rust 及 vitejs-rs 分享</h3>
+
+<p><strong>嘉宾</strong>：夏歌&amp;lencx</p>
+
+<p>夏歌老师根据自己整理的 WebAssembly 生态图，对其整体状况进行简单介绍。</p>
+
+<p>Lencx 老师现场演示，通过一个标准的 <a href='https://vitejs.dev/'>Vite</a> 脚手架开始项目，集成进 Rust，最后打包生成 Wasm 项目。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1pi4y1T78V?p=10'>查看回放</a></p>
+
+<p><strong>扩展资料</strong></p>
+
+<ol type="1">
+<li>https://github.com/second-state/tencent-tensorflow-scf</li>
+
+<li>https://mtc.nofwl.com/tech/post/wasm-start.html#rust</li>
+
+<li>https://vitejs.dev/</li>
+</ol>
+]]></content:encoded></item><item><title>知乎 Rust 圆桌年话专题问答精选</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_zhihu.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='知乎_rust_圆桌年话专题问答精选'>知乎 Rust 圆桌年话专题问答精选</h1>
+
+<p>编辑：张汉东</p>
+
+<p>在牛年春节期间，我在知乎发起 [Rust 语言圆桌年话 | 关于 Rust 语言基金会成立，你有什么想说的呢？ ](https://www.zhihu.com/question/443595816)</p>
+
+<h2 id=''></h2>
+
+<p><strong><a href='https://www.zhihu.com/question/443595816'>关于 Rust 语言基金会成立，你有什么想说的呢？</a></strong></p>
+
+<p><strong>@韩朴宇：</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/443595816/answer/1734191236
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p>华为在创始成员中既惊讶又感到正常，因为并没有听说华为在rust项目上的投资（其他4个成员公司存在大量的Rust项目组成员），但是华为也有Rust写的产品，比如StratoVirt。StratoVirt 是华为的企业级Linux操作系统EulerOS的开源版openEuler旗下的一个项目，是一个基于Linux KVM的虚拟机StratoVirt兼容QEMU的QMP API,同时支持x86和鲲鹏arm处理器，并且使用virtio半虚拟化设备接口。除了华为的StratoVirt, 还有一些Rust编写的虚拟机。最早的应该是Google的crosvm （cros是ChromeOS的缩写），这个虚拟机管理器是为了在ChromeOS上运行一个单独的Linux虚拟机而设计的（即Crostini 计划）。</p>
+
+<p>ChromeOS是一个类似于Android的系统，其系统分区是只读的，使用A/B分区的方式无缝升级，并且使用单独的用户数据分区。但是不同于Android高度定制化的用户空间，ChromeOS的用户空间就是用Gentoo Linux的包管理器Portage编译出来的，因此ChromeOS是一个标准的GNU/Linux系统。但是Google认为直接在该系统上运行任意的Linux程序会损害ChromeOS的安全性，因此在ChromeOS上运行一个轻量级虚拟机来运行一个命令行版的ChromeOS, 该系统可以运行LXC容器，默认的容器是Debian。Google认为这样套娃下来，既可以运行普通的Linux程序，又不会产生安全性问题。crosvm的特色是实现了一个基于virtio的Wayland总线，可以将虚拟机的Wayland/Xwayland程序的窗口直接穿过虚拟机的界限绘制到主系统的Wayland合成器上。使用最广的应该是AWS的 firecracker-microvm/firecracker ，AWS已经将其用于生成环境。此外还有Intel的 cloud-hypervisor/cloud-hypervisor，不仅支持x64, 而且像前3者一样也支持ARM64,而且还支持Windows 10。Rust在KVM上的生态离不开rust-vmm项目，该项目提供了对KVM api的绑定，该项目带起了整个Rust虚拟机的生态。</p>
+
+<p><strong>@iyacontrol：</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/443595816/answer/1723079060
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p>首先恭喜Rust有了好爸爸，而且不止一个。而且可以预见不久的未来，IBM、阿里云、腾讯云等大厂也会加入进来。有了这么多的好爸爸的加持，小伙伴们可以放心大胆地用Rust了，不用再担心Rust被砍掉了。通过基金会的成员来看，除了亲爸爸Mozilla，其他member大多都和云有关系。可以得出两点：Rust 的安全性和不差的性能，适合用来写一些偏底层的软件，比如各种运行时。而且也得到了大家一致的认可。Rust 将在云原生领域大放异彩了。目前来看，很有可能和Golang相互配合，Rust负责底层部分，Go负责中间部分，共同服务上层各种语言的应用。另外，感谢Mozilla的不为五斗米折腰，没有让Rust走了Java的路。如果Rust卖给类似于甲骨文的公司，那么Rust的前景就不好说了。</p>
+
+<p><strong>@最帅的物理课代表：</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/443595816/answer/1734618924
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p>虽然我是老华为黑粉了，但是其实很开心能看到华为在创始人名单之列。rust语言是很有前途的语言，这几乎是业界共识。华为有自研的容器项目，采用rust语言编写，这是一个很有意义的作品，比hm系列高到不知道哪里去。我们能通过这些看到华为的决心和勇气。同时这也很能带动国内的其他互联网企业，一起为rust投入更多精力，也给全球的rust社区添砖加瓦。我国的互联网发展和欧美一些国家一直都有较大的差距。但是众所周知，我们的传统艺能就是弯道超车。</p>
+
+<p>还有很多回答，可以去知乎查看。</p>
+
+<h2 id=''></h2>
+
+<p><strong><a href='https://www.zhihu.com/question/438833112'>您对 2021 年的 Rust 语言有哪些期待？</a></strong></p>
+
+<p><strong>@韩朴宇:</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/438833112/answer/1673155747
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p>我在<code>rustbuild（即src/bootstrap）</code>上提过几个pr，因此说几个和<code>rustc</code>相关的（或者说和语言无关的工程问题）。</p>
+
+<ol type="1">
+<li>
+<p><code>cranelift</code>以及<code>rustc_codegen_cranelift</code>可以大大加速debug build，test，proc<em>macro和build.rs的速度，结合<code>jit</code>模式，可以实现以接近cargo check的速度同时检查语法错误，借用检查错误和逻辑错误。目前cg</em>clif已经进入rust仓库，在SYSV abi，Windows ABI，原子操作，内联汇编，SIMD上还有一些问题。cg<em>clif是由一位开发者bjorn3单枪匹马写出来的，很厉害。另外新的asm！内联汇编宏不再使用llvm</em>asm的语法，就是因为有朝一日rustc会集成上全功能的rust编写的后端。由Inline Assembly project group开发</p>
+</li>
+
+<li>
+<p><code>std aware cargo</code>也就是 <code>cargo -Z build-std</code>，这个功能在优化二进制大小上很有用，在操作系统开发上是必需品。由std Aware Cargo working group负责。</p>
+</li>
+
+<li>
+<p><code>core::error::Error</code>, <code>core::io::Error</code>和<code>backtrace</code>支持这是<code>Error handling project group</code>的工作重点，目前已有demo可用。有了这个wasm，嵌入式和操作系统开发也可以用常用的错误处理库了。</p>
+</li>
+
+<li>
+<p><code>chalk</code> 。trait 系统的改进全靠这个，包括<code>GAT</code>由<code>traits working group</code>负责为什么我的期待都有working group，因为这就是rust项目的治理方式，没有working group的东西就肯定是没戏的，至少一年内是如此。比如取一个稳定的abi，作为rust abi和c++ abi的子集和C abi的超集，已经吵了好几年了，估计今年也是没戏。</p>
+</li>
+</ol>
+
+<p><strong>@Nugine：</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/438833112/answer/1672070201
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p><code>min const generics</code> 将于 1.51 稳定，大约3月底，可以解锁一些较为常规的设计方法。</p>
+
+<p>GAT 仍然是我最期待的有生之年的特性，它与 async trait, monad 之类的东西相关，能派生出很多魔法设计。</p>
+
+<p><code>async-std 1.8</code>，<code>tokio 1.0</code>，希望更多常用的库不再犹豫，赶紧1.0。</p>
+
+<p>希望 tracing 加快速度到 0.2，异步上下文追踪就指望它了。</p>
+
+<p>生态中很多常见领域都已经有了至少一两个占主导地位的库，但还需要打磨。希望做到商业级、工业级可用。</p>
+
+<p>希望 2021 Rust 多出一些杀手级产品，最好是国产的。</p>
+
+<p><strong>@dontpanic:</strong></p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/438833112/answer/1673710125
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。</code></pre>
+
+<p>我比较没出息，我只想要糖…… 最想要的几个：</p>
+
+<ol type="1">
+<li><code>arbitrary_self_types</code>(p.s 这个例子并不是必须使用arbitrary self types，使用 associate function可以有同样的效果，参见评论区）真的好用，已经离不开了。</li>
+</ol>
+
+<p>目前能用做 Self 类型的，只有 <code>self/&amp;self/&amp;mut self/Box&lt;Self&gt;/Rc&lt;Self&gt; </code>等几个类型。 Arbitrary self types 允许使用任意 Deref 到 Self 的类型用作 self。有什么用呢？比如，我想扩展下面的</p>
+
+<pre><code class="language-`rust">Base:trait Derived {
+    fn foobar(&amp;self);
+}
+
+struct Base&lt;T: Derived&gt; {
+    ext: T,
+}
+
+impl&lt;T: Derived&gt; Base&lt;T&gt; {
+    fn foo(&amp;self) {
+        self.ext.foobar();
+    }
+
+    fn bar(&amp;self) {
+        println!(&quot;bar!&quot;);
+    }
+}
+
+struct DerivedImpl {
+    base: Weak&lt;RefCell&lt;Base&lt;DerivedImpl&gt;&gt;&gt;,
+}
+
+impl Derived for DerivedImpl {
+    fn foobar(&amp;self) {
+        self.base.upgrade().unwrap().borrow().bar();
+        println!(&quot;foobar!&quot;);
+    }
+}</code></pre>
+
+<p>这样的实现就会强制 base 必须以使用 Rc 的方式使用，并且要小心多次 BorrowMut（很容易发生，要么就需要 Derived 提供 interior mutability）。或者也可以在 trait Derived 的函数参数里面把 base 传进去，但是有点 verbose。当然也可以说这种设计不够 rust idiomatic...不过有了 Arbitrary self types 之后，世界就清爽了。</p>
+
+<p>首先实现一下<code>deref/deref_mut</code>：</p>
+
+<pre><code class="language-`rust">impl&lt;T: Derived + &#8217;static&gt; Deref for Base&lt;T&gt; {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&amp;self) -&gt; &amp;T {
+        &amp;self.ext
+    }
+}
+
+impl&lt;T: Derived + &#8217;static&gt; DerefMut for Base&lt;T&gt; {
+    #[inline(always)]
+    fn deref_mut(&amp;mut self) -&gt; &amp;mut T {
+        &amp;mut self.ext
+    }
+}
+然后 Derived 可以直接：trait Derived : &#8217;static + Sized {
+    fn foobar(self: &amp;mut Base&lt;Self&gt;);
+}
+
+struct DerivedImpl {
+}
+
+impl Derived for DerivedImpl {
+    fn foobar(self: &amp;mut Base&lt;Self&gt;) {
+        self.bar();  // !!!!!
+        println!(&quot;foobar!&quot;);
+    }
+}</code></pre>
+
+<p>多了 &#8217;static + Sized，但也可以接受。</p>
+
+<ol type="2">
+<li>
+<p><a href='https://github.com/rust-lang/rust/issues/53667'>let_chains_2</a>，啥也不说了，羡慕 Swift。</p>
+</li>
+
+<li>
+<p>标准库里面有很多 unstable 的函数，经常会一用上来发现还是 unstable 需要开 feature。自己的项目随便开开倒是无所谓，但生产环境必定要谨慎的多。希望能够尽快 stable，比如 drain_filter。</p>
+</li>
+</ol>
+
+<p>longfangsong:</p>
+
+<pre><code class="language-`">链接：https://www.zhihu.com/question/438833112/answer/1674659637
+来源：知乎
+著作权归作者所有。商业转载请联系作者获得授权，非商业转载请注明出处。    </code></pre>
+
+<p>其他答主说的已经很好了，尤其是语言设计上的（GAT什么的大家都久等了），我再补充几点：</p>
+
+<p>语言设计：</p>
+
+<ol type="1">
+<li>看Rust Internals的时候看到的一个感觉有点意思的idea：更细粒度的unsafe。</li>
+
+<li>看到前面有人说的enumerate variant as type，我想要的一个和这个比较像的一个糖是 Typescript 那样的 (untagged) union type，目前我习惯是用enum_dispatch crate来部分模拟这个特性。</li>
+</ol>
+
+<p>工具方面的：</p>
+
+<ol type="1">
+<li>IDE支持，CLion 现在index不了编译时生成的代码（即使开了RA也一样）。vsc可以但是RA有时会莫名其妙地hang住。</li>
+
+<li>能不能修修<code>cargo</code> 的 <code>[patch]</code> 只认repo的url而不管rev的问题，即<code>cargo#7497</code></li>
+
+<li>求编译能再快一点……编译产物能再多复用一点……</li>
+</ol>
+
+<p>社区建设方面：</p>
+
+<ol type="1">
+<li>现在感觉很多还没有入门rust的人都被它“传言中”的难度吓到了，实际上rust也就是一门普通的语言，可能所有权检查、强制性的线程安全这些特性确实是别的语言没有的，但掌握这些特性其实也不比掌握指针之类的概念困难，还有其实很多看着很长很可怕的写法（<code>Option&lt;Rc&lt;RefCell&gt;&gt;&gt;</code>）虽然第一眼看上去劝退实际上却更合理更可读（分离了是否可空、是否多个所有者、是否可变三个关注点，相比其他某些语言一个指针走天下其实更容易分析）。其实宣传的时候可以更多的去给新人一种rust并不难的印象，可以更好地壮大社区。</li>
+
+<li>有没有入口可以给rust foundation捐钱啊（x</li>
+</ol>
+
+<p>还有很多回答，可以去知乎查看。</p>
+
+<h2 id=''></h2>
+
+<p>还有很多精彩的问题等待你的探索和回答：</p>
+
+<ul>
+<li><a href='https://www.zhihu.com/question/31644802'>Rust相较于Haskell除了效率还有何优势？</a></li>
+
+<li><a href='https://www.zhihu.com/question/30407715'>如何看待 Rust 的应用前景？</a></li>
+
+<li><a href='https://www.zhihu.com/question/442315024'>写 wasm 项目选 C++ 还是 Rust？</a></li>
+
+<li><a href='https://www.zhihu.com/question/400001723'>学Rust之前，是不是应该先学C++？</a></li>
+
+<li><a href='https://www.zhihu.com/question/424290703'>学习Rust, 可以绕开C语言吗?</a></li>
+
+<li><a href='https://www.zhihu.com/question/344733952'>在中国有多少开发者使用Rust编程语言？</a></li>
+
+<li><a href='https://www.zhihu.com/question/308540043'>只学过 C 语言适合学 Rust 吗？</a></li>
+
+<li><a href='https://www.zhihu.com/question/30511494'>GitHub 上有哪些值得关注的 Rust 项目？</a></li>
+
+<li><a href='https://www.zhihu.com/question/31038569'>如何开始学习 Rust 语言?</a></li>
+
+<li><a href='https://www.zhihu.com/question/34665842'>学习Rust适合写什么练手项目？</a></li>
+
+<li><a href='https://www.zhihu.com/question/352420716'>Rust程序员都做什么项目？</a></li>
+
+<li><a href='https://www.zhihu.com/question/441960256'>本科毕业论文想写点 Rust 语言相关的内容，什么样的题目比较好？</a></li>
+
+<li><a href='https://www.zhihu.com/question/30408031'>我应该放弃 C++，学习 Rust 吗？</a></li>
+</ul>
+]]></content:encoded></item><item><title>华为 | 可信编程 -- 华为引领Rust语言开发的实践和愿景</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/huawei_rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='华为_|_可信编程_--_华为引领rust语言开发的实践和愿景'>华为 | 可信编程 -- 华为引领Rust语言开发的实践和愿景</h1>
+
+<p>作者：（俞一峻、Amanieu d&#8217;Antras、Nghi D. Q. Bui） / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='本文结构'>本文结构</h2>
+
+<ul>
+<li>
+<p>可信编程 -- 华为引领 Rust 语言开发的实践和愿景</p>
+
+<ul>
+<li>Rust带来的创新</li>
+
+<li>Rust在华为的初步推进</li>
+
+<li>华为对 Rust 社区的贡献</li>
+
+<li>配置华为的端到端 Rust 工具链</li>
+
+<li>tokei</li>
+
+<li>cargo-geiger</li>
+
+<li>通过深度代码学习研究 Rust</li>
+
+<li>结论</li>
+</ul>
+</li>
+</ul>
+
+<h2 id='rust带来的创新'>Rust带来的创新</h2>
+
+<p>StackOverflow 的调查表明, 自 2015 年以来，Rust 一直是开发者最爱的编程语言。</p>
+
+<p><img src='./huawei_rust/1-RustConChina2020-yu-v42.png' alt='img' /></p>
+
+<p>学术界对于Rust也越来越重视，在编程语言和软件工程顶会上发表的关于Rust的论文正逐年增加。</p>
+
+<p><img src='./huawei_rust/2-RustConChina2020-yu-v43.png' alt='img' /></p>
+
+<p>不仅如此，《自然》杂志2020年尾的文章《Why Scientists are Turning to Rust》中也强调：科学家极为推崇Rust。</p>
+
+<p><img src='./huawei_rust/3-RustConChina2020-yu-v41.png' alt='img' /></p>
+
+<h2 id='rust在华为的初步推进'>Rust在华为的初步推进</h2>
+
+<p>华为的目标是引领通信系统软件向安全可信演进，其中 Rust 语言正在发挥很大的作用。</p>
+
+<p>例如，我们希望通过部分 C/C++ 代码的迁移，在保证高性能的同时，拥有更高的安全性。在此过程中， 我们为开发者提供一套自动化工具支持：基于开源的 C2Rust 转译工具， 首先从 C 代码生成 Rust 代码, 然后通过源到源变换工具自动重构。</p>
+
+<p>在华为内部我们还基于 Actor 的并发编程模式开发了 Rust 库，方便程序员充分利用 Rust的语言特性, 例如<code>async/await</code>等。</p>
+
+<p>以华为代表的通信系统软件的开发以 C/C++ 代码为主, 这些 Rust 库将使 C/C++ 到 Rust 的迁移更加顺畅。 作为业界领先公司和 Rust基金会 的创始成员，华为致力于 Rust 在通信软件行业，并将持续为 Rust 社区做出贡献。</p>
+
+<h2 id='华为对rust社区的贡献'>华为对Rust社区的贡献</h2>
+
+<p>我们为 Rust 社区贡献了许多重要的功能特性。例如，我们最近为 Rust 编译器提交了一系列代码，使得 Rust 编译目标可以支持<code>ARM AArch64 32</code>位大端变体<a href='https://developer.arm.com/documentation/dai0490/latest/'>ILP32</a>芯片组, 用于我们的通信产品中。 这些改进使得我们和友商可以在这些常用网络硬件架构上执行Rust 原生程序。这些代码已经通过我们的 Rust 专家<code>Amanieu d&#8217;Antras</code> 提交给了 <a href='https://reviews.llvm.org/rG21bfd068b32ece1c6fbc912208e7cd1782a8c3fc'>LLVM 编译器</a>, <a href='https://github.com/rust-lang/libc/pull/2039'>libc 库</a>, 以及 <a href='https://github.com/rust-lang/rust/pull/81455'>Rust 编译器</a>等开源社区。</p>
+
+<p>这些对 Rust 编译器的更改引入了新的端到端交叉编译目标，针对定制硬件构建 Rust 产品变得更容易,只需要简单的命令，比如：</p>
+
+<pre><code class="language-`rust">cargo build --target aarch64_be-unknown-linux-gnu
+cargo build --target aarch64-unknown-linux-gnu_ilp32
+cargo build --target aarch64_be-unknown-linux-gnu_ilp32</code></pre>
+
+<p>华为在中国 Rust 社区方面也走在前列，战略支持 12月26日至27日 在 深圳 举办了<a href='https://2020conf.rustcc.cn/'>第一届 Rust China Conf 大会</a>，并推行多项 社区活动，包括为中国的开发者提供 Rust教程 和 Rust编码规范。</p>
+
+<h2 id='配置华为的端到端rust工具链'>配置华为的端到端Rust工具链</h2>
+
+<p>Rust社区中有几种端到端的工具，我们已经开始从开发人员和工具的交互中获取信息。</p>
+
+<p>这里有一些例子:</p>
+
+<p><strong>tokei</strong></p>
+
+<p>由于可信编程项目通常涉及多个编程语言，我们采用了tokei作为多语言代码复杂性度量工具，识别多达200种编程语言。例如，开源的 Fuchhia 项目涉及了多种编程语言，下面的统计信息显示有多少行不同语种的代码：</p>
+
+<p><img src='./huawei_rust/4-RustConChina2020-yu-v49.png' alt='img' /></p>
+
+<p>C、C++、Rust 代码在 Fuchhia 项目的占比，可以绘制成如下演进图：</p>
+
+<p><img src='./huawei_rust/5-RustConChina2020-yu-v410.png' alt='img' /></p>
+
+<p>为了在大型项目中满足处理多种编程语言的场景需求，我们提交代码到tokei支持识别编程语言的批处理。</p>
+
+<p><strong>cargo-geiger</strong></p>
+
+<p>为了提高安全性，我们经常想知道有多少代码已经被 Rust 编译器检查过。幸运的是，通过统计&quot;Unsafe&quot;项目，如<code>fn</code>、<code>expr</code>，<code>struct</code>、<code>impl</code>、<code>trait</code>及其在各相关库实现中的出现次数， <a href='https://github.com/rust-secure-code/cargo-geiger'>cargo-geiger</a>几乎做到了这点。</p>
+
+<p><img src='./huawei_rust/6-RustConChina2020-yu-v411.png' alt='img' /></p>
+
+<p>不过，统计数字中并没有反映安全性，所以没办法展现Rust项目总体上取得了多少进展的比例。因此，我们 提交了<a href='https://github.com/rust-secure-code/cargo-geiger/pull/167'>代码</a>，在改进的 cargo-geiger 计数器报告中提供 Rust 项目的安全检查比率。这个代码采纳后，我们的产品团队现在每天定期都在使用这个工具，一份典型的报告能够更容易理解哪些代码库还没被 Rust 编译器完全检查到。</p>
+
+<p><img src='./huawei_rust/7-RustConChina2020-yu-v412.png' alt='img' /></p>
+
+<h2 id='通过深度代码学习研究_rust'>通过深度代码学习研究 Rust</h2>
+
+<p>随着 Rust 开源社区代码的发展和革新，初学者需要学习掌握Rust最佳的实践，其包括但不限于 Rust 语言本身。把统计机器学习的方法应用到源代码数据上，也称为<a href='https://arxiv.org/abs/1709.06182'>大代码</a>，正被全世界的软件工程研究团队关注：类似于 图像处理和自然语言处理中的机器学习问题，这些问题都需要通过深度神经网络(deep neural networks DNN)提取大量的特征，Big Code 可能同样需要去训练DNN来反映程序的统计特性，所以也称为&quot;深度代码学习&quot;。</p>
+
+<p>在这方面，华为与<a href='https://mcs.open.ac.uk/yy66'>英国开放大学</a>和<a href='http://www.mysmu.edu/faculty/lxjiang/'>新加坡管理大学</a>进行技术合作，在现在最先进的“跨语言”深度代码学习基础上进行优化研究。</p>
+
+<p>例如，最初的深度代码学习方法应用于北京大学编程课程收集到的104个算法类的5.2万个C/C++程序。对此数据集，树基卷积神经网络(TBCNN)算法分类准确率达到94%(<a href='https://github.com/bdqnghi/tbcnn.tensorflow'>AAAI&#8217;16</a>)。最近的 SOTA 在语句级使用抽象语法树 (<a href='https://github.com/zhangj111/astnn'>ICSE &#8217;19</a>)准确率达到98%。近期我们同英国开放大学和新加坡管理大学在树基胶囊网络的合作研究进展推动了SOTA进一步提高，达到98.4%的准确率(<a href='https://arxiv.org/abs/2009.09777'>AAAI&#8217;21</a>)。</p>
+
+<p>早些时候我们已经使用跨语言的数据集表明，对一种编程语言的深度代码学习模型也适用于另一种编程语言。例如，从GitHub 爬取的数据集 Rosetta Code，从 Java 到 C 语言，可以获得86%的算法分类准确度 (<a href='https://github.com/bdqnghi/bi-tbcnn'>SANER&#8217;19</a>)，在Java到C#的跨语言API映射 问题也能发挥重要作用(ESEC/FSE&#8217;19)。这些统计语言模型在软件工程中可以应用于很多方面，比如代码分类、代码搜索、代码推荐、代码摘要、方法名称预测、代码克隆检测等等(<a href='https://github.com/bdqnghi/infercode'>ICSE&#8217;21</a>)。</p>
+
+<p>为了进一步研究分析 Rust 项目，我们向 Rust 解析器项目<code>tree-sitter</code>和 XML序列化 <code>quick-xml</code>等项目提交了代码，通过 Rust 程序的抽象语法树来训练深度代码学习模型。研究的初步结果很有希望，算法检测任务在 Rust代码上的精度高达85.5%。随着工具链的改进，这个比例还有望进一步提升。</p>
+
+<p>在 IDE 上的原型是在<code>Visual Studio Code IDE</code>上，我们开发扩展插件，使得程序员可以得到合适的算法推荐和可解释性的帮助。</p>
+
+<p><img src='./huawei_rust/8-RustConChina2020-yu-v414.png' alt='img' /></p>
+
+<h2 id='结论'>结论</h2>
+
+<p>综上所述，华为可信开源软件工程实验室正在开展的 Rust 工作为程序员提供智能化端到端 IDE 工具链，以期最大限度地提高代码的安全性和性能。走向可信编程远景的旅程刚刚开始，我们希望与 Rust社区 和 Rust基金会深度合作，引领电信软件产业的可信革新。</p>
+
+<h2 id=''></h2>
+
+<p>作者简介：</p>
+
+<p>俞一峻： 可信编程首席专家/华为可信软件工程开源实验室/华为爱尔兰研究所</p>
+
+<p>Amanieu d&#8217;Antras: 可信编程首席专家/华为可信软件工程开源实验室/华为爱尔兰研究所</p>
+
+<p>Nghi D. Q. Bui: 可信编程首席专家/华为可信软件工程开源实验室/华为爱尔兰研究所</p>
+]]></content:encoded></item><item><title>PingCAP | TiKV 高性能追踪的实现解析</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_trace.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='pingcap_|_tikv_高性能追踪的实现解析'>PingCAP | TiKV 高性能追踪的实现解析</h1>
+
+<p>作者：钟镇炽 / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='前言'>前言</h2>
+
+<p>本文为  PingCAP Observability 团队研发工程师钟镇炽在 Rust China Conf 2020 大会上所做演讲 《高性能 Rust tracing 库设计》的更详细文本，介绍了对性能要求非常苛刻的分布式 KV 数据库 TiKV 如何以不到 5% 的性能影响实现所有请求的耗时追踪 。另可点击 https://www.bilibili.com/video/BV1Yy4y1e7zR?p=22 查看演讲视频。</p>
+
+<h2 id='背景'>背景</h2>
+
+<p>系统的可观测性 (Observability) 通常由三个维度组成：日志 (Logging)、指标 (Metrics) 和追踪 (Tracing)，它们之间的关系如下：</p>
+
+<p><img src='./rust_trace/1.png' alt='1' /></p>
+
+<ul>
+<li>日志：离散的错误信息和状态信息。</li>
+
+<li>指标：记录和呈现可聚合的数据。</li>
+
+<li>追踪：单个请求的一系列事件。</li>
+</ul>
+
+<p>TiKV 实现了完备的日志和指标系统，但缺失了追踪，导致在诊断 TiKV 和 TiDB 问题时会遇到以下困难：</p>
+
+<ul>
+<li><strong>观测数据之间的没有关联</strong>：只有熟悉请求链路上每个操作对应什么监控指标的同学才能完整追溯和诊断问题。</li>
+
+<li><strong>请求抖动难以追溯</strong>：TiKV 节点往往同时处理不同模式的业务，零星请求的性能抖动无法体现在 AVG / P99 / MAX 等监控指标中，从而无法诊断抖动原因。</li>
+</ul>
+
+<p><strong>追踪可以有效解决上述场景中遇到的问题</strong>。以下详细介绍 TiKV 中高性能追踪的实现。追踪功能在 TiKV 中尚为实验性特性，需要特定代码分支开启，感兴趣的同学可以关注 GitHub issue <a href='https://github.com/tikv/tikv/pull/8981'>Introduce tracing framework (#8981)</a>。</p>
+
+<h3 id='基本概念'>基本概念</h3>
+
+<p>追踪（Trace）呈现系统中的一个请求的执行路径。例如追踪一个 SQL 语句从 TiDB 到 TiKV 的执行全过程后可以得到下图：</p>
+
+<p><img src='./rust_trace/2.png' alt='2' /></p>
+
+<p>从图中可以直观看到 SQL 语句<code>“INSERT INTO</code>t<code>VALUES (1), (2), (3);” </code>有趣的信息：</p>
+
+<ul>
+<li>TiDB 处理这个请求时依次进行了 compile、plan、execute 三个步骤</li>
+
+<li>TiDB 在 execute 阶段调用了 TiKV 的 Prewrite RPC 和 Commit RPC</li>
+
+<li>请求共耗时 5ms</li>
+</ul>
+
+<p>图中每个方框代表一个事件，称之为 Span。每个 Span 包含：</p>
+
+<ul>
+<li>事件名称</li>
+
+<li>事件起始时间戳和结束时间戳</li>
+</ul>
+
+<p>Span 之间有层级，可以构成父子关系或先后关系，如下图所示：</p>
+
+<p><img src='./rust_trace/3.png' alt='3' /></p>
+
+<h2 id='实现'>实现</h2>
+
+<p>&gt; &gt; 本文所有性能测试结果，若特别说明测试环境，均在以下平台完成： &gt; &gt; CPU: Intel Core i7-8700 &gt; Linux distros: Ubuntu 20.04 &gt; Linux kernel: 5.4 &gt; Memory: 32G &gt; Disk: NVMe SSD</p>
+
+<p>TiKV 使用 Rust 编写。Rust 生态中有几个现成的追踪库，分别是 <a href='https://github.com/tokio-rs/tracing'>tokio-tracing</a>, <a href='https://github.com/sile/rustracing'>rustracing</a> 和 <a href='https://github.com/open-telemetry/opentelemetry-rust'>open-telemetry</a>，它们都兼容 <a href='https://opentracing.io/specification/'>OpenTracing 规范</a>，但<strong>性能不够理想</strong>，引入后会降低 TiKV 50% 以上性能。<strong>TiKV 目前的实现能将性能的影响控制在 5% 以内</strong>。这主要来自于<strong>单个 Span 追踪收集仅耗时 <code>20ns</code></strong>：</p>
+
+<p><img src='./rust_trace/4.png' alt='4' /></p>
+
+<p>以下具体介绍 TiKV 如何在 <code>20ns</code> 内完成单个 Span 追踪和收集。</p>
+
+<h3 id='计时'>计时</h3>
+
+<p>计时在追踪中是高频操作，每个 Span 都需要取两次时间戳，分别代表事件的起始和结束时刻，因此计时的性能会很大程度上影响追踪的性能。</p>
+
+<p>追踪库采用的计时方式通常需要能满足以下要求：</p>
+
+<ul>
+<li>获取的时间戳单调递增</li>
+
+<li>高性能</li>
+
+<li>高精度</li>
+</ul>
+
+<h4 id='std::instant'>std::Instant</h4>
+
+<p>Rust 原生提供以下两种计时方式：</p>
+
+<ul>
+<li><code>std::SystemTime::now()</code></li>
+
+<li><code>std::Instant::now()</code></li>
+</ul>
+
+<p>其中第一种方式获取的是当前系统时间，它可能受用户手动调整、NTP 服务修正等原因的影响，获取到的时间戳并不提供单调递增的保证，因此不能采用。</p>
+
+<p>大多数 Rust 社区的追踪库采取了第二种方式，可以取得单调递增的、纳秒精度的时间戳。但它的性能不够理想，取两次时间需要 <code>50ns</code>，这是社区追踪库性能较低的原因之一。</p>
+
+<h4 id='coarse_time'>Coarse Time</h4>
+
+<p>若仅从高性能的角度出发来寻找计时方案，可使用 Coarse Time，<strong>它牺牲了一定的精度换取高性能</strong>。在 Linux 环境下，以 <code>CLOCK_MONOTONIC_COARSE</code> 作为时间源参数，通过 <code>clock_gettime</code> 系统调用可获取 Coarse Time。Rust 社区也提供了库 <a href='https://docs.rs/coarsetime/0.1.18/coarsetime/'>coarsetime</a> 获取 Coarse Time：</p>
+
+<pre><code class="language-`rust">coarsetime::Instant::now()</code></pre>
+
+<p>Coarse Time 性能很高，在测试环境下完成两次调用仅需要 <code>10ns</code>。它的精度取决于 Linux 的 jiffies 配置，默认精度为 <code>4ms</code>。</p>
+
+<p>低精度的计时对于短耗时请求的追踪会产生让人困惑的结果。如下图所示，从观测的角度来看已经损失了相当一部分的细节信息：</p>
+
+<p><img src='./rust_trace/5.png' alt='5' /></p>
+
+<p>当然<strong>在多数情况下，Coarse Time 仍是快速计时的首选</strong>。一方面是它在 Linux 系统下开箱即用，获取方便。另一方面，<code>4ms</code> 精度对大部分应用来说是可以接受的。</p>
+
+<p>尽管如此，作为追踪功能的开发者，我们不希望限制用户的场景，例如对于 KvGet 请求，<code>4ms</code> 在要求高的场景中已足够作为异常的抖动需要追溯了，因此<strong>有必要支持微秒乃至纳秒级别精度的追踪</strong>。同时，性能作为核心出发点，也不能被牺牲掉。幸运的是，这个问题是有解的，它便是接下来要介绍的 TSC。</p>
+
+<h4 id='tsc'>TSC</h4>
+
+<p>TiKV 采用 Time Stamp Counter (TSC) 寄存器进行高精度高性能计时。TSC 寄存器在现代 x86 架构的 CPU 中已经存在很久了，最早可以追溯到 2003 年推出的奔腾处理器。它记录了 CPU 供电重设后到当前时刻所经过的 CPU 时钟周期数。在 CPU 时钟周期速率相同的条件下，经过测量和换算即可用于高精度计时。</p>
+
+<p><strong>TSC 可以同时满足单调递增、高精度和高性能的需求</strong>。在我们的测试环境中取两次 TSC 仅需 <code>15ns</code>。在实际情况中，随着处理器的不断发展，TSC 寄存器积累了相当多历史遗留问题会对其正确性造成影响，需要修正。</p>
+
+<p><strong>TSC 速率</strong></p>
+
+<p>TSC 递增速率由 CPU 频率决定。<strong>现代化 CPU 可能会动态调节频率节省能耗，导致 TSC 递增速率不稳定</strong>：</p>
+
+<p><img src='./rust_trace/6.png' alt='6' /></p>
+
+<p>另外，<strong>一些 CPU 在休眠状态时不会递增 TSC</strong>：</p>
+
+<p><img src='./rust_trace/7.png' alt='7' /></p>
+
+<p><strong>比较现代的 x86 架构 CPU 提供了特性确保 TSC 递增速率的稳定性</strong>。在 Linux 下可以通过 <code>/proc/cpuinfo</code> 中的 CPU flag 来检查 TSC 速率是否稳定：</p>
+
+<ul>
+<li>constant_tsc: TSC 将以固定的额定标称频率而非瞬时频率递增</li>
+
+<li>nonstop_tsc: TSC 在 CPU 休眠状态下仍持续递增</li>
+</ul>
+
+<p>以上 TSC 速率的稳定性保证<strong>仅对单个 CPU 核心有效</strong>，在多核情况下还需处理 TSC 同步问题。</p>
+
+<p><strong>TSC 多核同步</strong></p>
+
+<p>x86 架构 CPU <strong>没有提供 TSC 寄存器在所有核心上的一致性保证</strong>，这会导致计时存在问题。下图展示了某台 2020 年生产的搭载了当时最新 x64 CPU 的笔记本上 TSC 测量情况。可以看到，16 个核心中有一个核心 CPU 0 的 TSC 值存在偏差。</p>
+
+<p><img src='./rust_trace/8.png' alt='8' /></p>
+
+<p>在追踪中，完整的计时操作会读取两次时间戳，分别代表事件的始末。由于操作系统的线程调度，这两个时间戳的读取可能发生在不同的核心上。若我们简单地以 TSC 值差值进行计时，会<strong>在多核 TSC 不同步的情况下造成耗时计算的偏差</strong>。</p>
+
+<p>举个例子：</p>
+
+<ol type="1">
+<li>t1 时刻，线程在 Core 1 上运行，读取了较大的 tsc1</li>
+
+<li>操作系统将线程从 Core 1 调度至 Core 2</li>
+
+<li>t2 时刻，线程在 Core 2 上运行，读取了较小的 tsc2</li>
+</ol>
+
+<p><img src='./rust_trace/9.png' alt='9' /></p>
+
+<p>此时计算的 TSC 差值甚至成为了负数，无法换算为耗时。</p>
+
+<p>为了解决这个问题，<strong>TiKV 会同步各个核心的原始 TSC 值，计算出 TSC 值在各个核心的偏移量</strong>，使用同步过后的 TSC 值用于计算耗时。具体算法为在各个核心上任取两次 TSC 和物理时间，以物理时间作为 x 轴、核心上的 TSC 作为 y 轴计算截距，差值即为各个核心的 TSC 偏移，如下图所示：</p>
+
+<p><img src='./rust_trace/10.png' alt='10' /></p>
+
+<p>在计算初始 TSC 偏移时，<strong>需要确保取两次 TSC 的过程全都同一核心上执行</strong>。在 Linux 中可以通过系统调用 <code>sched_setaffinity</code> 设置线程的亲核性，将线程固定到某个核心上运行：</p>
+
+<pre><code class="language-`rust">fn set_affinity(cpuid: usize) -&gt; Result&lt;(), Error&gt; {
+   use libc::{cpu_set_t, sched_setaffinity, CPU_SET};
+   use std::mem::{size_of, zeroed};
+ 
+   let mut set = unsafe { zeroed::&lt;cpu_set_t&gt;() };
+   unsafe { CPU_SET(cpuid, &amp;mut set) };
+ 
+   // Set the current thread&#8217;s core affinity.
+   if unsafe {
+       sched_setaffinity(
+           0, // Defaults to current thread
+           size_of::&lt;cpu_set_t&gt;(),
+           &amp;set as *const _,
+       )
+   } != 0
+   {
+       Err(std::io::Error::last_os_error().into())
+   } else {
+       Ok(())
+   }
+}</code></pre>
+
+<p>有了各个核心的 TSC 偏移值后，在计时阶段只需获取当前执行线程所在的 CPU 及 TSC 值，即可计算出同步后的 TSC 值。需要注意的是，当前执行所在的 CPU 及当前的 TSC 值需要在一条指令中同时获取，避免其中插入操作系统的线程调度导致计算错误。这<strong>可以通过 RDTSCP 指令实现</strong>。它可以帮助我们原子性地获取原始 TSC 值和 CPU ID。</p>
+
+<p>Rust 代码如下：</p>
+
+<pre><code class="language-`rust">#[cfg(any(target_arch = &quot;x86&quot;, target_arch = &quot;x86_64&quot;))]
+fn tsc_with_cpuid() -&gt; (u64, usize) {
+   #[cfg(target_arch = &quot;x86&quot;)]
+   use core::arch::x86::__rdtscp;
+   #[cfg(target_arch = &quot;x86_64&quot;)]
+   use core::arch::x86_64::__rdtscp;
+ 
+   let mut aux = std::mem::MaybeUninit::&lt;u32&gt;::uninit();
+   let tsc = unsafe { __rdtscp(aux.as_mut_ptr()) };
+   let aux = unsafe { aux.assume_init() };
+ 
+   // IA32_TSC_AUX are encoded by Linux kernel as follow format:
+   //
+   // 31       12 11      0
+   // [ node id ][ cpu id ]
+   (tsc, (aux &amp; 0xfff) as usize)
+}</code></pre>
+
+<p>上文描述的高精度计时的逻辑已经提取成一个独立的 Rust 社区库 <a href='https://github.com/zhongzc/minstant.git'>minstant</a>，可供相似需求的其他项目直接使用。</p>
+
+<h3 id='span_收集'>Span 收集</h3>
+
+<p>Span 可能在各个线程上产生，最终要收集起来汇聚成一个追踪，因此需要跨线程的 Span 收集机制。<strong>Span 的收集也是追踪库的一个常见性能瓶颈点</strong>。</p>
+
+<p>一般有以下方式进行线程安全的 Span 收集：</p>
+
+<ul>
+<li><code>Arc&lt;Mutex&lt;Vec&lt;Span&gt;&gt;&gt;</code></li>
+
+<li><code>std::sync::mpsc::Receiver&lt;Span&gt;</code></li>
+
+<li><code>crossbeam::channel::Receiver&lt;Span&gt;</code></li>
+</ul>
+
+<p>这几种常见的收集方式中 crossbeam channel 是最优的，发送和收集一次 Span 的耗时约为 40ns。为了在提升性能，TiKV 采用了与上述不同的方式收集 Span：同一线程上 Span 仅<strong>在线程本地无竞争地收集</strong>、最终汇集各个线程上已经<strong>收集好的一批 Span 到全局收集器</strong>。</p>
+
+<h4 id='local_span'>Local Span</h4>
+
+<p>TiKV 为每个线程维护一个线程本地结构 LocalSpanLine，负责 LocalSpan 的产生和存储。再由另外一个线程本地结构 LocalCollector，负责驱动 LocalSpanLine 和收集 LocalSpan。这三者之间的关系和各自的职责如下图。</p>
+
+<p><img src='./rust_trace/11.png' alt='11' /></p>
+
+<p>由于 LocalSpan、LocalSpanLine 和 LocalCollector 均是线程本地的，它们之间的交互均<strong>不需要线程间的同步和互斥，也不会破坏内存缓存，因此性能极高</strong>。LocalSpan 的收集是简单的 <code>Vec::push</code> 操作，平均耗费仅为 <code>4ns</code>。</p>
+
+<p>另外，在构造 Span 依赖关系时，利用线程本地的特性可以很方便地实现<strong>隐式上下文</strong>的机制，<strong>用户无需修改函数签名来手动传递追踪上下文</strong>，大大降低了对现有代码的侵入性。</p>
+
+<p>下面我们来深入了解关于 LocalSpan 产生和收集的实现细节。</p>
+
+<p>首先，LocalSpanLine 维护了一个容器 SpanQueue，用于装载正在进行的或者已经完成的 LocalSpan。“正在进行”意味着 LocalSpan 所指示的事件开始时间已知，而结束时间未知。这些 LocalSpan 均存储在 SpanQueue 内部的 Vec 结构。</p>
+
+<p>除此之外，上文提到我们利用隐式上下文来构造 LocalSpan 之间的父子依赖关系，这个过程实际上依赖于 SpanQueue 维护的一个变量 <code>next_parent_id</code>。</p>
+
+<p>接下来我们将通过一些例子对整个过程进行更为详细的展开。</p>
+
+<p>假设这样一个 foo 事件，于 <code>09:00</code> 产生，持续至 <code>09:03</code>：</p>
+
+<pre><code class="language-`rust">09:00  foo +
+09:01      |
+09:02      |
+09:03      +</code></pre>
+
+<p>初始状态下，SpanQueue 为空，<code>next_parent_id</code> 记为 root。那么在 foo 发生的时刻，即 09:00，SpanQueue 会去完成以下几个步骤：</p>
+
+<ul>
+<li>新增一条记录，填写事件名称 foo，起始时间 09:00，留空结束时间</li>
+
+<li>将 <code>next_parent_id</code> 的值赋给 foo 的 parent</li>
+
+<li>将 <code>next_parent_id</code> 更新为 foo</li>
+
+<li>向外部返回 <code>index</code> 的值 0，用以接收事件结束的通知，进而完成后续结束时间的回填</li>
+</ul>
+
+<p><img src='./rust_trace/12.png' alt='12' /></p>
+
+<p>在 foo 结束的时刻，即 <code>09:03</code>，用户提交 <code>index</code>，向 SpanQueue 通知 foo 事件结束，于是 SpanQueue 开始回填工作：</p>
+
+<ul>
+<li>通过 <code>index</code> 索引到 foo 事件所在记录</li>
+
+<li>将结束时间回填为 <code>09:03</code></li>
+
+<li>将 <code>next_parent_id</code> 更新为该记录的 <code>parent</code></li>
+</ul>
+
+<p><img src='./rust_trace/13.png' alt='13' /></p>
+
+<p>以上的例子描述了单个事件的记录过程，很简单也很有效。而实际上多个事件的记录也仅仅只是上述过程的重复。比如下面的过程，foo 事件包含了两个子事件：bar 和 baz。</p>
+
+<pre><code class="language-`rust">09:00  foo +
+09:01      | bar +
+09:02      |     |
+09:03      |     +
+09:04      |
+09:05      | baz +
+09:06      |     |
+09:07      |     +
+09:08      +</code></pre>
+
+<p>正如上文所述，SpanQueue 除了记录各个事件的起始和结束时间，还需要记录各个事件之间的父子依赖关系。这个例子中，foo 发生时 SpanQueue 的存储内容和上文没有区别。而在 bar 发生时，SpanQueue 设置 bar 的 parent 为当前的 <code>next_parent_id</code> 值，即 foo，同时将 <code>next_parent_id</code> 更新为 bar：</p>
+
+<p><img src='./rust_trace/14.png' alt='14' /></p>
+
+<p>在 bar 结束时，会按照上面提到的回填步骤，更新 bar 记录的结束时间以及 <code>next_parent_id</code> 变量：</p>
+
+<p><img src='./rust_trace/15.png' alt='15' /></p>
+
+<p>重复以上步骤，最终 SpanQueue 以一种高效的方式，完整记录了这三个事件的信息：</p>
+
+<p><img src='./rust_trace/16.png' alt='16' /> <img src='./rust_trace/17.png' alt='17' /></p>
+
+<p>将这些记录串连起来，最终形成如下的 Trace 树状结构：</p>
+
+<p><img src='./rust_trace/18.png' alt='18' /></p>
+
+<h4 id='normal_span'>Normal Span</h4>
+
+<p>虽然 LocalSpan 的记录比较高效，但是由于其本身基于线程本地的实现方式，使得灵活性不足。比如在异步场景下，一些 Span 的产生和结束发生在不同的线程，线程本地的实现就不再能发挥作用。</p>
+
+<p>针对上述问题，TiKV 保留了前文最开始所描述的线程安全的 Span 记录方式，即采用 crossbeam channel 每次进行单个 Span 的收集，这样的 Span 下文称之为 NormalSpan。</p>
+
+<p>从实现的角度看，NormalSpan 的信息不会记录在线程本地的容器当中，而是由相应的变量自行维护，以便于跨线程的移动。同时，NormalSpan 之间的父子关系不再由线程本地隐式构建，而需由用户手动指定。</p>
+
+<p>但是，NormalSpan 和 LocalSpan 并非完全隔离，TiKV 通过以下的交互方式将这两者联系起来：从 LocalCollector 收集而来的一组 LocalSpan，可以挂载在 NormalSpan 上作为子树，如下图所示。同时，挂载的数量不受限制，通过允许进行多对多的挂载方式，TiKV 在一定程度上支持了对 batch 场景的追踪，这是社区中大部分追踪库没有覆盖到的。</p>
+
+<p><img src='./rust_trace/19.png' alt='19' /></p>
+
+<p>上述实现方式形成了 Span 收集的快慢两条路径。它们共同合作，完成对某个请求的执行路径信息的记录：</p>
+
+<ul>
+<li>LocalSpan 不可跨越线程但记录高效，通过批量收集 LocalSpan 然后挂载至普通 Span 的方式，让追踪的开销变得非常低。</li>
+
+<li>普通 Span 的记录相对较慢，不过它可以跨线程传递，使用起来比较灵活。</li>
+</ul>
+
+<h2 id='使用方法'>使用方法</h2>
+
+<p><strong>TiKV 中的高性能追踪的逻辑已提取成一个独立的库</strong> <a href='https://github.com/tikv/minitrace-rust'>minitrace-rust</a>，可直接在各种项目中使用，步骤如下：</p>
+
+<ul>
+<li>请求到达时，创建对应根 Span；</li>
+
+<li>请求执行路径上，使用 minitrace-rust 提供的接口记录事件的发生；</li>
+
+<li>请求完成时，收集执行路径上产生的所有 Span。</li>
+</ul>
+
+<h3 id='根_span_的创建和收集'>根 Span 的创建和收集</h3>
+
+<p>一般在一个请求开始的时候可以创建根 Span。在 minitrace-rust 中用法如下：</p>
+
+<pre><code class="language-`rust">for req in listener.incoming() {
+   let (root_span, collector) = Span::root(&quot;http request&quot;);
+   let guard = root_span.enter();
+   my_request_handler(req);
+}</code></pre>
+
+<p>Span 基于 Guard 实现了自动在作用域结束后结束 Span，而无需手工标记 Span 的终止。除了返回根 Span 外，<code>Span::root(event)</code>  还返回了一个 <code>Collector</code>。 <code>Collector</code> 与根 Span 一一对应。在请求完成时，可调用 <code>Collector</code> 的 <code>collect</code> 方法，从而完成对执行路径上产生的所有 Span 的收集。如下所示。</p>
+
+<pre><code class="language-`rust">let (root_span, collector) = Span::root(&quot;http request&quot;);
+let guard = root_span.enter();
+ 
+handle_http_request(req);
+ 
+drop((guard, root_span));
+let spans = collector.collect();</code></pre>
+
+<h3 id='事件记录'>事件记录</h3>
+
+<p>比较推荐使用 minitrace-rust 提供的 <code>trace</code> 和 <code>trace_async</code> 宏进行函数级别的事件记录。通过上述方式为单个函数记录的执行信息如下：</p>
+
+<ol type="1">
+<li>调用的发生时刻</li>
+
+<li>调用的返回时刻</li>
+
+<li>直接（或间接）调用者的引用</li>
+
+<li>直接（或间接）调用的子函数的引用</li>
+</ol>
+
+<p>例如，追踪两个同步函数 <code>foo</code> 和 <code>bar</code>，通过添加 <code>trace(event)</code> 作为这两个函数的 attribute，即可记录函数的执行信息。如下所示。</p>
+
+<pre><code class="language-`rust">#[trace(&quot;foo&quot;)]
+fn foo() -&gt; u32 {
+   bar();
+   42
+}
+ 
+#[trace(&quot;bar&quot;)]
+fn bar() { }</code></pre>
+
+<p>最终记录下来的信息，包括这两个函数各自的起始和完成时刻，以及函数调用关系：<code>foo</code> 调用了 <code>bar</code>。</p>
+
+<p><img src='./rust_trace/20.png' alt='20' /></p>
+
+<p>对于异步函数的记录，步骤略有不同。首先须将 <code>trace</code> 替换成 <code>trace_async</code>，如下所示。</p>
+
+<pre><code class="language-`rust">#[trace_async(&quot;foo async&quot;)]
+async fn foo_aysnc() -&gt; u32 {
+   bar_async().await;
+   42
+}
+ 
+#[trace_async(&quot;bar async&quot;)]
+async fn bar_async() {
+   yield_now().await;
+}</code></pre>
+
+<p>另外还需要关键的一步：将 Task 用 minitrace-rust 提供的 Future 适配器 <code>in_span</code> 进行包装，从而将该 Future 与某个 Span 绑定起来。</p>
+
+<p>Task，在 Rust 异步语境中，特指被 spawn 至某个 executor 的 Future，也称根 Future。例如以下的 <code>foo_async</code> 就是一个 Task：</p>
+
+<pre><code class="language-`rust">executor::spawn(
+   foo_async()
+);</code></pre>
+
+<p>假设要追踪 <code>foo_async</code> 这样一个 Task，并且与一个由 <code>Span::from_local_parent(event)</code> 创建的 Span 进行绑定，那么，相关的应用代码将如下所示。</p>
+
+<pre><code class="language-`rust">executor::spawn(
+   foo_async().in_span(Span::from_local_parent(&quot;Task: foo_async&quot;))
+);</code></pre>
+
+<p>下图为该 Task 追踪的结果：</p>
+
+<p><img src='./rust_trace/21.png' alt='21' /></p>
+
+<h2 id='结语'>结语</h2>
+
+<p>TiKV 作为底层 KV 数据库，对其增加观测性功能天然有着与普通业务程序完全不一样的性能要求，非常具有挑战性。除了追踪以外，TiKV 及其上层 SQL 数据库 TiDB 也还有其他富有挑战性的观测性需求。PingCAP 的 Observability 团队专注于这类观测难题的解决与功能实现，感兴趣的同学可投递简历到 <a href='mailto:hire@pingcap.com'>hire@pingcap.com</a> 加入我们，或加入 Slack channel <a href='https://slack.tidb.io/invite?team=tidb-community&amp;channel=sig-diagnosis&amp;ref=tracing'>\#sig-diagnosis</a> 参与技术讨论。</p>
+]]></content:encoded></item><item><title>蚂蚁集团 CeresDB 团队 | 关于 Rust 错误处理的思考</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_error_handle.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='蚂蚁集团_ceresdb_团队_|_关于_rust_错误处理的思考'>蚂蚁集团 CeresDB 团队 | 关于 Rust 错误处理的思考</h1>
+
+<p>作者：evenyag / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>错误处理并非一件容易的事情，尽管在使用 Rust 时，有编译器不厌其烦地督促我们，基本不存在漏掉错误不处理的情况了，但这并不意味着错误处理这件事情变简单了。这里也记录一下我使用 Rust 一段时间后，对于错误处理的一些思考，包含大量主观看法，欢迎读者拍砖。</p>
+
+<h2 id='不可恢复错误和可恢复错误'>不可恢复错误和可恢复错误</h2>
+
+<p>使用 Rust 的人都知道， Rust 错误处理的手段主要分为两种，对于不可恢复的错误（unrecoverable error），可以通过 panic 来直接中断程序的执行，而对于可恢复的错误（recoverable error），一般会返回 Result 。至于什么时候使用 panic ，什么时候使用 Result ，官方提供了一些指导意见，很多文章对这块都有讨论，相信不少人在这上面是能达成共识的，因此本文在这块也不做过多展开。</p>
+
+<p>错误处理中最麻烦的，还是处理可恢复的错误。</p>
+
+<h2 id='error_类型'>Error 类型</h2>
+
+<p>在进行错误处理，首先，你得把自己 Error 类型给定义了。我认为，对于一个新项目来说，定义好自己的 Error 类型甚至是属于最先要做的几件事情之一。即便一开始不做，等到你写到了第一个 Result 时，你也不得不考虑了。定义 Error 类型是一个可简单，可复杂的事情，毕竟在 <code>Result&lt;T, E&gt;</code> 里，<code>E</code> 其实可以塞任何东西。如果你胆子够大，甚至可以直接把 String 作为 Error 来使用，还能带上一定的错误信息。</p>
+
+<pre><code class="language-`rust">fn make_string_err() -&gt; Result&lt;(), String&gt; {
+    Err(format!(&quot;Oh, string is not {}&quot;, 1))
+}
+
+fn string_err_example() -&gt; Result&lt;(), String&gt; {
+    make_string_err()?;
+    Ok(())
+}</code></pre>
+
+<p>String 甚至可以转为来使用 <code>Box&lt;dyn Error&gt;</code></p>
+
+<pre><code class="language-`rust">fn string_box_err() -&gt; Result&lt;(), Box&lt;dyn std::error::Error&gt;&gt; {
+    Err(format!(&quot;Oops, {}&quot;, 1))?;
+    Ok(())
+}</code></pre>
+
+<p>不过这种错误处理方式过于简单粗暴，而错误一旦转为了 String ，就丧失了大部分可编程性，上层想要针对某些类型的错误做针对性的处理就会变得非常困难 —— 唯一的手段估计就只剩下字符串匹配了。</p>
+
+<p>更多的时候，我们可能会想要把错误定义为一个 Enum 或者 Struct ，并实现 Error 等相关的 trait 。这是个体力活，如果你还需要处理 std 或者第三方库抛出来的 Error ，还需要手工实现一大堆 <code>From</code> 来为自己的 Error 实现相应的转换规则。这样下去，还没等 Error 类型定义完，写代码的热情就已经冷却了。</p>
+
+<p>这些工作太枯燥了，就应该交给工具库去做！而当你去找 Rust 相关的错误处理库（严格来说，可能称为错误管理或者错误定义库更合适）时，就会发现， Rust 的错误处理库也太多了，而且以后可能会更多，这对于有选择困难症的来说简直是灾难。后面我也会从早期到近期挑选出一些比较有代表性的错误处理库，谈下我对他们的理解和在错误处理上的一些看法。当然，由于不是每个库我都使用过，所以也难免理解存在偏颇，欢迎大家指正</p>
+
+<h2 id='quick-error'>quick-error</h2>
+
+<p>在我刚接触 Rust 时，市面上的错误处理库还没有现在多，或者说我对 Rust 错误处理还不如现在了解，挑选库的过程反而比较简单。由于当时 tikv 已经挺有名气了，于是我直接打开 tikv 的项目，发现它在使用 quick-error ，就决定跟着它用了。当时我的需求也很简单，就是希望有个工具库帮我把定义错误的这些 boilerplate code 给包掉，而 quick-error 也正如其名，能够比较麻利地帮我把 Error 类型定义出来。而 Rust 最早的错误处理库基本上也就只帮你干这样的事情，因此其实更像是错误定义库（如今 quick-error 也不仅仅只能帮你定义错误了，不过也是后话了）。</p>
+
+<p>例如下面就是个使用 quick-error 的例子，定义了一个 Error 类型，并且自动实现了 <code>From&lt;io::Error&gt;</code></p>
+
+<pre><code class="language-`rust">quick_error! {
+    #[derive(Debug)]
+    pub enum MyError {
+        Io(err: io::Error) {
+            from()
+            display(&quot;I/O error: {}&quot;, err)
+            source(err)
+        }
+        Other(descr: &amp;&#8217;static str) {
+            display(&quot;Error {}&quot;, descr)
+        }
+    }
+}</code></pre>
+
+<h2 id='丢失上下文'>丢失上下文</h2>
+
+<p>然而，仅仅只是把 Error 定义出来只不过是刚刚踏入了错误处理的门，甚至可以说定义 Error 也只是错误处理那一系列 boilerplate code 的一小部分而已。单纯见到错误就往上抛并不难，而且 Rust 还提供了 <code>?</code> 运算符来让你可以更爽地抛出错误，但与之相对的，直接上抛错误，就意味着丢弃了大部分错误的上下文，也会给时候定位问题带来不便。</p>
+
+<p>例如有类似下面的代码，使用了刚刚在上面定义的 Error 类型，而 eat()/drink()/work()/sleep() 中任意一个都有可能抛出 <code>io::Error</code> 的函数。那么当 daily() 出错时，你拿到的最终信息可能只是个 &quot;I/O error: failed to fill whole buffer&quot; ，而到底是哪里出的错，为什么出错了呢？不知道，因为错误来源丢失了。</p>
+
+<pre><code class="language-`rust">fn daily() -&gt; Result&lt;(), MyError&gt; {
+    eat()?;
+    drink()?;
+    work()?;
+    sleep()?;
+    Ok(())
+}</code></pre>
+
+<p>丢失错误源头这种问题在 Rust 里还是很容易发生的，也是 Rust 错误处理里较恼人的一件事。当然，很大的原因还是在于错误提供没有 backtrace （现在也尚未 stable）。为了避免出现类似的问题，遇到错误时就需要注意保存一些调用信息以及错误的现场，概况下来，就是两样东西</p>
+
+<ul>
+<li>调用栈，或者说 backtrace</li>
+
+<li>错误的上下文，如关键入参</li>
+</ul>
+
+<p>严格来说， backtrace 也属于上下文的一部分，这里分开提更多是考虑到两者在实现层面是有所区分的。有 backtrace 自然方便，但 backtrace 也并不能解决所有问题：</p>
+
+<ul>
+<li>光靠 backtrace 其实只能回答哪里出了错的问题，而回答不了为什么出错的</li>
+
+<li>一些预期内时常会抛错误的代码路径也不宜获取 backtrace</li>
+</ul>
+
+<p>反过来，通过在日志里打印或者在 Error 类型中追加上下文信息，其实是能反过来推断出调用链路的，使得排查问题不强依赖 backtrace。我在 Rust 里进行的错误处理时做得最多的事情就是，考虑这个地方适不适合打印错误日志：</p>
+
+<ul>
+<li>如果适合，打下错误日志和相关信息，继续抛错误</li>
+
+<li>
+<p>不适合，考虑错误直接抛上去了后续是否方便定位问题</p>
+
+<ul>
+<li>如果不方便，还会把 error 和上下文信息 format 下得到新的 error message ，然后产生个新的错误抛出去</li>
+</ul>
+</li>
+</ul>
+
+<p>这种方式虽说能解决问题，不过并不认为是一种最佳实践，更称不上优雅，光是打印日志和补充错误信息，就得写不少代码，更不提日志和错误信息里有不少内容可能还是相互重复的。</p>
+
+<h2 id='error-chain_和_failure'>error-chain 和 failure</h2>
+
+<p>有没有办法更方便地将错误的上下文信息放到 Error 里面呢？早期的 error-chain 库在这方面做了不少尝试，其中 <code>chaining errors</code> 模式有点类似 golang 中的 <code>errors.Wrap()</code> ，允许用户通过 <code>chain_err()</code> 将错误或者可转换为错误的类型（如 String）不断地串联起来。</p>
+
+<pre><code class="language-`rust">let res: Result&lt;()&gt; = do_something().chain_err(|| &quot;something went wrong&quot;);</code></pre>
+
+<p>除此之外，这个库还提供了 <code>ensure!</code> ， <code>bail!</code> 等工具宏以及 backtrace 功能，这些我认为对后来错误处理库的发展都是由一定启发作用的。不过 error-chain 文档里那一大坨宏定义，各种概念以及说明，对于刚接触 Rust 的人还是比较劝退的。</p>
+
+<p>到了 failure 库， <code>chain_err()</code> 的模式改为了通过 <code>context()</code> 来携带错误的上下文信息。</p>
+
+<pre><code class="language-`rust">use failure::{Error, ResultExt};
+
+fn root() -&gt; Result&lt;(), Error&gt; {
+    a().context(&quot;a failed&quot;)?;
+    b().context(&quot;b failed&quot;)?;
+    Ok(())
+}</code></pre>
+
+<p>如今错误处理库也基本沿用了 <code>context()</code> 这一 api 命名，甚至 <code>context()</code> 已经成为了 Rust 风格错误处理的一部分。</p>
+
+<p>尽管我也考虑过使用这两个库替换掉自己项目里在用的 quick-error ，不过，一旦项目变庞大后，这种替换错误处理库以及错误处理风格的工作就多少有点工作量抵不上收益了。另一方面， error-chain 和 failure 作为出现得比较早的错误处理库，更多起到探索和过渡的作用，他们当初需要解决的问题在 std 的 Error trait 的演进下，很多也都不复存在了（起码在 nightly 上是这样），因此他们的演进也基本走到尽头了。包括 failure 的开发后来也逐渐停滞，现在已经是处于 deprecated 的状态了，项目维护者也都推荐用一些更新的错误处理库。</p>
+
+<h2 id='thiserror_+_anyhow'>thiserror + anyhow</h2>
+
+<p>对于一些新的错误处理库，目前社区里较为主流的建议可能是组合使用 thiserror 和 anyhow 这两个库。其中 thiserror 可以看作是定义 Error 的一个工具，它只帮你生成一些定义 Error 的代码，别的什么都不做，相当纯粹。</p>
+
+<p>而 anyhow 则为你定义好了一个 Error 类型，基本可以看作是一个 <code>Box&lt;dyn Error&gt;</code> ，同时还提供了一些如 <code>context</code> 等扩展功能，用起来更加无脑。</p>
+
+<pre><code class="language-`rust">use anyhow::{Context, Result};
+
+fn main() -&gt; Result&lt;()&gt; {
+    ...
+    it.detach().context(&quot;Failed to detach the important thing&quot;)?;
+
+    let content = std::fs::read(path)
+        .with_context(|| format!(&quot;Failed to read instrs from {}&quot;, path))?;
+    ...
+}</code></pre>
+
+<p>除此之外， anyhow 的 Error 只占用一个指针大小的栈空间，相应的 Result 的栈空间占用也会变小，在一些<a href='https://zhuanlan.zhihu.com/p/191655266'>场景</a>下也比较有用。</p>
+
+<p>这两个库的作者 dtolnay 建议，如果你是在开发库，则用 thiserror ，而如果是开发应用则使用 anyhow 。这在实践时遇到的一个问题就是所谓库和应用的边界有时候并没有那么清晰：对一个多模块的应用来说，本质上也可以看作是由若干个库构成的，而这些模块或者&quot;库&quot;之间，也可能是有层级关系的。对于这些模块，使用 anyhow 就存在以下问题</p>
+
+<ul>
+<li>需要使用 anyhow 专门提供的 Error 类型，可能直接将 <code>anyhow::Error</code> 暴露到库的 api 上</li>
+
+<li>调用方拿到的不是明确的错误类型</li>
+
+<li>无法对 <code>anyhow::Error</code> 做 pattern match</li>
+
+<li>更近一步，应用也不保证不会有处理具体错误的需求</li>
+</ul>
+
+<p>本质上， <code>anyhow::Error</code> 库提供的 Error 类型，更类似一种 Report 类型，适合汇报错误，而不适合处理具体的错误。如果使用 thiserror ，就失去了便利的 <code>context</code> 功能，用起来相对没那么方便，而作者看上去也不打算支持这一点。总的看下来， thiserror + anyhow 的组合方案还是存在一定局限性，似乎用起来并没有那么顺手。</p>
+
+<h2 id='snafu'>snafu</h2>
+
+<p>而 snafu 的方案，则让我看到 context 也是可以和具体的 Error 类型比较优雅地结合起来。不妨看下 snafu 官方的例子</p>
+
+<pre><code class="language-`rust">use snafu::{ResultExt, Snafu};
+use std::{fs, io, path::PathBuf};
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display(&quot;Unable to read configuration from {}: {}&quot;, path.display(), source))]
+    ReadConfiguration { source: io::Error, path: PathBuf },
+
+    #[snafu(display(&quot;Unable to write result to {}: {}&quot;, path.display(), source))]
+    WriteResult { source: io::Error, path: PathBuf },
+}
+
+type Result&lt;T, E = Error&gt; = std::result::Result&lt;T, E&gt;;
+
+fn process_data() -&gt; Result&lt;()&gt; {
+    let path = &quot;config.toml&quot;;
+    let configuration = fs::read_to_string(path).context(ReadConfiguration { path })?;
+    let path = unpack_config(&amp;configuration);
+    fs::write(&amp;path, b&quot;My complex calculation&quot;).context(WriteResult { path })?;
+    Ok(())
+}
+
+fn unpack_config(data: &amp;str) -&gt; &amp;str {
+    &quot;/some/path/that/does/not/exist&quot;
+}</code></pre>
+
+<p>上面的例子就体现出 snafu 的一些特点：</p>
+
+<ul>
+<li>
+<p>基于 context selector 的 context 方案</p>
+
+<ul>
+<li>同样是 <code>io::Error</code> ， snafu 可以通过不同的 context 返回不同的 enum variant ，同时还能带上一些错误相关信息</li>
+
+<li>比起为 Error 直接实现 <code>From&lt;io::Error&gt;</code> 要更有意义，毕竟我们更希望拿到的错误告诉我是 read configuration 出错了，还是 write result 出错了，以及出错的文件 path 是哪个</li>
+
+<li>本质上是把 context 的类型也提前定义了</li>
+</ul>
+</li>
+
+<li>产生的 Error 就是我们自己定义的 Error，无需依赖 snafu 提供的 Error 类型</li>
+
+<li>这里其实还有一个隐含的好处，就是这个 Error 是可以做 pattern match 的</li>
+</ul>
+
+<p>关于 snafu 和错误处理， influxdb_iox 其实总结了一份他们错误处理的 style guide ，我觉得很有参考价值，里面也提到了 snafu 的一些<a href='https://docs.rs/snafu/0.6.10/snafu/guide/philosophy/index.html'>设计哲学</a></p>
+
+<ul>
+<li>同样的底层错误可以根据上下文不同而转换为不同的领域特定错误，例如同样是 io 错误，根据上层业务语义的不同能够转换为不同的业务错误</li>
+
+<li>在库和应用的场景下都同样好用</li>
+
+<li>模块级别的 Error 类型，每个模块都应该定义一个，甚至多个自己专用的错误类型</li>
+</ul>
+
+<p>而这些设计哲学，我认为也是错误处理里比较好的实践。其中，关于 Error 类型应该做到模块级别还是做到 crate 级别（全局），可能会有较多争议，也值得发散开来聊聊。</p>
+
+<h2 id='模块级_error_类型与全局_error_类型'>模块级 Error 类型与全局 Error 类型</h2>
+
+<p>先摆观点，我认为 Error 类型尽量做到模块级别是更好的，甚至部分函数有专门的 Error 类型也不过分，但是也要摆一个事实，那就是我自己的代码里这一点做得也还不够好。</p>
+
+<p>所以，这里还是要提一下全局 Error 类型的一些好处，起码包括</p>
+
+<ul>
+<li>方便做一套全局的错误码，而且类型参数不合法就是比较常见的错误</li>
+
+<li>不需要花太多精力定义 Error 类型，很多 enum variant 可以共用，<code>Result&lt;T, Error&gt;</code> 也只需要定义一份，，这也是全局 Error 类型最大的优势</li>
+</ul>
+
+<p>但是，全局 Error 类型也存在相应的缺陷</p>
+
+<ul>
+<li>所有用到了 Error 类型的模块，其实通过 Error 类型间接和其他模块耦合了，除非你的 Error 类型只想用 <code>anyhow::Error</code> 这样的类型</li>
+
+<li>即使来源 Error 相同，上下文也不同，定义到一个 enum variant 里面不见得合适</li>
+
+<li>更容易出现 Error 抛着抛着不知道哪来的情况</li>
+</ul>
+
+<p>而模块级的 Error 类型则看上去也更符合一个模块化的 crate 应有的设计</p>
+
+<ul>
+<li>不存在共用 Error 类型导致的间接耦合</li>
+
+<li>更加内聚，每个模块可以专心处理自己的错误， match 错误的范围也大大减少</li>
+
+<li>即使不依赖 backtrace ，错误本身也能明确反映出了层次关系和链路</li>
+</ul>
+
+<p>当然，模块级的 Error 类型也并非没有缺点，例如</p>
+
+<ul>
+<li>定义 Error 的工作会变多，做全局的错误码会麻烦些，可能需要在上层做一次转换</li>
+
+<li>模块层次过深的话，或者一些模块的 Error 字段较多，由于 Rust enum 的特点，越上层的 Error 类型就会越大（std::mem::size_of::&lt;Error&gt;()），像 snafu 同样也会有这样的问题</li>
+</ul>
+
+<h2 id='总结'>总结</h2>
+
+<p>错误处理可能不存在最佳方案一说，更多还是要结合实际场景。即便是谈到错误处理库，我要是大喊一声 snafu 是 Rust 最好的错误处理库，相信社区里肯定也会有一堆人跳出来反对我。而实际上 snafu 也存在自身的缺点，例如 Error 定义的工作量相对大（需要定义各种 context）， Error 类型体积可能会比较大等。</p>
+
+<p>总的来说，错误处理一直是一件麻烦的事。我觉得能做到错误的现场可追溯，就已经算错误处理做得不错了的。经过几年的发展， Rust 的错误处理库初步发展出了 context 和 backtrace 两种记录错误上下文的手段，同时也更加强大和易用了，但我认为目前他们尚未发展到终态，也尚未出现一个库独大的局面。如果说现在我新起个项目或者模块，需要选择一个错误处理库的话，我可能会先尝试下 snafu 。</p>
+
+<h2 id='关于我们'>关于我们</h2>
+
+<p>我们是蚂蚁智能监控技术中台的时序存储团队，我们正在使用 Rust 构建高性能、低成本并具备实时分析能力的新一代时序数据库，欢迎加入或者推荐，联系人 jiachun.fjc@antgroup.com</p>
+
+<h2 id='参考'>参考</h2>
+
+<ul>
+<li>https://blog.yoshuawuyts.com/error-handling-survey/</li>
+
+<li>https://www.ncameron.org/blog/migrating-a-crate-from-futures-0-1-to-0-3/</li>
+
+<li>https://zhuanlan.zhihu.com/p/225808164</li>
+
+<li>https://nick.groenen.me/posts/rust-error-handling/</li>
+
+<li>https://doc.rust-lang.org/book/ch09-00-error-handling.html</li>
+
+<li>https://github.com/tikv/rfcs/pull/38#discussion_r370581410</li>
+
+<li>https://github.com/shepmaster/snafu/issues/209</li>
+
+<li>https://github.com/rust-lang/project-error-handling/issues/24</li>
+
+<li>https://github.com/rust-lang/rust/issues/53487</li>
+
+<li>https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md</li>
+
+<li>https://zhuanlan.zhihu.com/p/191655266</li>
+
+<li>https://docs.rs/snafu/0.6.10/snafu/guide/philosophy/index.html</li>
+
+<li>https://doc.rust-lang.org/src/std/error.rs.html#48-153</li>
+
+<li>https://github.com/facebook/rocksdb/blob/00519187a6e495f0be0bbc666cacd9da467a6c1e/include/rocksdb/status.h#L34</li>
+
+<li>https://github.com/tailhook/quick-error/issues/22</li>
+
+<li>https://github.com/dtolnay/anyhow</li>
+
+<li>https://github.com/dtolnay/thiserror</li>
+
+<li>https://github.com/tailhook/quick-error</li>
+
+<li>https://github.com/rust-lang-nursery/failure</li>
+
+<li>https://github.com/rust-lang-nursery/error-chain</li>
+</ul>
+]]></content:encoded></item><item><title>华为 | Rust中的错误传递和日志记录</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_error_handle_and_log.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rust中的错误传递和日志记录'>Rust中的错误传递和日志记录</h1>
+
+<p>作者：楼智豪 / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='简介以及背景'>简介以及背景</h2>
+
+<p>在Rust代码的编写过程中，开发者也需要关注错误处理和日志记录的过程，程序能够及时反馈信息，保证程序的正常运行。 本文分两部分，第一部分讲述如何进行错误传递和处理，第二部分讲述应该如何记录日志。</p>
+
+<h2 id='错误处理'>错误处理</h2>
+
+<p>以前在使用C进行错误处理时，通常采用的是函数传递错误码的方式，而对于Rust而言这种方式显得有些古老。</p>
+
+<p>首先，Rust当中的错误处理基于两个特性，Result和Error。</p>
+
+<pre><code class="language-`rust">pub enum Result&lt;T, E&gt; {
+    /// Contains the success value
+    Ok(T),
+    /// Contains the error value
+    Err(E),
+}</code></pre>
+
+<p>Result是Rust提供的一个枚举类，它里面应当包含，程序成功运行时返回的值T，或者是程序运行失败时返回的错误类型E。如果一个函数，它的返回值是一个Result，那么就表明，它有可能失败并返回一个错误类型，需要我们来处理这个Result。</p>
+
+<p>Rust在标准库中提供了一个trait，<code>sdt::error::Error</code>，目前错误处理都是基于这个trait来进行，一个结构体/枚举如果实现了这个trait，那么我们认为，它就是一个错误类型。</p>
+
+<pre><code class="language-`rust">//为自定义的结构体实现Error的trait，该trait要求同时实现Display和Debug
+//Error tarit包含多个方法，但通常情况下impl的时候除了source方法其他无需重写
+pub trait Error: Debug + Display {
+    //如果该错误类型中包含了底层的错误Err，那么source方法应该返回Some(err),如果没有返回None。不重写则默认为None
+    fn source(&amp;self) -&gt; Option&lt;&amp;(dyn Error + &#8217;static)&gt;;
+    //type_id()：该方法被隐藏
+    fn type_id(&amp;self, _: private::Internal) -&gt; TypeId;
+    //backtrace()：返回发生此错误的堆栈追溯，目前为unstable，默认禁用，且占用大量内存，性能很差
+    fn backtrace(&amp;self) -&gt; Option&lt;&amp;Backtrace&gt;;
+    //description()：已废弃，改使用Display
+    fn description(&amp;self) -&gt; &amp;str;
+    //cause()：已废弃，改使用source()
+    fn cause(&amp;self) -&gt; Option&lt;&amp;dyn Error&gt;;
+}</code></pre>
+
+<p>错误传递的背景在于，在开发过程中，可能各个模块自身都定义了一个错误类型，那么当这些模块需要一起使用时，不同错误类型的结构体应该如何转换和处理，如何传递。</p>
+
+<h3 id='方式一：自定义错误类型'>方式一：自定义错误类型</h3>
+
+<ul>
+<li>自定义错误类型，并且通过From trait进行转换</li>
+
+<li>用 <code>?</code>来传递错误，自动执行类型转换</li>
+</ul>
+
+<pre><code class="language-`rust">impl Error for MyError {
+
+}
+
+/// MyError属于当前自定义的枚举，其中包含了多种错误类型
+/// MyError也包含了从下层传递而来的错误类型，统一归纳
+#[derive(Debug)]
+pub enum MyError {
+    BadSchema(String, String, String),
+    IO(io::Error),
+    Read,
+    Receive,
+    Send,
+}
+
+//实现Display
+impl fmt::Display for MyError {
+    fn fmt(&amp;self, f: &amp;mut fmt::Formatter) -&gt; fmt::Result {
+        match self {
+            MyError::BadSchema(s1, s2, s3) =&gt; {
+                write!(f, &quot;BadSchema Error:{}, {}, {}&quot;, s1, s2, s3)
+            }
+            MyError::IO(e) =&gt; {
+                write!(f, &quot;IO Error: {}&quot;, e)
+            }
+            MyError::Read =&gt; {
+                write!(f, &quot;Read Error&quot;)
+            }
+            MyError::Receive =&gt; {
+                write!(f, &quot;Receive Error&quot;)
+            }
+            MyError::Send =&gt; {
+                write!(f, &quot;Send Error&quot;)
+            }
+        }
+    }
+}</code></pre>
+
+<p>在定义MyError时，其中包括了多种错误类型，有当前模块产生的错误（比如Read, Receive, Send），也有从下层模块传递上来的错误，比如IO(io::Error)，针对从下层传递而来的这种错误，我们需要将它归纳到自己的MyError中，统一传递给上层。为了实现这个目的，我们就需要实现From 方法，当我们为一个错误类型的转换实现了From方法，就可以使用<code>?</code>来进行自动转换。如下所示</p>
+
+<pre><code class="language-`rust">impl From&lt;io::Error&gt; for MyError {
+    fn from(err: io::Error) -&gt; MyError {
+        MyError::IO(err)
+    }
+}</code></pre>
+
+<pre><code class="language-`rust">//这两个示例是相同的
+fn test_error() -&gt; Result&lt;i32, MyError&gt; {
+    let s = std::fs::read_to_string(&quot;test123.txt&quot;)?;
+    Ok(s)
+}
+
+fn test_error2() -&gt; Result&lt;String, MyError&gt; {
+    let s = match std::fs::read_to_string(&quot;test123.txt&quot;) {
+        Ok(s)=&gt;{
+            s
+        }
+        Err(e)=&gt;{
+            return Err(MyError::from(e));
+        }
+    };
+    Ok(s)
+}</code></pre>
+
+<p>注意在示例一当中<code>?</code>的作用，它等效于示例二中的match，意思是</p>
+
+<ul>
+<li>
+<p>该函数的返回值是一个<code>Result&lt;T,Error&gt;</code>，需要进行处理。</p>
+</li>
+
+<li>
+<p>如果该函数运行正确，那么返回T，上述的示例中返回String</p>
+</li>
+
+<li>
+<p>如果该函数运行失败，返回了一个错误类型Error，这里返回了io::Error， 并且因为我们实现了From方法，io::Error被自动转换成了MyError::IO(io::Error)，然后程序在此处直接return，不再继续往下走。</p>
+
+<p>注意From的类型转换是通过<code>?</code>来隐式调用的，如果不使用<code>?</code>而是直接return一个错误，它是不会自动进行类型转换的。</p>
+</li>
+</ul>
+
+<h3 id='方式二_：_使用trait_object传递错误'>方式二 ： 使用trait Object传递错误</h3>
+
+<ul>
+<li>
+<p>不定义自己的类型，而直接使用 <code>Box&lt;dyn Error&gt;</code> 来统一错误类型。</p>
+</li>
+
+<li>
+<p>用 <code>?</code>来传递错误，自动把Error转换成 <code>Box&lt;dyn Error&gt;</code></p>
+</li>
+</ul>
+
+<pre><code class="language-`rust">fn test_error() -&gt; Result&lt;i32, Box&lt;dyn Error&gt;&gt; {
+    let s = std::fs::read_to_string(&quot;test123.txt&quot;)?;
+    let n = s.trim().parse::&lt;i32&gt;()?;
+    Ok(n)
+}</code></pre>
+
+<p>在上面这个示例中，可以看到，我们返回了一个Box&lt;dyn Error&gt;，他是一个trait Object，意思是泛指一个具有Error trait的结构体/枚举类型。我们之所以可以这么写，其实是因为Rust本身为Box&lt;dyn Error&gt;实现了From方法，所以可以实现自动转换。</p>
+
+<p>上述代码中，第一行和第二行分别返回了io:Error和ParseIntError，都可以被转换成Box&lt;dyn Error&gt;。这种方式的好处在于开发者不用再一个个地去定义错误类型，编写From方法，坏处在于丢失了具体的错误类型的信息，如果要对于不同的错误类型进行不同处理，就会遇到麻烦。</p>
+
+<p>虽然Rust提供的downcast方法可以将Box&lt;dyn Error&gt;重新还原成具体的结构体，但是<code>e.downcast::&lt;MyError&gt;();</code>这种形式的调用也还是需要预先知道结构体类型，所以使用起来还是有困难。</p>
+
+<h3 id='对比'>对比</h3>
+
+<p>|方式|优点|缺点| |------|------|------| |自定义错误类型|可以统一错误类型，方便上层用户对不同的错误类型采取不同的措施|需要进行各式的类型转换，较为繁琐| |Box\&lt;dyn Error&gt;|Error可以直接透传，不需要在乎具体的类型|丢失了结构体类型信息，但是也可以通过downcast把trait object转换回具体的结构体|</p>
+
+<p>结论：综合以上两种方式的优缺点以及各方给出的意见，得出结论如下</p>
+
+<ul>
+<li>如果是编写一个库，那么最好采取方式一，因为我们需要给上层用户传递具体的错误类型，来方便他们进行处理。</li>
+
+<li>如果是编写一个完整的应用程序，所有错误都在自身内部进行处理了，不需要传递给其他人，那么可以考虑采取方式二</li>
+</ul>
+
+<h3 id='其他：第三方库'>其他：第三方库</h3>
+
+<h3 id='anyhow_：专门为错误处理设计的第三方库'>anyhow ：专门为错误处理设计的第三方库</h3>
+
+<pre><code class="language-`rust">use anyhow::Result;
+
+fn get_cluster_info() -&gt; Result&lt;ClusterMap&gt; {
+    //从std::io::Error转换成了anyhow::Error
+    let config = std::fs::read_to_string(&quot;cluster.json&quot;)?;
+    let map: ClusterMap = serde_json::from_str(&amp;config)?;
+    Ok(map)
+}</code></pre>
+
+<pre><code class="language-`rust">match root_cause.downcast_ref::&lt;DataStoreError&gt;() {
+    //从anyhow::Error转换成自定义的DataStoreError
+    Some(DataStoreError::Censored) =&gt; Ok(),
+    None =&gt; Err(error),
+}</code></pre>
+
+<p>anyhow这个库可以把用户自定义的，所有实现了<code>std::Error trait</code>的结构体，统一转换成它定义的<code>anyhow::Error</code>。这样用户在传递错误的过程中就使用的是统一的一个结构体，不用自定义各种各样的错误。</p>
+
+<p>论用法，其实anyhow和第二种trait Object方法是类似的，但是有几点不同</p>
+
+<ul>
+<li><code>anyhow::Error</code> 的错误是<code>Send</code>, <code>Sync</code> 和 <code>&#8217;static</code>的</li>
+
+<li><code>anyhow::Error</code> 保证<code>backtrace</code>方法可用，即便你的底层Error没有提供<code>backtrace</code></li>
+
+<li><code>anyhow::Error</code>是一个机器字长，而<code>Box&lt;dyn Error&gt;</code>是两个机器字长</li>
+</ul>
+
+<h3 id='thiserror_：提供便捷的派生宏的第三方库'>thiserror ：提供便捷的派生宏的第三方库</h3>
+
+<p>前面有提到，一个自定义的MyError结构体，需要实现很多内容，Error trait，Display，Debug以及各种From函数，手动编写可能较为麻烦，而thiserror这个库则提供了过程宏来简化这个过程</p>
+
+<pre><code class="language-`rust">use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DataStoreError {
+    #[error(&quot;data store disconnected&quot;)]
+    Disconnect(#[from] io::Error),
+    #[error(&quot;the data for key `{0}` is not available&quot;)]
+    Redaction(String),
+    #[error(&quot;invalid header (expected {expected:?}, found {found:?})&quot;)]
+    InvalidHeader {
+        expected: String,
+        found: String,
+    },
+    #[error(&quot;unknown data store error&quot;)]
+    Unknown,
+    #[error(&quot;Utf data store error&quot;)]
+    Utf{
+        #[from]
+        source: Utf8Error,
+        backtrace: Backtrace
+    },
+    #[error(transparent)]
+    Other(#[from] anyhow::Error)
+}</code></pre>
+
+<ul>
+<li>
+<p>在我们自定义的结构体前加上<code>#[derive(Error)]</code>，就可以自动impl Error</p>
+</li>
+
+<li>
+<p><code>#[error(&quot;invalid header (expected {expected:?}, found {found:?})&quot;)]</code>这条语句代表如何实现Display，后面的字符串就代表Display会输出的字符，同时支持格式化参数，比如这条语句里的expected就是代表结构体里面的元素。如果是元组则可以通过<code>.0</code>或者<code>.1</code>的方式来表示元素</p>
+</li>
+
+<li>
+<p><code>#[from]</code>表示会自动实现From方法，将对应的子错误进行转换</p>
+
+<ul>
+<li><code>#[from]</code>有两种写法，第一种就是<code>Disconnect(#[from] io::Error)</code>这样，自动将<code>io::Error</code>转换成<code>DataStoreError::Disconnect</code>，简单的结构体嵌套</li>
+
+<li>第二种写法是<code>Utf { #[from] source: Utf8Error, backtrace: Backtrace }</code>这种，这种格式有且只能有两个字段，<code>source</code>和<code>backtrace</code>，不能有其他字段。它会自动将<code>Utf8Error</code>转换成<code>DtaStoreError::Utf</code>，并且自动捕获原错误中的<code>backtrace</code>方法</li>
+</ul>
+</li>
+
+<li>
+<p><code>#[source]</code>表示将这个结构体字段的值作为<code>source</code>方法的返回值，如果字段本身的名称就是<code>source</code>的话就不用加<code>#[source]</code>而会自动应用。而<code>backtrace</code>方法则会自动寻找结构体里类型为<code>std::backtrace::Backtrace</code>的字段来作为返回值。</p>
+
+<pre><code class="language-`rust">#[derive(Error, Debug)]
+pub struct MyError {
+  msg: String,
+  #[source]  // optional if field name is `source`
+  source: anyhow::Error,
+  backtrace: Backtrace,  // automatically detected
+}</code></pre>
+</li>
+
+<li>
+<p><code>#[error(transparent)]</code>表示将源错误的<code>source</code>方法和<code>Display</code>方法不加修改直接应用到<code>DataStoreError::Other</code></p>
+</li>
+</ul>
+
+<h2 id='日志记录'>日志记录</h2>
+
+<h3 id='log库'><a href='https://crates.io/crates/log'>log库</a></h3>
+
+<pre><code class="language-`rust">error!(target: &quot;yak_events&quot;, &quot;Commencing yak shaving for {:?}&quot;, yak);
+// target默认为当前crate的名称
+warn!( &quot;hello world&quot;);
+info!( &quot;hello world&quot;);
+debug!( &quot;hello world&quot;);
+trace!( &quot;hello world&quot;);</code></pre>
+
+<ul>
+<li>记录当前crate的名字、文件名路径、行号、文本信息</li>
+</ul>
+
+<p><strong>日志门面库</strong></p>
+
+<p>通过定义统一的接口，使用统一的日志记录方式，可以在多个日志框架中灵活切换，可以让开发者不必关心底层的日志系统。如果你是Rust库的开发者，自然不期望自己的框架绑定某个具体日志库，而是只使用log门面日志库，由使用者自行决定日志库。</p>
+
+<p>&lt;pre class=&quot;mermaid&quot;&gt;graph TD</p>
+
+<pre><code>应用程序--&amp;gt;log
+log--&amp;gt;具体的日志系统
+具体的日志系统--&amp;gt;env_logger
+具体的日志系统--&amp;gt;pretty_env_logger
+具体的日志系统--&amp;gt;log4rs
+具体的日志系统--&amp;gt;slog-stdlog
+具体的日志系统--&amp;gt;...</code></pre>
+
+<p>&lt;/pre&gt;</p>
+
+<pre><code class="language-`rust">struct SimpleLogger {};
+
+impl log::Log for SimpleLogger {};
+
+log::set_logger(SimpleLogger);</code></pre>
+
+<p>使用方式：调用set_logger方法绑定底层的日志系统，然后用户只需调用error!、log!这几个宏，其余的如何写入日志的问题则交给系统自己去做。</p>
+
+<h3 id='开源库如何记录日志'>开源库如何记录日志</h3>
+
+<p>下面列出了一些开源库使用了什么日志工具，以及它们是如何记录日志的。</p>
+
+<p>可以得到结论，绝大部分开源库都在使用log这个日志门面库，而且日志记录的方式，通常是直接写入字符串信息，以及调用Error的Display方法进行写入。</p>
+
+<ul>
+<li>
+<p><a href='https://github.com/ivanceras/diwata'>ivanceras / diwata</a> —用于PostgreSQL的数据库管理工具 ： 使用log库</p>
+
+<pre><code class="language-`rust">debug!(&quot;ERROR: {} ({})&quot;, msg, status);</code></pre>
+</li>
+
+<li>
+<p><a href='https://community.chef.io/products/chef-habitat/'>habitat</a>—由<a href='https://www.chef.io/'>Chef</a>创建的用于构建，部署和管理应用程序的工具：使用log库</p>
+
+<pre><code class="language-`rust">match server::run(args) {
+    Err(err) =&gt; {
+        error!(&quot;Launcher exiting with 1 due to err: {}&quot;, err);
+        process::exit(1);
+    }
+    Ok(code) =&gt; {
+        let level = if code == 0 { Level::Info } else { Level::Error };
+        log!(level, &quot;Launcher exiting with code {}&quot;, code);
+        process::exit(code);
+    }
+} </code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/changlan/kytan'>kytan</a> —高性能对等VPN ：使用log库</p>
+
+<pre><code class="language-`rust">warn!(&quot;Invalid message {:?} from {}&quot;, msg, addr);</code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/servo/servo'>Servo</a> —原型Web浏览器引擎 :  使用log库和gstreamer库</p>
+
+<pre><code class="language-`rust">gst_element_error!(src, CoreError::Failed, [&quot;Failed to get memory&quot;]);
+// 引用C动态库，采取错误码方式传递u32</code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/wez/wezterm'>wezterm</a> — GPU加速的跨平台终端仿真器和多路复用器 ：使用log库</p>
+
+<pre><code class="language-`rust">log::error!(&quot;not an ioerror in stream_decode: {:?}&quot;, err);</code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/nicohman/eidolon'>nicohman / eidolon</a> —适用于linux和macosx的无Steam和drm的游戏注册表和启动器：使用log库</p>
+
+<pre><code class="language-`rust">error!(&quot;Could not remove game. Error: {}&quot;, res.err().unwrap());</code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/tokio-rs/mio'>Mio</a> - Mio是一个用于Rust的，快速的底层I/O库：使用log库</p>
+
+<pre><code class="language-`rust">if let Err(err) = syscall!(close(self.kq)) {
+          error!(&quot;error closing kqueue: {}&quot;, err);
+      }</code></pre>
+</li>
+
+<li>
+<p><a href='https://github.com/alacritty/alacritty'>Alacritty</a> —跨平台，GPU增强的终端仿真器：使用log库</p>
+
+<pre><code class="language-`rust">if let Err(err) = run(window_event_loop, config, options) {
+      error!(&quot;Alacritty encountered an unrecoverable error:\n\n\t{}\n&quot;, err);
+      std::process::exit(1);
+  }</code></pre>
+</li>
+
+<li>
+<p>最后，关于Error的Display方法具体应当输出什么内容，这里可以参考<code>std::io::Error</code>的内容（这里的<code>io::Error</code>并不是一个trait，而是一个实现了<code>std::error::Error</code>的trait的具体类型，是一个结构体）</p>
+
+<pre><code class="language-`rust">impl ErrorKind {
+pub(crate) fn as_str(&amp;self) -&gt; &amp;&#8217;static str {
+    match *self {
+        ErrorKind::NotFound =&gt; &quot;entity not found&quot;,
+        ErrorKind::PermissionDenied =&gt; &quot;permission denied&quot;,
+        ErrorKind::ConnectionRefused =&gt; &quot;connection refused&quot;,
+        ErrorKind::ConnectionReset =&gt; &quot;connection reset&quot;,
+        ErrorKind::ConnectionAborted =&gt; &quot;connection aborted&quot;,
+        ErrorKind::NotConnected =&gt; &quot;not connected&quot;,
+        ErrorKind::AddrInUse =&gt; &quot;address in use&quot;,
+        ErrorKind::AddrNotAvailable =&gt; &quot;address not available&quot;,
+        ErrorKind::BrokenPipe =&gt; &quot;broken pipe&quot;,
+        ErrorKind::AlreadyExists =&gt; &quot;entity already exists&quot;,
+        ErrorKind::WouldBlock =&gt; &quot;operation would block&quot;,
+        ErrorKind::InvalidInput =&gt; &quot;invalid input parameter&quot;,
+        ErrorKind::InvalidData =&gt; &quot;invalid data&quot;,
+        ErrorKind::TimedOut =&gt; &quot;timed out&quot;,
+        ErrorKind::WriteZero =&gt; &quot;write zero&quot;,
+        ErrorKind::Interrupted =&gt; &quot;operation interrupted&quot;,
+        ErrorKind::Other =&gt; &quot;other os error&quot;,
+        ErrorKind::UnexpectedEof =&gt; &quot;unexpected end of file&quot;,
+    }
+}
+}</code></pre>
+</li>
+</ul>
+
+<h3 id='slog库：结构化日志'>slog库：结构化日志</h3>
+
+<p>这里还要提到一个库，slog，意为structured log，结构化日志。前面提到的日志都是非结构化日志，直接记录一段话，没有具体的格式。如果程序的日志数量比较小，那么非结构化日志是可以满足要求的，如果日志的数量很大，那么非结构化的日志就会带来诸多问题，就比如，格式多种多样，难以进行查询和解析。</p>
+
+<p>何为结构化日志，就是具有明确具体结构的日志记录形式，最主要的是具有key-value的键值对的形式，典型的是使用json来记录日志，一个json条目就是一条日记，每个字段就是一个键值对。</p>
+
+<pre><code class="language-`rust">debug!(log, &quot;Here is message&quot;; key1 =&gt; value1, key2 =&gt; value2);</code></pre>
+
+<pre><code class="language-`json">//传统的非结构化日志
+DEBUG 2018-02-05 02:00:45.541 [file:src/main.rs][line:43] CPU OVerload in location 100,ThreadId is 123456,MemoryUsage is 0,ThreadId is 234567,MemoryUsage is 0
+
+//结构化日志
+{
+    &quot;Timestamp&quot;: &quot;2018-02-05 02:00:45.541&quot;,
+    &quot;Severity&quot;: &quot;Debug&quot;,
+    &quot;File&quot;: &quot;src/main.rs&quot;,
+    &quot;Line&quot;: &quot;43&quot;,
+    &quot;Message&quot;: &quot;Memory overflow&quot;,
+    &quot;Info&quot;: {
+        &quot;ThreadId&quot;: &quot;123456&quot;,
+        &quot;MemoryUsage&quot;: &quot;0&quot;,
+        &quot;ThreadId&quot;: &quot;234567&quot;,
+        &quot;MemoryUsage&quot;: &quot;0&quot;,
+    }
+}</code></pre>
+
+<p>日志是维测能力的一个重要方面，也是调试的重要工具。 传统上非结构化的字符串，很难进行后续的二次分析，日志的相关处理也很麻烦。目前结构化日志日趋流行，使用结构化日志，使日志文件具有机器可读性和更高级的功能，以易于解析的结构化格式编写日志文件。这意味着日志分析工具可以轻松地获取结构化日志数据，这也使处理和查询日志更容易，并且分析日志更快，针对特定的条目进行过滤和跟踪分析。</p>
+
+<p>非结构化的日志查询，往往就是搜索关键字，速度慢，准确性差，容易查询出其他不相关的内容，效率低下。而目前的许多json分析工具，支持使用sql语言对条目进行查询；<a href='https://cloud.google.com/logging/docs/view/logs-viewer-interface'>Google Cloud</a>的提供的结构化日志的服务还内置了日志解析工具，提供图形化界面解析日志，定义了日志查询语言来进行查询。</p>
+
+<p>最后，结构化日志可以帮助降低日志的存储成本，因为大多数存储系统上，结构化的键值数据比非结构化的字符串有更高的压缩率。</p>
+
+<h2 id=''></h2>
+
+<p>作者介绍：</p>
+
+<p>楼智豪</p>
+
+<p>任职于华为技术有限公司嵌入式软件能力中心，本文章仅代表作者个人观点，不代表公司意见。</p>
+]]></content:encoded></item><item><title>新年新人新气象 | Rust 学习笔记</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_study.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='新年新人新气象_|_rust_学习笔记'>新年新人新气象 | Rust 学习笔记</h1>
+
+<p>作者：李大狗（李骜华）/ 后期编辑： 张汉东</p>
+
+<h2 id=''></h2>
+
+<p>&gt; &gt; <strong>本系列所有源码：</strong> &gt; &gt; https://github.com/leeduckgo/Rust-Study</p>
+
+<h2 id='新年新目标'>新年新目标</h2>
+
+<p>打算在 2021 年学习一门新的编程语言，Rust 是一个很好的标的，一方面它及其具备实用性；另一个方面它也能让我们在更高的层面上理解计算机。</p>
+
+<p>本系列将是我从Rust小学生开始的Rust学习过程全记录。</p>
+
+<p>话不多说，我们开整。</p>
+
+<p>由于是一门新的语言（相对 Java），所以传统的到网上去找一本好的入门教材的方法失效了。</p>
+
+<p>那我们就来康康 Rust 能做什么有趣的事情，有什么有趣的Repo。</p>
+
+<p>Substrate（Polkadot公链）、Libra（Facebook链）、WeDPR（FISCO BCOS 隐私保护组件）都是用 Rust 写的，不过评估一下，这些 Repo 的难度太高了，不适合用来作为语言入门。</p>
+
+<p>后来发现 Rust 在 WebAssembly 方面目前进展很不错：</p>
+
+<p>&gt; &gt; WebAssembly是一种新的编码方式，可以在现代的网络浏览器中运行 － 它是一种低级的类汇编语言，具有紧凑的二进制格式，可以接近原生的性能运行，并为诸如C / C ++等语言提供一个编译目标，以便它们可以在Web上运行。它也被设计为可以与JavaScript共存，允许两者一起工作。 &gt; &gt; ## 简而言之 &gt; &gt; 对于网络平台而言，WebAssembly具有巨大的意义——它提供了一条途径，以使得以各种语言编写的代码都可以以接近原生的速度在Web中运行。在这种情况下，以前无法以此方式运行的客户端软件都将可以运行在Web中。</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml3h1uij30w00mi41a.jpg' alt='image-20210212094819556' /></p>
+
+<p>所以，Rust 的学习路线就这么定下来了，从wasm开始！</p>
+
+<h2 id='检索实例'>检索实例</h2>
+
+<p>既然确定了目标，那么可以开始检索相应的实例。这个实例有两个条件：</p>
+
+<ul>
+<li>光有文章是不行的，必须配套相应的的源码</li>
+
+<li>这个源码必须足够简洁，适合用来入门</li>
+</ul>
+
+<p>经过一番检索，最后找到了这个：</p>
+
+<p>&gt; &gt; 项目代码： &gt; &gt; https://github.com/RodionChachura/rust-js-snake-game/ &gt; &gt; 运行地址： &gt; &gt; https://rodionchachura.github.io/rust-js-snake-game/ &gt; &gt; 教程地址： &gt; &gt; https://geekrodion.com/blog/rustsnake</p>
+
+<p>git clone 下来，运行了试试，的确可以。</p>
+
+<p>但感觉不是我想要的，因为前端代码的内容太多了。</p>
+
+<p>然后打开官方教程：</p>
+
+<p>&gt; &gt; https://developer.mozilla.org/zh-CN/docs/WebAssembly/Rust<em>to</em>wasm</p>
+
+<p>看到：</p>
+
+<p>&gt; &gt; Rust 和 WebAssembly 有两大主要用例： &gt; &gt; * 构建完整应用 —— 整个 Web 应用都基于 Rust 开发！ &gt; * 构建应用的组成部分 —— 在现存的 JavaScript 前端中使用 Rust。 &gt; &gt; 目前，Rust 团队正专注于第二种用例，因此我们也将着重介绍它。对于第一种用例，可以参阅 <code>yew</code> 这类项目。</p>
+
+<p>Yep，感觉我需要的是<code>yew</code>！</p>
+
+<h2 id='yew_的探索之旅'>Yew 的探索之旅</h2>
+
+<p>首先找到 <code>yew</code>的官网：</p>
+
+<p>&gt; &gt; <strong>Yew</strong> is a modern Rust framework for creating multi-threaded front-end web apps with WebAssembly. &gt; &gt; https://github.com/yewstack/yew</p>
+
+<p>找到它官方的例子：</p>
+
+<p>&gt; &gt; https://yew.rs/docs/zh-CN/getting-started/build-a-sample-app</p>
+
+<p>结果，运行报错……</p>
+
+<pre><code class="language-`">cargo-web is not compatible with web-sys.</code></pre>
+
+<p>遇到问题，第一时间，当然是到官方Repo里去检索啦，然后就搜到这么一条 Issue：</p>
+
+<p>&gt; &gt; https://github.com/yewstack/yew/issues/1081</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml07drdj30x60u0tf8.jpg' alt='image-20210212102606760' /></p>
+
+<p>建议使用 trunk，妥~</p>
+
+<h2 id='trunk_的探索之旅'>Trunk 的探索之旅</h2>
+
+<p>跳转到 Trunk Repo：</p>
+
+<p>&gt; &gt; https://github.com/thedodd/trunk</p>
+
+<p>发现里面有examples，于是直接 clone 下来运行：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzmkyp56nj315m020mxd.jpg' alt='image-20210212103935572' /></p>
+
+<p>执行没问题，很好！</p>
+
+<p>但是只有一个简单的实例，没法基于这个进行学习，怎么办？</p>
+
+<p>我们回到 yew 的 Repo 里面，看下有没啥实例。</p>
+
+<p>&gt; &gt; https://github.com/yewstack/yew/tree/master/examples</p>
+
+<p>Examples 很多，也都能跑通，赞：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzmky3r5lj31160u0k06.jpg' alt='image-20210212104228167' /></p>
+
+<h2 id='魔改出_base64_encoder！'>魔改出 Base64 Encoder！</h2>
+
+<p>在入门一个新的计算机技术的时候，千万不要一开始就从0到1！因为从0到1的难度对新手来说太高。最开始应该先去魔改一个已有的项目。</p>
+
+<p>我选择的是todomvc，原始是长这样：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml3vu1zj310q0hydhg.jpg' alt='image-20210212104717518' /></p>
+
+<p>目的是把它修改成一个 Base64-Encoder：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzmkz5c6mj30yi0bc75c.jpg' alt='image-20210212104823485' /></p>
+
+<p>Ok，那我们来看看原始代码：</p>
+
+<pre><code class="language-`rust">......
+    fn view(&amp;self) -&gt; Html {
+        let hidden_class = if self.state.entries.is_empty() {
+            &quot;hidden&quot;
+        } else {
+            &quot;&quot;
+        };
+        html! {
+            &lt;div class=&quot;todomvc-wrapper&quot;&gt;
+                &lt;section class=&quot;todoapp&quot;&gt;
+                    &lt;header class=&quot;header&quot;&gt;
+                        &lt;h1&gt;{ &quot;todos&quot; }&lt;/h1&gt;
+                        { self.view_input() }
+                    &lt;/header&gt;
+                    &lt;section class=classes!(&quot;main&quot;, hidden_class)&gt;
+                        &lt;input
+                            type=&quot;checkbox&quot;
+                            class=&quot;toggle-all&quot;
+                            id=&quot;toggle-all&quot;
+                            checked=self.state.is_all_completed()
+                            onclick=self.link.callback(|_| Msg::ToggleAll)
+                        /&gt;
+                        &lt;label for=&quot;toggle-all&quot; /&gt;
+                        &lt;ul class=&quot;todo-list&quot;&gt;
+                            { for self.state.entries.iter().filter(|e| self.state.filter.fits(e)).enumerate().map(|e| self.view_entry(e)) }
+                        &lt;/ul&gt;
+                    &lt;/section&gt;
+                    &lt;footer class=classes!(&quot;footer&quot;, hidden_class)&gt;
+                        &lt;span class=&quot;todo-count&quot;&gt;
+                            &lt;strong&gt;{ self.state.total() }&lt;/strong&gt;
+                            { &quot; item(s) left&quot; }
+                        &lt;/span&gt;
+                        &lt;ul class=&quot;filters&quot;&gt;
+                            { for Filter::iter().map(|flt| self.view_filter(flt)) }
+                        &lt;/ul&gt;
+                        &lt;button class=&quot;clear-completed&quot; onclick=self.link.callback(|_| Msg::ClearCompleted)&gt;
+                            { format!(&quot;Clear completed ({})&quot;, self.state.total_completed()) }
+                        &lt;/button&gt;
+                    &lt;/footer&gt;
+                &lt;/section&gt;
+                &lt;footer class=&quot;info&quot;&gt;
+                    &lt;p&gt;{ &quot;Double-click to edit a todo&quot; }&lt;/p&gt;
+                    &lt;p&gt;{ &quot;Written by &quot; }&lt;a href=&quot;https://github.com/DenisKolodin/&quot; target=&quot;_blank&quot;&gt;{ &quot;Denis Kolodin&quot; }&lt;/a&gt;&lt;/p&gt;
+                    &lt;p&gt;{ &quot;Part of &quot; }&lt;a href=&quot;http://todomvc.com/&quot; target=&quot;_blank&quot;&gt;{ &quot;TodoMVC&quot; }&lt;/a&gt;&lt;/p&gt;
+                &lt;/footer&gt;
+            &lt;/div&gt;
+        }
+    }
+}
+......</code></pre>
+
+<p>挺好，这个就是前端部分了，我们把它删减一下：</p>
+
+<pre><code class="language-`rust">    fn view(&amp;self) -&gt; Html {
+        let hidden_class = if self.state.entries.is_empty() {
+            &quot;hidden&quot;
+        } else {
+            &quot;&quot;
+        };
+        html! {
+            &lt;div class=&quot;todomvc-wrapper&quot;&gt;
+                &lt;h1&gt;{ &quot;encode/decode&quot; }&lt;/h1&gt;
+                { self.view_input() }
+                &lt;section class=classes!(&quot;main&quot;, hidden_class)&gt;
+                    &lt;ul class=&quot;todo-list&quot;&gt;
+                        { for self.state.entries.iter().filter(|e| self.state.filter.fits(e)).enumerate().map(|e| self.view_entry(e)) }
+                    &lt;/ul&gt;
+                &lt;/section&gt;
+            &lt;/div&gt;
+        }
+    }</code></pre>
+
+<p>我们可以看到，输入的逻辑在<code>view_input()</code>这个地方，于是我们找到那个函数：</p>
+
+<pre><code class="language-`rust">fn view_input(&amp;self) -&gt; Html {
+        html! {
+            // You can use standard Rust comments. One line:
+            // &lt;li&gt;&lt;/li&gt;
+            &lt;input
+                class=&quot;new-todo&quot;
+          			// 改掉replaceholder
+                placeholder=&quot;What needs to be encode/decode?&quot;
+                value=&amp;self.state.value
+                oninput=self.link.callback(|e: InputData| Msg::Update(e.value))
+                onkeypress=self.link.batch_callback(|e: KeyboardEvent| {
+                    if e.key() == &quot;Enter&quot; { Some(Msg::Add) } else { None }
+                })
+            /&gt;
+            /* Or multiline:
+            &lt;ul&gt;
+                &lt;li&gt;&lt;/li&gt;
+            &lt;/ul&gt;
+            */
+        }
+    }</code></pre>
+
+<p>再找到<code>Msg::Add</code>：</p>
+
+<pre><code class="language-`rust">fn update(&amp;mut self, msg: Self::Message) -&gt; ShouldRender {
+        match msg {
+            Msg::Add =&gt; {
+                //info!(&quot;add things&quot;);
+                let description = self.state.value.trim();
+                let description_handled = format!(&quot;{}: {}&quot;, description, encode(description.to_string()));
+
+                if !description.is_empty() {
+                    let entry = Entry {
+                        description: description_handled,
+                        completed: false,
+                        editing: false,
+                    };
+                    //info!(&quot;{}&quot;, entry.description);
+                    self.state.entries.push(entry);
+                }
+                self.state.value = &quot;&quot;.to_string();
+            }
+......</code></pre>
+
+<p>这个时候，我想先调试一下，因此需要把一些数据打印出来。</p>
+
+<p>这个时候，首先想到的是<code>print</code>大法：</p>
+
+<pre><code class="language-`rust">println!(&quot;Input: {}&quot;, val);</code></pre>
+
+<p>但是，在<code>trunk serve</code>命令中，<code>println!</code>这个函数失效了！</p>
+
+<p>在<code>trunk</code>和<code>yew</code>的 Repo 中进行检索，均未找到解决方案。</p>
+
+<p>但是随即发现<code>yew</code>有 Discord Chatroom，于是乎进去搜索聊天记录。</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml4by57j311q0qmgpg.jpg' alt='image-20210212105847278' /></p>
+
+<p>Yummy，这里提到只要使用wasm-logger即可。</p>
+
+<p>&gt; &gt; https://crates.io/crates/wasm-logger</p>
+
+<p>在项目里添加<code>wasm-logger</code>：</p>
+
+<pre><code class="language-`rust">......
+// in the first of main.rs
+#[macro_use] extern crate log;
+......
+fn main() {
+		// init wasm logger!
+    wasm_logger::init(wasm_logger::Config::default());
+    yew::start_app::&lt;Model&gt;();
+}</code></pre>
+
+<p>调用试试看：</p>
+
+<pre><code class="language-`rust">fn update(&amp;mut self, msg: Self::Message) -&gt; ShouldRender {
+        match msg {
+            Msg::Add =&gt; {
+                info!(&quot;add things&quot;);
+......</code></pre>
+
+<p>妥了！</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml2kyvrj31ga0oo0vx.jpg' alt='image-20210212110203302' /></p>
+
+<p>接下来找到Rust Base64 的库，调用之（修改的地方用new标出了）：</p>
+
+<pre><code class="language-`rust">......
+use base64::{encode, decode};
+......
+fn update(&amp;mut self, msg: Self::Message) -&gt; ShouldRender {
+        match msg {
+            Msg::Add =&gt; {
+                // new
+                info!(&quot;add things&quot;);
+                let description = self.state.value.trim();
+                // new
+                let description_handled = format!(&quot;{}: {}&quot;, description, encode(description.to_string()));
+
+                if !description.is_empty() {
+                    let entry = Entry {
+                      	// new
+                        description: description_handled,
+                        completed: false,
+                        editing: false,
+                    };
+                  	// new
+                    info!(&quot;{}&quot;, entry.description);
+                    self.state.entries.push(entry);
+                }
+                self.state.value = &quot;&quot;.to_string();
+            }</code></pre>
+
+<p>运行之。</p>
+
+<p>Okay，Base64-Encoder就做好了！</p>
+
+<p>效果：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1gnzml2w1ejj30k009z758.jpg' alt='encoder' /></p>
+
+<p><code>Cargo.toml</code>最后长这样：</p>
+
+<pre><code class="language-`rust">[package]
+name = &quot;encoder&quot;
+version = &quot;0.1.0&quot;
+authors = [&quot;Denis Kolodin &lt;deniskolodin@gmail.com&gt;&quot;]
+edition = &quot;2018&quot;
+
+[dependencies]
+strum = &quot;0.20&quot;
+strum_macros = &quot;0.20&quot;
+serde = &quot;1&quot;
+serde_derive = &quot;1&quot;
+yew = { path = &quot;./packages/yew&quot; }
+yew-services = { path = &quot;./packages/yew-services&quot; }
+
+log = &quot;0.4.6&quot;
+wasm-logger = &quot;0.2.0&quot;
+base64 = &quot;0.13.0&quot;</code></pre>
+
+<h1 id='生成_eth_公私钥与地址'>生成 ETH 公私钥与地址</h1>
+
+<p>&gt; &gt; <strong>本系列所有源码：</strong> &gt; &gt; https://github.com/leeduckgo/Rust-Study</p>
+
+<p>本篇是 Rust 学习笔记的第二篇。在第一篇里，我们魔改出了一个 Encoder，现在我们继续延续我们的魔改之路，挑战一个难度+1的Repo：</p>
+
+<p>&gt; &gt; Rust library for generating cryptocurrency wallets &gt; &gt; https://github.com/AleoHQ/wagyu</p>
+
+<p>魔改目标 0x1：</p>
+
+<p>&gt; &gt; <strong>抽取 Repo 中以太坊私钥、公钥、地址生成的部分，打印到控制台中。</strong></p>
+
+<p>但在魔改之前，笔者首先要对上一篇文章稍作补充，总结一下上篇文章中所涉及的知识点。</p>
+
+<h2 id='上篇文章中所涉及的知识点'>上篇文章中所涉及的知识点</h2>
+
+<ul>
+<li>变量的赋值</li>
+
+<li>format!函数（连接字符串）</li>
+
+<li>库的添加与使用，以wasm-logger为例</li>
+
+<li>trunk 与 yew 结合，让Rust程序 wasm 化，使其在浏览器中可访问</li>
+</ul>
+
+<h2 id='跑一遍_wagyu'>跑一遍 wagyu</h2>
+
+<p>首先要验证这个库符合我们的需求，所以按照 Repo 中的 Readme，采用源码的方式跑一遍。</p>
+
+<pre><code class="language-`bash"># Download the source code
+git clone https://github.com/AleoHQ/wagyu
+cd wagyu
+
+# Build in release mode
+$ cargo build --release
+./target/release/wagyu</code></pre>
+
+<p>成功：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEly1gnpi5cklf3j313y0fi79f.jpg' alt='image-20210213091719643' /></p>
+
+<p>在这个过程里，我们学习到了 cargo 的更多用法：</p>
+
+<pre><code class="language-`bash">$ cargo run # 直接执行
+$ cargo build # build 出 debug 版本，可执行文件在 ./target/debug 目录下
+$ cargo build --release # build 出 正式版本（release version)，可执行文件在 ./target/release 下</code></pre>
+
+<h2 id='研究_wagyu_代码'>研究 wagyu 代码</h2>
+
+<p>首先喵一眼目录结构：</p>
+
+<pre><code class="language-`">.
+├── AUTHORS
+├── Cargo.lock
+├── Cargo.toml
+├── LICENSE-APACHE
+├── LICENSE-MIT
+├── README.md
+├── bitcoin
+├── ethereum
+├── model
+├── monero
+├── target
+├── zcash
+└── wagyu
+      ├── cli
+      │   ├── bitcoin.rs
+      │   ├── ethereum.rs
+      │   ├── mod.rs
+      │   ├── monero.rs
+      │   ├── parameters
+      │   └── zcash.rs
+      ├── lib.rs
+      └── main.rs</code></pre>
+
+<p>我们可以看到，主入口是<code>wagyu</code>。</p>
+
+<p>在<code>wagyu</code>的<code>main.rs</code>中，会对<code>cli</code>目录下的子模块进行调用，进而对和<code>cli</code>平级的子模块进行调用。</p>
+
+<p>其代码如下：</p>
+
+<pre><code class="language-`rust">fn main() -&gt; Result&lt;(), CLIError&gt; {
+    let arguments = App::new(&quot;wagyu&quot;)
+        .version(&quot;v0.6.3&quot;)
+        .about(&quot;Generate a wallet for Bitcoin, Ethereum, Monero, and Zcash&quot;)
+        .author(&quot;Aleo &lt;hello@aleo.org&gt;&quot;)
+        .settings(&amp;[
+            AppSettings::ColoredHelp,
+            AppSettings::DisableHelpSubcommand,
+            AppSettings::DisableVersion,
+            AppSettings::SubcommandRequiredElseHelp,
+        ])
+        .subcommands(vec![
+            BitcoinCLI::new(),
+            EthereumCLI::new(),
+            MoneroCLI::new(),
+            ZcashCLI::new(),
+        ])
+        .set_term_width(0)
+        .get_matches();
+
+    match arguments.subcommand() {
+        (&quot;bitcoin&quot;, Some(arguments)) =&gt; BitcoinCLI::print(BitcoinCLI::parse(arguments)?),
+        (&quot;ethereum&quot;, Some(arguments)) =&gt; EthereumCLI::print(EthereumCLI::parse(arguments)?),
+        (&quot;monero&quot;, Some(arguments)) =&gt; MoneroCLI::print(MoneroCLI::parse(arguments)?),
+        (&quot;zcash&quot;, Some(arguments)) =&gt; ZcashCLI::print(ZcashCLI::parse(arguments)?),
+        _ =&gt; unreachable!(),
+    }
+}</code></pre>
+
+<p>我们再进入<code>wagyu &gt; cli &gt; ethereum.rs</code>目录下，发现里面有个简单的函数：</p>
+
+<pre><code class="language-`rust">    pub fn new&lt;R: Rng&gt;(rng: &amp;mut R) -&gt; Result&lt;Self, CLIError&gt; {
+        let private_key = EthereumPrivateKey::new(rng)?;
+        let public_key = private_key.to_public_key();
+        let address = public_key.to_address(&amp;EthereumFormat::Standard)?;
+        Ok(Self {
+            private_key: Some(private_key.to_string()),
+            public_key: Some(public_key.to_string()),
+            address: Some(address.to_string()),
+            ..Default::default()
+        })
+    }</code></pre>
+
+<p>很好，就拿这个改造了！</p>
+
+<h2 id='复制必要文件到新项目'>复制必要文件到新项目</h2>
+
+<ol type="1">
+<li>新建项目</li>
+</ol>
+
+<pre><code class="language-`bash">$ cargo new hello-crypto-rust</code></pre>
+
+<p>或者直接把上一个项目复制一份。</p>
+
+<ol type="2">
+<li>把<code>wagyu</code>的<code>Cargo.toml</code>中的必要内容复制过来</li>
+</ol>
+
+<pre><code class="language-`rust">[dependencies]
+log = &quot;0.4&quot;
+pretty_env_logger = &quot;0.3&quot;
+
+wagyu-ethereum = { path = &quot;./ethereum&quot;, version = &quot;0.6.3&quot; }
+wagyu-model = { path = &quot;./model&quot;, version = &quot;0.6.3&quot; }
+
+arrayvec = { version = &quot;0.5.1&quot; }
+base58 = { version = &quot;0.1&quot; }
+clap = { version = &quot;~2.33.1&quot; }
+colored = { version = &quot;1.9&quot; }
+digest = { version = &quot;0.9.0&quot; }
+either = { version = &quot;1.5.3&quot; }
+failure = { version = &quot;0.1.8&quot; }
+hex = { version = &quot;0.4.2&quot; }
+lazy_static = { version = &quot;1.4.0&quot; }
+rand = { version = &quot;0.7&quot; }
+rand_core = { version = &quot;0.5.1&quot; }
+safemem = { version = &quot;0.3.3&quot; }
+serde = { version = &quot;1.0&quot;, features = [&quot;derive&quot;] }
+serde_json = { version = &quot;1.0&quot; }
+tiny-keccak = { version = &quot;1.4&quot; }
+
+[profile.release]
+opt-level = 3
+lto = &quot;thin&quot;
+incremental = true
+
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = &quot;thin&quot;
+incremental = true
+debug-assertions = false
+
+[profile.dev]
+opt-level = 0
+
+[profile.test]
+opt-level = 3
+incremental = true
+debug-assertions = true
+debug = true</code></pre>
+
+<ol type="3">
+<li>把<code>ethereum</code>与<code>model</code>两个文件夹复制到<code>hello-crypto-rust</code>目录下</li>
+</ol>
+
+<p>此时的文件目录是这个样子的：</p>
+
+<pre><code class="language-`bash">.
+├── Cargo.lock
+├── Cargo.toml
+├── ethereum
+├── model
+├── src
+└── target</code></pre>
+
+<h2 id='补充代码'>补充代码</h2>
+
+<ol type="1">
+<li>补充<code>lib.rs</code>文件</li>
+</ol>
+
+<p>在<code>src</code>目录下新建<code>lib.rs</code>文件，内容：</p>
+
+<pre><code class="language-`rust">pub extern crate wagyu_ethereum as ethereum;
+pub extern crate wagyu_model as model;
+extern crate pretty_env_logger;</code></pre>
+
+<p>作用是加载外部 crate，更详细的说明可见：</p>
+
+<p>&gt; &gt; https://wiki.jikexueyuan.com/project/rust-primer/module/module.html</p>
+
+<ol type="2">
+<li>编写<code>main.rs</code>文件。</li>
+</ol>
+
+<p>首先引用必要的外部模块：</p>
+
+<pre><code class="language-`rust">use rand::{rngs::StdRng};
+use rand_core::SeedableRng;
+use hello_crypto_rust::ethereum::{EthereumPrivateKey, EthereumFormat};
+use hello_crypto_rust::model::{PrivateKey, PrivateKeyError, AddressError, PublicKeyError, PublicKey};
+
+#[macro_use] extern crate log;</code></pre>
+
+<p>然后我们编写主函数：</p>
+
+<pre><code class="language-`rust">fn main(){
+    pretty_env_logger::init();  // 初始化 pretty_env_logger 模块
+    new(); //调用new函数
+}</code></pre>
+
+<p>写<code>new()</code>函数：</p>
+
+<pre><code class="language-`rust">pub fn new() -&gt; Result&lt;EthereumPrivateKey, CreateError&gt; {
+    let rng = &amp;mut StdRng::from_entropy();
+    let private_key = EthereumPrivateKey::new(rng)?;
+    info!(&quot;priv: {}&quot;, private_key.to_string());
+    let public_key = private_key.to_public_key();
+    info!(&quot;pub: {}&quot;, public_key.to_string());
+    let address = public_key.to_address(&amp;EthereumFormat::Standard)?;
+    info!(&quot;addr: {}&quot;, address.to_string());
+    Ok(private_key)
+}</code></pre>
+
+<p>我们这里使用了相对于<code>println!</code>更高级的输出方式，通过log输出。</p>
+
+<p>这里有个关键的语法糖——<code>?</code>，用于错误处理。</p>
+
+<p>&gt; &gt; 把 result 用 match 连接起来会显得很难看；幸运的是，<code>?</code> 运算符可以把这种逻辑变得 干净漂亮。<code>?</code> 运算符用在返回值为 <code>Result</code> 的表达式后面，它等同于这样一个匹配 表达式：其中 <code>Err(err)</code> 分支展开成提前返回的 <code>return Err(err)</code>，而 <code>Ok(ok)</code> 分支展开成 <code>ok</code> 表达式。 &gt; &gt; —— https://rustwiki.org/zh-CN/rust-by-example/std/result/question_mark.html</p>
+
+<p>两个等价的函数，一个使用了<code>?</code>，一个没有：</p>
+
+<pre><code class="language-`rust">fn not_use_question_mark() {
+    let a = 10;                                                   // 把这里改成 9 就会报错.
+    let half = halves_if_even(a);
+    let half = match half {
+        Ok(item) =&gt; item,
+        Err(e) =&gt; panic!(e),
+    };
+    assert_eq!(half, 5);
+}
+
+
+fn use_question_mark&lt;&#8217;a &gt;() -&gt; Result&lt;i32, &amp;&#8217;a str&gt; {              // 这里必须要返回Result
+    let a = 10;
+    let half = halves_if_even(a)?;                     // 因为?要求其所在的函数必须要返回Result
+    assert_eq!(half, 5);
+    Ok(half)                                                                   
+}</code></pre>
+
+<p>然后，我们定义一下枚举类型<code>CreateError</code>，里面会囊括<code>AddressError</code>、<code>PrivateKeyError</code>与<code>PublicKeyError</code>。</p>
+
+<pre><code class="language-`rust">pub enum CreateError {
+    AddressError(AddressError),
+    PrivateKeyError(PrivateKeyError),
+    PublicKeyError(PublicKeyError)
+}
+
+impl From&lt;AddressError&gt; for CreateError {
+    fn from(error: AddressError) -&gt; Self {
+        CreateError::AddressError(error)
+    }
+}
+
+impl From&lt;PrivateKeyError&gt; for CreateError {
+    fn from(error: PrivateKeyError) -&gt; Self {
+        CreateError::PrivateKeyError(error)
+    }
+}
+
+impl From&lt;PublicKeyError&gt; for CreateError {
+    fn from(error: PublicKeyError) -&gt; Self {
+        CreateError::PublicKeyError(error)
+    }
+}</code></pre>
+
+<h2 id='try_it！'>Try It！</h2>
+
+<p>实现成功：</p>
+
+<p><img src='https://img.learnblockchain.cn/2021/02/22_/320988596.jpg' alt='image-20210213095659766' /></p>
+
+<h2 id='本篇所涉及的知识点'>本篇所涉及的知识点</h2>
+
+<ul>
+<li>cargo 的更多用法</li>
+
+<li><code>lib.rs</code>的用法</li>
+
+<li>函数与函数返回值</li>
+
+<li><code>pretty_env_logger</code>的用法</li>
+
+<li>枚举类型，以<code>CreateError</code>为例</li>
+</ul>
+
+<hr><p>作者简介：</p>
+
+<p>李大狗（李骜华），上海对外经贸大学区块链技术与应用研究中心副主任、柏链教育 CTO、FISCO BCOS（微众银行区块链框架）区块链认证讲师、5 年区块链工程师、北京大学硕士。 研究领域包括：区块链系统、共识机制、智能合约、区块链应用、数字身份等。</p>
+]]></content:encoded></item><item><title>「译」使用 Rust 实现命令行生命游戏</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/cli_gameoflife.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」使用_rust_实现命令行生命游戏'>「译」使用 Rust 实现命令行生命游戏</h1>
+
+<p>译者：m1zzx2</p>
+
+<h2 id=''></h2>
+
+<p>原文：</p>
+
+<ul>
+<li><a href='https://dev.to/jbarszczewski/rust-cli-game-of-life-tutorial-part-1-57pp'>https://dev.to/jbarszczewski/rust-cli-game-of-life-tutorial-part-1-57pp</a></li>
+
+<li><a href='https://dev.to/jbarszczewski/rust-cli-game-of-life-tutorial-part-2-16j3'>https://dev.to/jbarszczewski/rust-cli-game-of-life-tutorial-part-2-16j3</a></li>
+</ul>
+
+<h2 id='介绍'>介绍</h2>
+
+<p>你好！如果你看到了这篇文章，说明你对Rust感兴趣，并且想学习或者了解它。我早在2020年6月就编写了我的第一个Rust教程<a href='https://dev.to/jbarszczewski/rust-actix-cosmosdb-mongodb-tutorial-api-17i5'>Rust + Actix + CosmosDB (MongoDB) tutorial api</a>。这次，我将尝试介绍Rust的CLI。为了让这次的介绍更有趣，使用了<a href='https://rustwasm.github.io/docs/book/game-of-life/rules.html'>Official Rust WebAssembly</a>教程来实现“生命游戏”，来增强用户的交互逻辑。</p>
+
+<p>虽然这是个新手教程，但是我仍然强烈建议你通过了官方的新手教程后再来做这个。 <a href='https://github.com/rust-lang/rustlings'>rustlings tutorial</a></p>
+
+<p>可以在我的<a href='https://github.com/jbarszczewski/cli-game-of-life'>github仓库</a>中找到“最终”代码</p>
+
+<h2 id='创造universe'>创造Universe</h2>
+
+<p>开始吧！ 在创建一些新的项目像 new cli-game-of-life (或者 cargo init 如果你已经在一个正确的目录里面)之后。 使用你喜欢的编辑器打开它，目前要忽略main.rs。我们先要创建一个逻辑模块，所以继续创建一个src/game.rs文件。和前面说的一样，我将使用和wasm官方教程一样的逻辑来讲解，如果你之前做过它，你就会对它非常熟悉。让我们在游戏Universe里面来定义一个游戏单元格的枚举。</p>
+
+<pre><code class="language-`">#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Cell {
+    Dead = 0,
+    Alive = 1,
+}</code></pre>
+
+<p>derive 声明会告诉编译器提供(Copy, Clone, Debug, Eq, PartialEq)的基本实现，所以我们可以给单元分配枚举值并且比较他们。</p>
+
+<p><strong>注意</strong>: 我们也可以用bool值来实现一样的功能，不过使用enum可以具有更好的可读性，两者占用的内存是相等的。</p>
+
+<p>我们的游戏Universe定义如下:</p>
+
+<pre><code class="language-`">pub struct Universe {
+    width: u32,
+    height: u32,
+    cells: Vec&lt;Cell&gt;,
+}</code></pre>
+
+<p>好了现在我们开始实现游戏的函数了。让我们从一个方便的构造函数开始，这个构造函数将会设置Universe的大小，并初始化Cells的初始值。set_cells函数将会接受一个cells坐标，并把对应坐标的Cell设置成Alive状态。</p>
+
+<pre><code class="language-`">impl Universe {
+    pub fn new(width: u32, height: u32) -&gt; Universe {
+        Universe {
+            width: width,
+            height: height,
+            cells: vec![Cell::Dead; (width * height) as usize],
+        }
+    }
+
+    pub fn set_cells(&amp;mut self, cells: &amp;[(u32, u32)]) {
+        for (row, col) in cells.iter().cloned() {
+            let idx = self.get_index(row, col);
+            self.cells[idx] = Cell::Alive;
+        }
+    }
+
+    fn get_index(&amp;self, row: u32, column: u32) -&gt; usize {
+        (row * self.width + column) as usize
+    }
+}</code></pre>
+
+<p>get_index 函数是一个辅助函数，它会把Universed的坐标翻译成cells数组对应的下标。</p>
+
+<p>接下来，我们会实现Display特性，方便打印当前游戏的状态。</p>
+
+<pre><code class="language-`">use std::fmt;
+
+impl fmt::Display for Universe {
+    fn fmt(&amp;self, f: &amp;mut fmt::Formatter) -&gt; fmt::Result {
+        for line in self.cells.as_slice().chunks(self.width as usize) {
+            for &amp;cell in line {
+                let symbol = if cell == Cell::Dead { &#8217;◻&#8217; } else { &#8217;◼&#8217; };
+                write!(f, &quot;{}&quot;, symbol)?;
+            }
+            write!(f, &quot;\n&quot;)?;
+        }
+
+        Ok(())
+    }
+}</code></pre>
+
+<p>Perfect! Now we have something to run. Head over to your main.rs and replace all with the following content: 非常完美!现在我们需需要定义一个启动函数: 挑转到main.rs 用下面的内容替换main.rs的内容：</p>
+
+<pre><code class="language-`">mod game;
+
+fn main() {
+    let mut game = game::Universe::new(5, 5);
+    game.set_cells(&amp;[(2, 1), (2, 2), (2, 3)]);
+    print!(&quot;{}&quot;, game);
+}</code></pre>
+
+<p>运行 cargo run之后 ,代码顺利的跑起来了，但是它实际上没有做什么，因此我们需要新增一个tick函数:</p>
+
+<pre><code class="language-`">pub fn tick(&amp;mut self) {
+    let mut next = self.cells.clone();
+    for row in 0..self.height {
+        for col in 0..self.width {
+            let idx = self.get_index(row, col);
+            let cell = self.cells[idx];
+            let live_neighbours = self.live_neighbour_count(row, col);
+            next[idx] = match (cell, live_neighbours) {
+                (Cell::Alive, x) if x &lt; 2 =&gt; Cell::Dead,
+                (Cell::Alive, 2) | (Cell::Alive, 3) =&gt; Cell::Alive,
+                (Cell::Alive, x) if x &gt; 3 =&gt; Cell::Dead,
+                (Cell::Dead, 3) =&gt; Cell::Alive,
+                (otherwise, _) =&gt; otherwise,
+            };
+        }
+    }
+    self.cells = next;
+}
+
+fn live_neighbour_count(&amp;self, row: u32, column: u32) -&gt; u8 {
+    let mut count = 0;
+    for delta_row in [self.height - 1, 0, 1].iter().cloned() {
+        for delta_col in [self.width - 1, 0, 1].iter().cloned() {
+            if delta_row == 0 &amp;&amp; delta_col == 0 {
+                continue;
+            }
+
+            let neighbour_row = (row + delta_row) % self.height;
+            let neighbour_col = (column + delta_col) % self.width;
+            let idx = self.get_index(neighbour_row, neighbour_col);
+            count += self.cells[idx] as u8;
+        }
+    }
+
+    count
+}</code></pre>
+
+<p>该代码直接来自WASM锈皮书，它将Conway的《生命游戏》规则应用到我们的宇宙中，同时还要注意边缘包裹，以使我们的宇宙看起来像是循环的（请参见风味3）。 在使用刻度之前，我们需要准备终端以显示动画游戏Universe。 让我们现在就跳进去！</p>
+
+<p>P.S. -您可以在我的GitHub上找到本章的源代码</p>
+
+<p>这段代码来自wasm rust book ，它把ConWay的 Conway&#8217;s Game Of Life 的规则应用到我们的universe中，它也会注意边界条件，让我们的universe看起来是循环运动的。<a href='https://rustwasm.github.io/docs/book/game-of-life/implementing.html'>看第三章</a></p>
+
+<p>在我们使用tick函数之前，我们需要准备用终端去展示Universe 的界面，让我们来进入这个操作吧!</p>
+
+<p>P.S -你们可以在<a href='https://github.com/jbarszczewski/cli-game-of-life/tree/42c60e1c10073dd65819af7d1a6d7b049d1a449d'>这里</a>找到本章的源代码</p>
+
+<h2 id='绘制游戏universe'>绘制游戏Universe</h2>
+
+<p>为了让终端输入输出，我们将会使用<a href='https://crates.io/crates/crossterm'>Crossterm crate</a>包，因此我们需要把它添加进我们的Cargo.toml文件里面:</p>
+
+<pre><code class="language-`">[dependencies]
+crossterm = &quot;0.19.0&quot;</code></pre>
+
+<p>这个工具箱里面有很多方便的函数来操作终端，并且它是跨平台的，我们不需要担心任何平台的区别。大多数crossterm指令是容易理解的，因为他们被分进了不同的模块，就像cursor:Hide 就是和它的字面意思的一样，隐藏光标。</p>
+
+<pre><code class="language-`">use crossterm::{
+    cursor::{Hide, MoveTo, Show},
+    event::{poll, read, Event},
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor},
+    terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
+    Result,
+};
+use std::io::stdout;
+use std::time::Duration;</code></pre>
+
+<p>接下老，我们的main函数需要被填充成这个样子:</p>
+
+<pre><code class="language-`">fn main() -&gt; Result&lt;()&gt; {
+    let mut game = game::Universe::new(5, 5);
+    game.set_cells(&amp;[(2, 1), (2, 2), (2, 3)]);
+    execute!(
+        stdout(),
+        EnterAlternateScreen,
+        SetForegroundColor(Color::Magenta),
+        Hide
+    )?;
+
+    loop {
+        if poll(Duration::from_millis(500))? {
+            match read()? {
+                Event::Key(_) =&gt; break,
+                _ =&gt; {}
+            }
+        } else {
+            execute!(
+                stdout(),
+                Clear(ClearType::All),
+                MoveTo(0, 0),
+                Print(&amp;game),
+                Print(&quot;Press enter to exit...&quot;)
+            )?;
+            game.tick();
+        }
+    }
+    execute!(stdout(), ResetColor, Show, LeaveAlternateScreen)?;
+    Ok(())
+}</code></pre>
+
+<p>好的让我们拆解一下在做的事情:</p>
+
+<ol type="1">
+<li>main函数现在返回了Result类型。这能让用户随时退出。</li>
+
+<li>我们在execute!宏里面设置临时终端，它的第一个参数是std::io::Writer(这个case里面的输入)类，后面的参数是一些命令。</li>
+
+<li>在这个循环里面，我们用poll去读取用户的输入，这样不会阻塞execution去绘画终端。当用户输入回车按钮时，这个循环就会退出，如果用户在500ms内没有输入，我们将会根据tick计算的状态重新绘画Universe。</li>
+
+<li>循环结束以后，我们就会离开这个临时终端。 现在我们可以跑脚本cargo run 了。 你将会看到水平线和垂直线相互交替出现，但是输入enter，游戏没有停止。我们需要修改代码来实现这个功能。</li>
+</ol>
+
+<h2 id='和universe交互'>和Universe交互</h2>
+
+<p>我们只能处理回车的原因是，默认的输入是在按下回车后处理的。通常，你的输入都准备好之后，在按下会车触发，这才有意义。但是在我们的需求里面，我们希望和一个键交互。这意味着我们需要启用<a href='https://docs.rs/crossterm/0.19.0/crossterm/terminal/#raw-mode'>raw mode</a>. 新的代码会被改成这样:</p>
+
+<pre><code class="language-`">// add required imports:
+use terminal::{disable_raw_mode, enable_raw_mode};
+
+// add this line at the very begining of the main() function:
+enable_raw_mode()?;
+
+// replace code block when poll returns true, the match statement, with following:
+
+if let Event::Key(KeyEvent { code, .. }) = read()? {
+    match code {
+        KeyCode::Esc =&gt; {
+            break;
+        }
+        _ =&gt; {}
+    }
+}
+
+// finaly disable raw mode at the end of the function before returning Ok(()):
+disable_raw_mode()?;</code></pre>
+
+<p>添加循环退出功能是很重要的，因为raw mode模式下，会禁用ctrl+c退出的方式。 现在你可以运行这个代码了，但是你会发现输出的格式都是乱的，这是因为raw mode不会处理换行符。现在我们需要将光标显示在正确的位置。这意味着我们不能用Display 特征来显示了。取而代之的，我们会遍历Universe，把每一行分别打印出来，向Universe中添加新方法：</p>
+
+<pre><code class="language-`">pub fn row_as_string(&amp;self, row: u32) -&gt; Option&lt;String&gt; {
+    if row &lt; self.height {
+        let mut row_string = String::new();
+        let start = self.get_index(row, 0);
+        let end = self.get_index(row, self.width);
+        let line = &amp;self.cells[start..end];
+        for &amp;cell in line {
+            let symbol = if cell == Cell::Dead { &#8217;◻&#8217; } else { &#8217;◼&#8217; };
+            row_string.push(symbol);
+        }
+        Some(row_string)
+    } else {
+        None
+    }
+}</code></pre>
+
+<p>如果该行和Universe大小一致，我们返回整行作为一个字符串，否则，返回None. 在我们的main.rs中，从crossterm队列中添加新的导入，请排队！宏类似于执行，但需要手动刷新。如果要有条件地构建输出，这将非常方便。让我们看看它如何进行。首先在main（）函数的开头初始化一个新变量：</p>
+
+<pre><code class="language-`">let mut stdout = stdout();</code></pre>
+
+<p>现在，可以把stdout()替换为我们的新名称，我们需要用以下代码替换整个循环:</p>
+
+<pre><code class="language-`">loop {
+    if poll(Duration::from_millis(500))? {
+        if let Event::Key(KeyEvent { code, .. }) = read()? {
+            match code {
+                KeyCode::Esc =&gt; {
+                    break;
+                }
+                _ =&gt; {}
+            }
+        }
+    } else {
+        queue!(stdout, Clear(ClearType::All))?;
+        let mut i = 0;
+        while let Some(line) = game.row_as_string(i) {
+            queue!(stdout, MoveTo(0, i as u16), Print(line))?;
+            i += 1;
+        }
+
+        queue!(
+            stdout,
+            MoveTo(0, (i + 1) as u16),
+            Print(&quot;Press Esc to exit...&quot;)
+        )?;
+        stdout.flush()?;
+        game.tick();
+    }
+}</code></pre>
+
+<p>按键处理逻辑不会改变,所有的更改都在else里面：</p>
+
+<ol type="1">
+<li>
+<p>我们把execute!替换成 queue! 宏。</p>
+</li>
+
+<li>
+<p>遍历Universe的每一行，queue! 会直接打印结果，你会看到返回Option &lt;T&gt;有多方便！我们不需要任何额外的处理，这个代码看起来会很干净。</p>
+</li>
+
+<li>
+<p>在所有文本都准备好之后，我们调用 flush() 刷新到输出。</p>
+</li>
+</ol>
+
+<h2 id='接受参数'>接受参数</h2>
+
+<p>使用std :: env :: args函数可以非常简单的接受参数.但是我想展示一些依赖外部包 <a href='https://crates.io/crates/clap'>clap</a>的方法。有三种配置clap的方式:</p>
+
+<ul>
+<li>&#8217;Builder Pattern&#8217;</li>
+
+<li>yaml配置</li>
+
+<li>宏 &#8217;Builder Pattern&#8217;是我最喜欢的一种方式，它可以动态扩展输入的参数，并提供一些检查。对于像这样的简单项目，将配置放在main.rs中是完全可以的，随着项目复杂度的增长，可能湖考虑把配置放在单独的文件里面，可以有更好的可读性。首先Cargo.toml添加依赖：</li>
+</ul>
+
+<pre><code class="language-`">clap = &quot;2.33.3&quot;</code></pre>
+
+<p>接下来更新我们的main.rs文件:</p>
+
+<pre><code class="language-`">use clap::{crate_version, App, Arg};
+
+//below code goes at the beginning of main() function:
+  let matches = App::new(&quot;CLI Game Of Life&quot;)
+        .version(crate_version!())
+        .author(&quot;jbarszczewski&quot;)
+        .about(&quot;Simple implementation of Conway&#8217;s Game Of Life in Rust.&quot;)
+        .after_help(&quot;Have fun!&quot;)
+        .arg(
+            Arg::with_name(&quot;INPUT&quot;)
+                .help(&quot;Sets the input file to configure initial state of game&quot;)
+                .short(&quot;i&quot;)
+                .long(&quot;input&quot;)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(&quot;DELAY&quot;)
+                .help(&quot;Sets the delay between game ticks. Value is in miliseconds&quot;)
+                .short(&quot;d&quot;)
+                .long(&quot;delay&quot;)
+                .takes_value(true)
+                .default_value(&quot;500&quot;),
+        )
+        .get_matches();</code></pre>
+
+<p>clap包会创建两个子命令(除非你覆盖了它们):</p>
+
+<ul>
+<li>help (-h or --help)</li>
+
+<li>version (-V --version) That&#8217;s why we provide basic info about the app. You may notice crate_version! macro, this will grab the version number from your Cargo.toml file so you don&#8217;t need to manually update it. Then we add two arguments, INPUT and DELAY, with some description how to use it. Build your app with cargo build (you will find binary in /target/debug directory) and run like this ./cli-game-of-life -h which will print out help page:</li>
+</ul>
+
+<pre><code class="language-`">CLI Game of Life 0.2.0
+jbarszczewski
+Simple implementation of Conway&#8217;s Game of Life in Rust.
+
+USAGE:
+    cli-game-of-life [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --delay &lt;DELAY&gt;    Sets the delay between game ticks. Value is in miliseconds [default: 500]
+    -i, --input &lt;INPUT&gt;    Sets the input file to configure initial state of game
+
+Have fun!</code></pre>
+
+<p>现在，可以写代码获取你输入的值:</p>
+
+<pre><code class="language-`">if let Some(input) = matches.value_of(&quot;INPUT&quot;) {
+    println!(&quot;A config file was passed: {}&quot;, input);
+}</code></pre>
+
+<p>value<em>of() 将会返回  Option&lt;T&gt; 因此你可以输入的数据是否存在而采取相应的行动，我们把DELAY设置成了默认值，也就是说无论有没有解析到输入，我们都会可以采取行动.现在我们不会使用value</em>of(), 在这个项目里面，我们会使用flag接受参数。默认情况下，所有的clap参数都是flag，这也就是为什么我们在描述INPUT和DELAY的时候，需要添加take_values()方法。因为flag并不会有值，当我们使用它们，像在这种场景:</p>
+
+<pre><code class="language-`">if matches.is_present(&quot;TEST&quot;) {
+    println!(&quot;TEST!&quot;);
+}</code></pre>
+
+<p>这里有太多的可能的配置，所以我只建议你用到配置的时候才去看<a href='https://docs.rs/clap/2.33.3/clap/struct.Arg.html'>文档</a>。</p>
+
+<p>好的，我们通过配置，已经能让我们的应用接受参数了，但是他们不会做任何处理，接下来将会做一些处理。</p>
+
+<h2 id='控制速度'>控制速度</h2>
+
+<p>让我们使用DELAY参数，现在我们的游戏hard-code了500ms作为刷新下一个状态的频率，动态地改变它是很简单的，首先，我们需要去读并且解析(Duration::from_millis() accept u64)我们输入的参数:</p>
+
+<pre><code class="language-`">let delay:u64 = matches.value_of(&quot;DELAY&quot;).unwrap().parse().unwrap();</code></pre>
+
+<p>我们的第一个unwrap(返回空，将会抛出panic)，来检查输入是否为空，第二个unwrap(如果返回Err，将会抛出panic)来检查输入是不是一个合法的int, panic时候，我们希望程序退出。如果你想定制第二个错误，你需要写下面的逻辑:</p>
+
+<pre><code class="language-`">let delay: u64 = match matches.value_of(&quot;DELAY&quot;).unwrap().parse() {
+    Ok(val) =&gt; val,
+    Err(e) =&gt; {
+        println!(&quot;Error parsing DELAY argument: {}&quot;, e);
+        500
+    }
+};</code></pre>
+
+<p>然后我们可以吧poll 函数里面的500换成delay变量。如果你想测试脚本是否正确运行，你需要执行这样的脚本: ./cli-game-of-life -d 200(记住这个值是毫秒) 这里有个小问题。由于处理的方式，我们需要在delay ms后，才展示屏幕上面的内容，如果delay5秒，那么程序开始的5秒不会有任何输出。我们可以用&quot;drawing&quot;修复它， 代码:</p>
+
+<pre><code class="language-`">loop {
+    queue!(stdout, Clear(ClearType::All))?;
+    let mut i = 0;
+    while let Some(line) = game.row_as_string(i) {
+        queue!(stdout, MoveTo(0, i as u16), Print(line))?;
+        i += 1;
+    }
+
+    queue!(
+        stdout,
+        MoveTo(0, (i + 1) as u16),
+        Print(&quot;Press Esc to exit...&quot;)
+    )?;
+    stdout.flush()?;
+    if poll(Duration::from_millis(delay))? {
+        if let Event::Key(KeyEvent { code, .. }) = read()? {
+            match code {
+                KeyCode::Esc =&gt; {
+                    break;
+                }
+                _ =&gt; {}
+            }
+        }
+    }
+
+    game.tick();
+}</code></pre>
+
+<h2 id='定义universe'>定义Universe</h2>
+
+<p>现在是使用INPUT参数的时候了，这个参数制定了universe的配置路径，文件将会是下面这种格式:</p>
+
+<pre><code class="language-`">5
+5
+00000
+00100
+00010
+01110
+00000</code></pre>
+
+<p>第一行代表Universe的行数，第二行代表Universe的列数，接下来就是描述Universe每个格子的详情,0代表死,1代表或者。现在这里有两个地方你可以放置配置文件:</p>
+
+<ol type="1">
+<li>项目的根目录，一些文件像是Cargo.toml就在这个里面，并且你能通过脚本cargo run -- -i INPUT跑你的应用。使用cargo运行之后的内容，都可以作为参数传递给你的项目。</li>
+
+<li>./target/debug. 这意味着您需要在每次更改后重新构建，然后执行/debug/cli-game-of-life -i starship。 在本次教程里面，建议使用第一种方式，因为它更方便。上面的配置在“Game of Life”中称为starship pattern，因此我们将文件命名为一样的，然后继续下一步 我们将会读取这个文件，首先需要导入一个新的依赖:</li>
+</ol>
+
+<pre><code class="language-`">use std::fs::File;
+use std::io::{BufRead, BufReader};</code></pre>
+
+<p>下面是解析文件的函数，返回game::Universe::</p>
+
+<pre><code class="language-`">fn create_game_from_file(path: &amp;str) -&gt; game::Universe {
+    let file = File::open(path).unwrap();
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut rows_number = 0;
+    if let Ok(success) = reader.read_line(&amp;mut line) {
+        if success &gt; 0 {
+            rows_number = line.trim().parse().unwrap();
+            line.clear();
+        } else {
+            panic!(&quot;Rows number not detected!&quot;);
+        }
+    };
+    let mut cols_number = 0;
+    if let Ok(success) = reader.read_line(&amp;mut line) {
+        if success &gt; 0 {
+            cols_number = line.trim().parse().unwrap();
+            line.clear();
+        } else {
+            panic!(&quot;Columns number not detected!&quot;);
+        }
+    };
+    let mut game_universe = game::Universe::new(cols_number, rows_number);
+    let mut row = 0;
+    let mut live_cells = Vec::&lt;(u32, u32)&gt;::new();
+    loop {
+        match reader.read_line(&amp;mut line) {
+            Ok(0) =&gt; break,
+            Ok(_) =&gt; {
+                let mut col = 0;
+                for char in line.chars() {
+                    match char {
+                        &#8217;1&#8217; =&gt; live_cells.push((row, col)),
+                        _ =&gt; {}
+                    }
+                    col += 1;
+                }
+            }
+            _ =&gt; break,
+        }
+
+        line.clear();
+        row += 1;
+    }
+    game_universe.set_cells(&amp;live_cells);
+    game_universe
+}</code></pre>
+
+<p>这看起来很长而且有一定重构的空间，但是比较容易理解:</p>
+
+<ol type="1">
+<li>打开文件，写入BufReader。</li>
+
+<li>创建变量line读取每一行。</li>
+
+<li>尝试去解析行数和列数。</li>
+
+<li>创建新的 Universe。</li>
+
+<li>遍历剩余行，解析cell，写入vector。</li>
+
+<li>调用game<em>universe.set</em>cell方法，把vector的值写入对象，然后返回。</li>
+</ol>
+
+<p>我们需要做的最后一件事情就是让我们的新的函数得到使用，在main函数里面删除初始化游戏的逻辑，并且把我们新的代码放在解析DELAY变量后面:</p>
+
+<pre><code class="language-`">let mut game = match matches.value_of(&quot;INPUT&quot;) {
+    Some(path) =&gt; create_game_from_file(path),
+    None =&gt; {
+        let mut default_game = game::Universe::new(5, 5);
+        default_game.set_cells(&amp;[(2, 1), (2, 2), (2, 3)]);
+        default_game
+    }
+};</code></pre>
+
+<p>这个逻辑很简单：我们尝试读取INPUT参数，如果一个通过了，我们接下来调用create<em>game</em>from_file方法，如果没通过，我们然后默认的universe。</p>
+
+<p>现在我们可以调用cargo run -- -i starship并且享受美景!你可以使用更大的场地，类似15\*15， 并且由于我们不校验参数，所以不需要在每行最后输入0。</p>
+
+<h2 id='总结'>总结</h2>
+
+<p>希望您喜欢本教程，多谢您的阅读！</p>
+
+<h2 id=''></h2>
+
+<p>译者介绍：</p>
+
+<p>m1zzx2 ，Rust 初学者，知乎工程师。</p>
+]]></content:encoded></item><item><title>「译」使用 Tokio 实现 Actor 系统</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/actor_with_tokio.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」使用_tokio_实现_actor_系统'>「译」使用 Tokio 实现 Actor 系统</h1>
+
+<p>译者：Matrixtang</p>
+
+<p>原文：<a href='https://ryhl.io/blog/actors-with-tokio/'>https://ryhl.io/blog/actors-with-tokio/</a></p>
+
+<h2 id=''></h2>
+
+<p>本文将不使用任何 Actors 库(例如 Actix ) 而直接使用Tokio实现 Actors 系统。事实上这甚至是更容易的，但是还是有一些细节需要注意：</p>
+
+<ol type="1">
+<li><code>tokio::spawn</code> 的调用位置。</li>
+
+<li>使用带有<code>run</code>方法的结构体还是裸函数。</li>
+
+<li>Actor 的 Handle 函数。</li>
+
+<li>背压( Backpressure ) 和 有界信道。</li>
+
+<li>优雅的关闭。</li>
+</ol>
+
+<p>本文概述的技术适用于任何执行器，但为简单起见，我们仅讨论Tokio。与Tokio教程中的 <a href='https://tokio.rs/tokio/tutorial/spawning'>spawning</a> 和<a href='https://tokio.rs/tokio/tutorial/channels'>channel chapters</a>章节有一些重叠， 当然啦，我建议也阅读这些章节。</p>
+
+<p>​	在讨论如何编写 Actor 之前，我们需要知道 Actor 是什么。Actor 背后的基本思想是产生一个独立的任务，该任务独立于程序的其他部分执行某些工作。 通常，这些参与者通过使用消息传递信道与程序的其余部分进行通信。 由于每个 Actor 独立运行，因此使用它们设计的程序自然是并行的。 Actor 的一个常见用法是为 Actor 分配你要共享的某些资源的专有所有权，然后让其他任务通过与 Actor 通信来间接访问彼此的资源。 例如，如果要实现聊天服务器，则可以为每个连接生成一个任务，并在其他任务之间路由一个聊天消息的主任务。 十分有用，因为主任务可以避免必须处理网络IO，而连接任务可以专门处理网络IO。</p>
+
+<h2 id='实现'>实现</h2>
+
+<p>​	Actor 分为两部分：任务和handle。 该任务是独立生成的Tokio任务，实际上执行 Actor 的职责，而 handle 是一种允许你与该任务进行通信的结构。</p>
+
+<p>​	让我们考虑一个简单的 Actor 。 Actor 在内部存储一个计数器，该计数器用于获取某种唯一ID。 Actor 的基本结构如下所示：</p>
+
+<pre><code class="language-`rust">use tokio::sync::{oneshot, mpsc};
+
+struct MyActor {
+    receiver: mpsc::Receiver&lt;ActorMessage&gt;,
+    next_id: u32,
+}
+enum ActorMessage {
+    GetUniqueId {
+        respond_to: oneshot::Sender&lt;u32&gt;,
+    },
+}
+
+impl MyActor {
+    fn new(receiver: mpsc::Receiver&lt;ActorMessage&gt;) -&gt; Self {
+        MyActor {
+            receiver,
+            next_id: 0,
+        }
+    }
+    fn handle_message(&amp;mut self, msg: ActorMessage) {
+        match msg {
+            ActorMessage::GetUniqueId { respond_to } =&gt; {
+                self.next_id += 1;
+
+                // The `let _ =` ignores any errors when sending.
+                // `let _ =` 忽略了发送的任何 error
+                // This can happen if the `select!` macro is used
+                // to cancel waiting for the response.
+                // 当 `select!` 宏被用到时将会停止接受响应
+                let _ = respond_to.send(self.next_id);
+            },
+        }
+    }
+}
+
+async fn run_my_actor(mut actor: MyActor) {
+    while let Some(msg) = actor.receiver.recv().await {
+        actor.handle_message(msg);
+    }
+}</code></pre>
+
+<p>现在我们有了 Actor 本身，我们还需要一个与 actor 配套的handle 。 handle  是其他代码段可以用来与 actor 对话的对象，也是让 Actor 存活的原因。</p>
+
+<p>以下是 handle 的实现：</p>
+
+<pre><code class="language-`rust">#[derive(Clone)]
+pub struct MyActorHandle {
+    sender: mpsc::Sender&lt;ActorMessage&gt;,
+}
+
+impl MyActorHandle {
+    pub fn new() -&gt; Self {
+        let (sender, receiver) = mpsc::channel(8);
+        let actor = MyActor::new(receiver);
+        tokio::spawn(run_my_actor(actor));
+        // 译者提醒： 注意 tokio::spawn 的位置
+        Self { sender }
+    }
+
+    pub async fn get_unique_id(&amp;self) -&gt; u32 {
+        let (send, recv) = oneshot::channel();
+        let msg = ActorMessage::GetUniqueId {
+            respond_to: send,
+        };
+
+        // Ignore send errors. If this send fails, so does the
+        // recv.await below. There&#8217;s no reason to check for the
+        // same failure twice.
+        // 忽略发送 error 。如果它发送失败， 将会执行下方的 recv.await
+        // 检测同样的错误两次是没有道理的。
+        let _ = self.sender.send(msg).await;
+        recv.await.expect(&quot;Actor task has been killed&quot;)
+    }
+}</code></pre>
+
+<p><a href='https://play.rust-lang.org/?version=stable&amp;mode=debug&amp;edition=2018&amp;gist=1e60fb476843fb130db9034e8ead210c'>full example</a></p>
+
+<p>让我们仔细看一下本示例中的不同部分。</p>
+
+<p><strong><code>ActorMessage.</code></strong> <code>ActorMessage</code> 枚举定义了我们可以发送给 Actor 的消息类型。 通过使用这个枚举，我们可以拥有许多不同的消息类型，并且每种消息类型都可以具有自己的参数集。我们通过<a href='https://docs.rs/tokio/1/tokio/sync/oneshot/index.html'>`oneshot`</a>信道向 sender 返回值 , 而这种信道只允许发送一条消息。</p>
+
+<p>在上面的示例中，我们在 actor 结构的 <code>handle_message</code> 方法中的枚举上进行了匹配，但这不是构造此方法的唯一办法。 也可以在 <code>run_my_actor</code> 函数的枚举中进行匹配。 然后，此匹配项中的每个分支都可以在 actor 对象上调用各种方法，例如  <code>get_unique_id</code> 。</p>
+
+<p><strong>发送消息时出错</strong> 在处理信道时，并非所有错误都是致命( fatal )的。 因此，该示例有时使用 <code>let _ =</code> 来忽略错误。 通常，如果 receiver 被丢弃，那在信道上的 <code>send</code> 操作将失败。 在我们的示例中，此操作的第一个实例是 actor 中我们响应已发送的消息的那行 。</p>
+
+<pre><code class="language-`rust">let _ = respond_to.send(self.next_id);)</code></pre>
+
+<p>这将发生在接收方不再需要操作的结果的情形下，例如 发送消息的任务可能已被杀死。</p>
+
+<p><strong>关闭Actor</strong>  我们可以通过查看接收消息是否失败来决定何时关闭 Actor 。 在我们的示例中，这发生在以下 while 循环中：</p>
+
+<pre><code class="language-`rust">while let Some(msg) = actor.receiver.recv().await {
+    actor.handle_message(msg);
+}</code></pre>
+
+<p>当所有发送到<code>receiver</code> 的 <code>sender</code> 都被丢弃时，我们就知道将不会再收到其他信息了，因此可以关闭 Actor 。 当这种情况发生时，调用<code>.recv（）</code>将返回 <code>None</code> ，并且由于它与模式<code>Some（msg）</code>不匹配，while 循环将退出并且函数会返回。</p>
+
+<h2 id='结构体的_run_方法'>结构体的 run 方法</h2>
+
+<p>​	我上面给出的示例使用的顶层函数并未在任何结构上定义，因为我们将其作为 Tokio 任务产生 ，但是许多人发现直接在 MyActor 结构体中定义 <code>run</code>方法并且启动更加自然。 也不是不行，但是我举这个使用顶层函数的示例的原因是，使用这种方法就可以避免很多由生命周期而产生的问题了。 为了说清楚这种问题，我准备了一个例子，说明不熟悉该模式的人经常会想到什么。</p>
+
+<pre><code class="language-`rust">impl MyActor {
+    fn run(&amp;mut self) {
+        tokio::spawn(async move {
+            while let Some(msg) = self.receiver.recv().await {
+                self.handle_message(msg);
+            }
+        });
+    }
+
+    pub async fn get_unique_id(&amp;self) -&gt; u32 {
+        let (send, recv) = oneshot::channel();
+        let msg = ActorMessage::GetUniqueId {
+            respond_to: send,
+        };
+
+        // Ignore send errors. If this send fails, so does the
+        // recv.await below. There&#8217;s no reason to check for the
+        // same failure twice.
+        let _ = self.sender.send(msg).await;
+        recv.await.expect(&quot;Actor task has been killed&quot;)
+    }
+}
+
+... and no separate MyActorHandle</code></pre>
+
+<p>这个示例存在两个问题：</p>
+
+<ol type="1">
+<li><code>tokio::spawn</code>在  <code>run</code> 方法中被调用。</li>
+
+<li>Actor 和 handle 其实是一个结构体。</li>
+</ol>
+
+<p>导致问题的第一个原因是，因为<code>tokio :: spawn</code>函数要求参数为 <code>&#8217;static&#8217;</code>。那就意味着新任务必须拥有完整的所有权，这就导致了该方法借用了<code>self</code>，所以它无法将 <code>self</code> 的所有权交给新任务。</p>
+
+<p>第二个问题是，因为Rust强制实施了单一所有权原则。 如果将 actor 和 handle 都合并为同一个结构体，则（至少从编译器的角度来看）将使每个handle 都可以访问 actor 的任务所拥有的全部字段。 例如， <code>next_id</code> 应仅由 actor 任务拥有，而且不应该让任何 handle 直接访问。</p>
+
+<p>也就是说，有一个通过解决以上两个问题，变得可行的版本。代码如下：</p>
+
+<pre><code class="language-`rust">impl MyActor {
+    async fn run(&amp;mut self) {
+        while let Some(msg) = self.receiver.recv().await {
+            self.handle_message(msg);
+        }
+    }
+}
+
+impl MyActorHandle {
+    pub fn new() -&gt; Self {
+        let (sender, receiver) = mpsc::channel(8);
+        let actor = MyActor::new(receiver);
+        tokio::spawn(async move { actor.run().await });
+
+        Self { sender }
+    }
+}</code></pre>
+
+<p>该函数与顶层函数相同。 请<strong>注意</strong>，严格来讲，可以编写<code>tokio :: spawn</code>在<code>run</code>内的那种 ， 但是我并不推荐。</p>
+
+<h2 id='actor_的_其他变体'>actor 的 其他变体</h2>
+
+<p>​	我在本文中的示例使用了参与者使用消息的请求-响应模型(request-response)，但是这不是必须的。 在本节中，我将给你一些使用其他方式的例子，给你一些启发。</p>
+
+<h3 id='不对消息回应'>不对消息回应</h3>
+
+<p>​	在之前的示例中我们介绍了一种使用<code>oneshot</code>信道发送对消息响应的方式，但是并不总是需要响应。在这些情况下，仅在消息枚举中不包含 <code>oneshot</code> 信道是没有问题的。当信道中有空间时，这甚至可以让你在处理完消息之前就返回。 但是仍应确保使用有界信道，以保证在该信道中等待的消息数不会无限增长。在某些情况下，这意味着仍然需要由一个异步函数来处理<code>发送</code>操作，用于处理等待信道需要更多空间的情况。 但是，还有一种替代方法可以使<code>send</code>操作成为异步的。即使用 <code>try_send</code> 方法，并通过简单地杀死 Actor 来处理发送失败的情况。这在 Aoctor 管理 <code>TcpStream</code> 时，用于转发发送到连接中的任何消息的情况下是很有用的。这种情况下，如果无法继续向 <code>TcpStream</code> 写入 ，则可直接关闭连接。</p>
+
+<h3 id='多个handle共享一个_actor'>多个handle共享一个 Actor</h3>
+
+<p>​	如果需要从不同的地方向 actor 发送消息，则可以使用多个 handle 来强制某些消息只能从某些地方发送。 当使用这种方法时，你仍然可以在内部重复使用相同的 <code>mpsc</code> 通道，并使用其中包含所有可能的消息类型的枚举。 如果你<strong>不得不</strong>想要为此使用单独的信道，则  actor 可以使用 <a href='https://docs.rs/tokio/1/tokio/macro.select.html'>`tokio::select!`</a> 来一次性冲多个信道中接受信息。</p>
+
+<pre><code class="language-`rust">loop {
+    tokio::select! {
+        Some(msg) = chan1.recv() =&gt; {
+            // handle msg
+        },
+        Some(msg) = chan2.recv() =&gt; {
+            // handle msg
+        },
+        else =&gt; break,
+    }
+}</code></pre>
+
+<p>需要注意的是在信道关闭时的处理方式，因为在这种情况下，它们的 <code>recv</code> 方法会立即返回 <code>None</code> 。 幸运的是，<code>tokio :: select！</code> 宏允许您通过提供 <code>Some（msg）</code> 来处理这种情况。 如果仅关闭一个信道，则该分支将被禁用，另外一个信道依旧是可用的。 当两者都关闭时，else分支运行并使用<code>break</code>退出循环。</p>
+
+<h3 id='actors_间发送信息'>Actors 间发送信息</h3>
+
+<p>​	让 Actor 将消息发送给其他 Actor 也是可行的。 为此，只需为一个 Actor 提供其他 Actor 的 handle 即可。 当Actor 形成了循环时，需要上点心，因为为了保持彼此的 handle 存活，防止 Actor 被关闭最后一个 <code>sender</code> 不会被丢弃。 为了处理这种情况，您可以让一个 actor 具有两个带有独立的<code>mpsc</code>通道的 handle ，<code>tokio :: select！</code>会被用在下面这个示例里 ：</p>
+
+<pre><code class="language-`rust">loop {
+    tokio::select! {
+        opt_msg = chan1.recv() =&gt; {
+            let msg = match opt_msg {
+                Some(msg) =&gt; msg,
+                None =&gt; break,
+            };
+            // handle msg
+        },
+        Some(msg) = chan2.recv() =&gt; {
+            // handle msg
+        },
+    }
+}</code></pre>
+
+<p>如果 <code>chan1</code> 关闭，即使<code>chan2</code>仍然打开，上述循环也将退出。 如果<code> chan2</code>  是 Actor 循环的一部分，则这会中断该循环并让 Actor 关闭。</p>
+
+<p>只需要简单的在循环里调用  <a href='https://docs.rs/tokio/1/tokio/task/struct.JoinHandle.html#method.abort'>`abort`</a> 就可以了。</p>
+
+<h3 id='多个_actors_共享一个_handle'>多个 Actors 共享一个 handle</h3>
+
+<p>​	就像每个 Actor 可以共享多个 handle 一样，每个 handle 也可以共享多个  Actors 。 最常见的示例是在处理诸如 <code>TcpStream</code>之类的连接时，通常会产生两个任务：一个用于读，一个用于写。 使用此模式时，需要将读和写入任务变得尽可能简单——它们的唯一工作就是执行IO。 读任务会将接收到的所有消息发送给其他任务，通常是另一个 Actor ，而写任务会将接收到的所有消息转发给连接。 这种模式非常有用，因为它把与执行IO相关的复杂性隔离开来，这意味着其他程序部分可以假装将某些内容立即写入连接，尽管实际的写入其实是在 Actor 处理消息后进行的。</p>
+
+<h2 id='当心循环'>当心循环</h2>
+
+<p>​	我已经在<code>Actors 间发送信息</code> 标题下讨论了一些关于循环的问题，在此我讨论了如何关闭循环的Actors。但是，如何关闭并不是循环可能导致的唯一问题，因为这种循环还会产生死锁，循环中的每个 Actor 都在等待下一个 Actor 接收消息，但是下一个 Actor 直到它的下一个Actor接收到消息才会接收到该消息，依此类推。 为避免这种死锁，必须确保循环的信道容量都不受限。这样做的原因是有界信道上的 <code>send</code> 方法不会立即返回，而具有立即返回<code>send</code> 方法的信道是不记入这种循环，因为这种<code>send</code>方法是不会产生死锁的。 当心，这意味着<code>oneshot</code> 信道也不会产生死锁，因为它们也有 立即返回的 <code>send</code>  方法。还要当心，如果使用的是 <code>try_send</code> 而不是<code>send</code>来发送消息，那么这也不是死锁循环的一部分。</p>
+
+<p>感谢 <a href='https://matklad.github.io/'>matklad</a>指出循环和死锁的问题。</p>
+
+<h2 id=''></h2>
+
+<p>译者简介：</p>
+
+<p>Matrixtang，Rust/cpp 程序员，对编译相关领域感兴趣，不会 pwn 的安全爱好者。</p>
+]]></content:encoded></item><item><title>解读 Rust 1.50 稳定版</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_1.50.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='解读_rust_1.50_稳定版'>解读 Rust 1.50 稳定版</h1>
+
+<p>作者：张汉东 / 后期编辑： 张汉东</p>
+
+<h2 id=''></h2>
+
+<ol type="2">
+<li>年 2 月 11 号，<a href='https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html'>Rust 1.50 稳定版发布</a>。1.50 版更新包括：</li>
+</ol>
+
+<ul>
+<li>语言级特性</li>
+
+<li>编译器</li>
+
+<li>标准库</li>
+
+<li>稳定的 API</li>
+
+<li>Cargo 相关</li>
+
+<li>其他</li>
+
+<li>兼容性提示</li>
+</ul>
+
+<p>以下挑一些重点讲解。</p>
+
+<h1 id='语言级特性'>语言级特性</h1>
+
+<h3 id='常量泛型_`[const;_n]`_进一步得到完善：'><a href='https://rust-lang.github.io/rfcs/2000-const-generics.html'>常量泛型 `[CONST; N]`</a> 进一步得到完善：</h3>
+
+<ul>
+<li>常量泛型数组实现了 <code>ops::Index</code> 和 <code>ops::IndexMut</code>。</li>
+
+<li>值重复的常量数组<code>[x; N]</code>现在支持 常量值作为 x ，无论 x 是否实现 <code>Copy</code>。</li>
+</ul>
+
+<p>Rust 有一种内置数组类型<code>[T; LEN]</code>，但是这个 <code>LEN</code>一直无法支持泛型，所以这类数组就沦为了二等公民。比如 <code>[0,0,0]</code>和<code>[0,0,0,0]</code>不是同一个类型。所谓一等公民应该是不管数组长度如何，至少可以用同一个类型表示。为了提升这个数组类型，就引入了常量泛型的支持。<code>[CONST; N]</code> 是从 1.38 版本开始筹划，在 Rust 1.38~1.46 版本内，引入了一个<code>std::array::LengthAtMost32</code>来限制默认<code>[T; LEN]</code>的长度不能超过 32 。到 Rust 1.47 版本，首次在内部引入了 <code>[CONST; N]</code> 的支持。</p>
+
+<p>直到 <code>Rust 1.50 </code>版本，进一步对<code>[CONST; N]</code> 功能进行了完善。</p>
+
+<p>对常量泛型数组实现了 <code>ops::Index</code> 和 <code>ops::IndexMut</code>：</p>
+
+<pre><code class="language-`rust">fn second&lt;C&gt;(container: &amp;C) -&gt; &amp;C::Output
+where
+    C: std::ops::Index&lt;usize&gt; + ?Sized,
+{
+    &amp;container[1]
+}
+
+fn main() {
+    let array: [i32; 3] = [1, 2, 3];
+    assert_eq!(second(&amp;array[..]), &amp;2); // 之前必须转成切片才可以
+    assert_eq!(second(&amp;array), &amp;2); // 现在直接传引用就可以了
+}</code></pre>
+
+<p>值重复的常量数组<code>[x; N]</code>现在支持 常量值作为 x ：</p>
+
+<pre><code class="language-`rust">fn main() {
+    // 这行代码是不允许的，因为`Option&lt;Vec&lt;i32&gt;&gt;` 没有实现 `Copy`。
+    let array: [Option&lt;Vec&lt;i32&gt;&gt;; 10] = [None; 10];
+
+  	// 但是，现在改成 `const` 定义就可以了
+    const NONE: Option&lt;Vec&lt;i32&gt;&gt; = None;
+    const EMPTY: Option&lt;Vec&lt;i32&gt;&gt; = Some(Vec::new());
+
+    // 虽然没有实现`Copy`，但是现在可以重复`const`的值了。
+    let nones = [NONE; 10];
+    let empties = [EMPTY; 10];
+}</code></pre>
+
+<p>这样写起来可能比较麻烦，但是在随后 <a href='https://github.com/rust-lang/rfcs/blob/master/text/2920-inline-const.md'>RFC 2920: inline const </a>功能稳定后，就可以写成下面这种形式了：</p>
+
+<pre><code class="language-`rust">fn main() {
+    // 这行代码是不允许的，因为`Option&lt;Vec&lt;i32&gt;&gt;` 没有实现 `Copy`。
+    let array: [Option&lt;Vec&lt;i32&gt;&gt;; 10] = [None; 10];
+
+    // 虽然没有实现`Copy`，但是现在可以重复`const`的值了。
+    let nones : [Option&lt;Vec&lt;i32&gt;&gt;; 10] = [const {None}; 10];
+    let empties : [Option&lt;Vec&lt;i32&gt;&gt;; 10]  = [const {Some(Vec::new())}; 10];
+}</code></pre>
+
+<p>其实可以 Rust 本可以做到下面这种形式：</p>
+
+<pre><code class="language-`rust">fn main() {
+    // 这行代码是不允许的，因为`Option&lt;Vec&lt;i32&gt;&gt;` 没有实现 `Copy`。
+    let array: [Option&lt;Vec&lt;i32&gt;&gt;; 10] = [None; 10];
+
+    // 虽然没有实现`Copy`，但是现在可以重复`const`的值了。
+    let nones : [Option&lt;Vec&lt;i32&gt;&gt;; 10] = [None; 10];
+    let empties : [Option&lt;Vec&lt;i32&gt;&gt;; 10]  = [Some(Vec::new()); 10];
+}</code></pre>
+
+<p>上面<code>None</code>和<code>Some(Vec::new())</code>可以自动被编译器提升为常量，但这样可能为用户带来困扰，对于一些不能被自动提升为常量的类型，还需要用户去学习一大堆<a href='https://github.com/rust-lang/const-eval/blob/master/promotion.md#promotability'>常量提升规则</a>，并且使用 <code>const fn</code>等功能来定义常量。倒不如显示地加一个 const 块表达式来直接标注更好。</p>
+
+<p>另外，关于<code>#![feature(min_const_generics)]</code><a href='https://github.com/rust-lang/rust/pull/79135'>将在 Rust 1.51 中稳定</a>，预计 <code>2021-03-25</code>。</p>
+
+<h3 id='将共用体(_union_)中_`manualdrop`_类型字段的分配视为安全'>将共用体(<code>union</code>)中<a href='https://doc.rust-lang.org/stable/std/mem/struct.ManuallyDrop.html?search='>`ManualDrop`</a>类型字段的分配视为安全</h3>
+
+<pre><code class="language-`rust">// Rust 1.49 新增特性，允许 union 中使用 ManuallyDrop
+use core::mem::ManuallyDrop;
+
+union MyUnion {
+    f1: u32,
+    f2: ManuallyDrop&lt;String&gt;,
+}
+
+fn main() {
+    let mut u = MyUnion { f1: 1 };
+
+    // These do not require `unsafe`.
+    u.f1 = 2;
+    u.f2 = ManuallyDrop::new(String::from(&quot;example&quot;));
+}</code></pre>
+
+<p>在<code>Union</code> 类型 中 <code>Copy</code>或<code>ManuallyDrop</code>的字段不会调用析构函数，所以不必加 <code>unsafe</code>块。</p>
+
+<p>进一步，当 Drop 一个 Union 类型的时候，需要手工去实现 Drop。因为 共用体 本身的特性，它不会知道该 drop 哪个字段才是安全的，所以才需要字段都是 <code>Copy</code> 或 <code>ManuallyDrop</code>的。</p>
+
+<pre><code class="language-`rust">#![feature(untagged_unions)]
+use std::mem::ManuallyDrop;
+use std::cell::RefCell;
+
+union U1 {
+    a: u8
+}
+
+union U2 {
+    a: ManuallyDrop&lt;String&gt;
+}
+
+union U3&lt;T&gt; {
+    a: ManuallyDrop&lt;T&gt;
+}
+
+union U4&lt;T: Copy&gt; {
+    a: T
+}
+
+// 对于 ManuallyDrop 之外的 非 Copy 类型，目前还是 unstable，需要 `#![feature(untagged_unions)]` 特性门支持。
+union URef {
+    p: &amp;&#8217;static mut i32,
+}
+
+// RefCell 没有实现 Drop ，但是它是非 Copy 的
+union URefCell { // field that does not drop but is not `Copy`, either
+    a: (RefCell&lt;i32&gt;, i32),
+}
+
+fn generic_noncopy&lt;T: Default&gt;() {
+    let mut u3 = U3 { a: ManuallyDrop::new(T::default()) };
+    u3.a = ManuallyDrop::new(T::default()); // OK (assignment does not drop)
+    
+}
+
+fn generic_copy&lt;T: Copy + Default&gt;() {
+    let mut u3 = U3 { a: ManuallyDrop::new(T::default()) };
+    u3.a = ManuallyDrop::new(T::default()); // OK
+    
+    let mut u4 = U4 { a: T::default() };
+    u4.a = T::default(); // OK
+}
+
+fn main() {
+    let mut u1 = U1 { a: 10 }; // OK
+    
+    u1.a = 11; // OK
+
+    let mut u2 = U2 { a: ManuallyDrop::new(String::from(&quot;old&quot;)) }; // OK
+    u2.a = ManuallyDrop::new(String::from(&quot;new&quot;)); // OK (assignment does not drop)
+
+    let mut u3 = U3 { a: ManuallyDrop::new(0) }; // OK
+    u3.a = ManuallyDrop::new(1); // OK
+
+    let mut u3 = U3 { a: ManuallyDrop::new(String::from(&quot;old&quot;)) }; // OK
+    u3.a = ManuallyDrop::new(String::from(&quot;new&quot;)); // OK (assignment does not drop)
+    
+}</code></pre>
+
+<h1 id='编译器'>编译器</h1>
+
+<ul>
+<li><a href='https://github.com/rust-lang/rust/pull/78142'>添加对`armv5te-unknown-linux-uclibcgnueabi`目标的内置支持</a>。 基于ARMv5TE指令集的，你可以认为是ARM处理器，但实际上已经有原来intel的很多技术在里面进行了修改。</li>
+
+<li><a href='https://github.com/rust-lang/rust/pull/77484'>在ARM Mac上添加对Arm64 Catalyst的支持</a>。苹果很快将发布基于ARM64的Mac，macOS应用将使用在ARM上运行的Darwin ABI。 该PR增加了对ARM Macs上Catalyst应用程序的支持：为darwin ABI编译的iOS应用程序。</li>
+
+<li><a href='https://github.com/rust-lang/rust/pull/79484'>修复 FreeBSD 上的链接问题</a>。在FreeBSD上，有时会出现一个问题，即使基本系统中包含<code>lld</code>，由于 Rust 未找到链接程序，链接 Rust 程序也会失败。 这似乎主要影响裸机/交叉编译，例如<code>wasm</code>构建和<code>arm / riscv</code>裸机工作（例如，尝试编译时）。 在<code>Linux</code>和其他操作系统上，启用了用于构建 Rust 的完整工具，因此没有链接问题。 如果使用这些选项正确构建了 Rust，则此PR应该可以在FreeBSD上启用完整的功能。</li>
+</ul>
+
+<p>除了这三个，还有其他 target 支持，查看<a href='https://forge.rust-lang.org/release/platform-support.html'>Platform Support 页面</a>。</p>
+
+<h1 id='标准库'>标准库</h1>
+
+<h3 id='为`proc_macro::punct`增加_`partialeq<char>_`'><a href='https://github.com/rust-lang/rust/pull/78636'>为`proc_macro::Punct`增加 `PartialEq&lt;char&gt; `</a></h3>
+
+<p>用于在宏中判断特殊标点符号更加方便。比如：</p>
+
+<pre><code class="language-`rust">// ...
+else if let TokenTree::Punct(ref tt) = tree {
+  if tt.as_char() == &#8217;$&#8217; {
+    after_dollar = true;
+    return None;
+  }
+  // ...
+ if p.as_char() == &#8217;&gt;&#8217; { 
+  // ...
+if tt.as_char() == &#8217;=&#8217; { </code></pre>
+
+<h3 id='unix_平台优化：_option<file>_大小等价于_file'>Unix 平台优化：<code>Option&lt;File&gt;</code> 大小等价于 <code>File</code></h3>
+
+<p>在Unix平台上，Rust 的文件仅由系统的整数文件描述符组成，并且它永远不会为<code>-1</code>！ 返回文件描述符的系统调用使用<code>-1</code>表示发生了错误（检查errno），因此<code>-1</code>不可能是真实的文件描述符。 从<code>Rust 1.50</code>开始，此niche（特定生态场景）被添加到类型的定义中，因此它也可以用于布局优化。 因此，<code>Option &lt;File&gt;</code>现在将具有与<code>File</code>本身相同的大小！</p>
+
+<h1 id='兼容性变更'>兼容性变更</h1>
+
+<h3 id='过期_compare_and_swap_方法'><a href='https://github.com/rust-lang/rust/pull/79261'>过期 compare_and_swap 方法</a></h3>
+
+<p>推荐使用 <code>compare_exchange</code> 和 <code>compare_exchange_weak</code>。过期这个cas方法一方面是为了和<code> cpp</code> 的  <code>compare_exchange_strong</code> 和  <code>compare_exchange_weak</code> 对应，另一方面也是为了避免使用这个cas在 arm 架构下产生不必要的指令，因为有 cas 的时候，很多人可能会直接使用 cas，从而在 ARM 下产生不必要的指令。</p>
+
+<p>&gt; &gt; ARM 架构实现LL/SC对(load-linked/store-conditional) ，可以基于它们实现 cas。Load-linked（LL） 运算仅仅返回指针地址的当前变量值，如果指针地址中的内存数据在读取之后没有变化，那么 Store-conditional（SC）操作将会成功，它将LL读取 指针地址的存储新的值，否则，SC将执行失败。</p>
+
+<p>&gt; &gt; 通过LL/SC对实现的CAS并不是一个原子性操作，但是它确实执行了原子性的CAS，目标内存单元内容要么不变，要么发生原子性变化。由于通过LL/SC对实现的CAS并不是一个原子性操作，于是，该CAS在执行过程中，可能会被中断。因此<code>C++11</code>标准中添入两个<code>compare_exchange</code>原语: <code>compare_exchange_weak</code>和<code>compare_exchange_strong</code>。即使当前的变量值等于预期值，这个弱的版本也可能失败，比如返回false。可见任何weak CAS都能破坏CAS语义，并返回false，而它本应返回true。而Strong CAS会严格遵循CAS语义。</p>
+
+<p>&gt; &gt; 何种情形下使用Weak CAS，何种情形下使用Strong CAS呢？通常执行以下原则：</p>
+
+<p>&gt; &gt; 倘若CAS在循环中（这是一种基本的CAS应用模式），循环中<strong>不存在</strong>成千上万的运算（循环体是轻量级和简单的），使用<code>compare_exchange_weak</code>。否则，采用强类型的<code>compare_exchange_strong</code>。</p>
+
+<p>因此，Rust 标准库过期 cas 方法，就是为了让开发者可以根据场景来判断使用 强还是弱的 cas 语义。而 标准库里的cas方法则只是对 <code>compare_exchange</code> 的包装，而 Rust 中 <code>compare_exchange</code> 对应 强CAS 语义，所以容易被滥用。</p>
+
+<h3 id='放弃对所有_cloudabi_target_的支持'><a href='https://github.com/rust-lang/rust/pull/78439'>放弃对所有 cloudabi target 的支持</a></h3>
+
+<p>包括：</p>
+
+<ul>
+<li>aarch64-unknown-cloudabi</li>
+
+<li>armv7-unknown-cloudabi</li>
+
+<li>i686-unknown-cloudabi</li>
+
+<li>x86_64-unknown-cloudabi</li>
+</ul>
+
+<p>因为 <a href='https://github.com/NuxiNL/cloudabi#note-this-project-is-unmaintained'>CloudABI 不再被维护了</a>，可以考虑 WASI 了，WASI 的一些概念就是受到 CloudABI 的启发，现在算是 CloudABI 的接班人了。</p>
+]]></content:encoded></item><item><title>解读 Rust 2021 Edition RFC </title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_2021_edition.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='解读_rust_2021_edition_rfc'>解读 Rust 2021 Edition RFC</h1>
+
+<p>作者/编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>目前 Rust 2021 Edition 正在讨论中，<a href='https://github.com/rust-lang/rfcs/pull/3085'>RFC 3085</a> 目前已经取代了 <a href='https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md'>RFC 2052</a> 成为新的 RFC。</p>
+
+<p><code>Edition</code> 在RFC 2052中提出，Rust在2018年发布了第一个 Edition版本。这项工作在许多方面都是成功的，但也带来了一些困难的教训。 RFC 3085 为 2021 Edition 提出了不同的模型。 需要注意的是，目前该 RFC 还未合并。</p>
+
+<h3 id='「2021_edition_模型」讨论的关键点包括：'>「2021 Edition 模型」讨论的关键点包括：</h3>
+
+<ul>
+<li><code>Edition</code> 用于将语言引入更改，否则可能会破坏现有代码，例如引入新关键字。</li>
+
+<li><code>Edition</code> 永远不允许分裂生态系统。 我们只允许不同版本的 crate 进行互操作的更改。</li>
+
+<li><code>Edition</code> 以其出现的年份命名（例如，Rust 2015，Rust 2018，Rust 2021）。</li>
+
+<li>发布新 <code>Edition</code> 时，我们还会发布工具以自动执行 crate 的迁移。 可能需要进行一些手动操作，但是这种情况很少见。</li>
+
+<li>Nightly 工具链提供对即将发布的 <code>Edition</code> 的“预览”访问权限，以便我们可以随时进行针对将来 <code>Edition</code> 的工作。</li>
+
+<li>我们维护一个《<code>Edition</code> 迁移指南》，其中提供了有关如何迁移到下一 <code>Edition</code> 的指南。</li>
+
+<li>只要有可能，都应使新功能适用于所有 <code>Edition</code> 。</li>
+</ul>
+
+<p>该RFC旨在确立 <code>Edition</code> 的高级用途，并描述RFC对最终用户的感觉。 它有意避免进行详细的策略讨论，这些讨论将由相应的子团队（编译器，lang，开发工具等）来解决。</p>
+
+<h3 id='目标与设计原则'>目标与设计原则</h3>
+
+<p>顺序代表优先级</p>
+
+<ol type="1">
+<li><code>Edition</code>不能分裂生态系统。</li>
+</ol>
+
+<p>最重要的一条规则是：一个<code>Edition</code>中的 crate 可以与其他<code>Edition</code>中编译的 crate 无缝地互操作。不管<code>Edition</code>如何，所有 Rust 代码最终都会在编译器中编译为相同的内部 IR。</p>
+
+<ol type="2">
+<li><code>Edition</code> 迁移应该很方便且尽最大可能自动化完成。</li>
+</ol>
+
+<p>在发布新<code>Edition</code>的同时也会发布一些工具帮助自动升级<code>Edition</code>。并且维护《<code>Edition</code>迁移指南》以便手动迁移之需。</p>
+
+<ol type="3">
+<li>
+<p>由用户来控制何时使用新的<code>Edition</code></p>
+</li>
+
+<li>
+<p><code>Edition</code> 注定是要被使用的。目标是看到所有Rust用户都采用新<code>Edition</code>。</p>
+</li>
+
+<li>
+<p>Rust 应该感觉像是一种语言，而非被 <code>Edition</code> 分割为多种“方言”。</p>
+</li>
+</ol>
+
+<p><code>Edition</code>向 Rust 引入了向后不兼容的更改，从而又增加了 Rust 开始感觉像具有多种方言的语言的风险。 我们想要避免人们进入 Rust 项目的经历，并对给定的代码含义或可以使用的功能种类感到不确定。 这就是为什么我们更喜欢基于年份的版本（例如Rust 2018，Rust 2021），这些版本将许多更改组合在一起，而不是细粒度的选择加入; 可以简洁地描述基于年份的版本，并确保当您进入代码库时，相对容易地确定可以使用哪些功能。</p>
+
+<h3 id='一些背景'>一些背景</h3>
+
+<p>Rust 2018版在 RFC 2052中被描述为一个“集结点”，不仅引入了一些迁移，而且还是许多其他更改（例如更新本书，实现连贯的新API集等）的目标。这在很多方面都很有帮助，但在其他方面却是有害的。 例如，在是否有必要升级到新<code>Edition</code>以使用其功能方面存在一定的困惑（尚不清楚该困惑是否具有除困惑之外的其他负面影响）。 这也是组织本身将所有内容整合在一起的压力。 它与「火车模型」相反，后者旨在确保我们具有“低压力”发布。</p>
+
+<p>相反，2021版故意是“低调”事件，其重点仅在于介绍已进行了一段时间的一些迁移，惯用法lint和其他工作。 我们没有将其与其他无关的更改进行协调。 这并不是说我们永远不应该再发布“集结点”。 但是，目前，我们在工作中并没有一整套协调一致的变化，我们需要将这些变化汇总在一起。</p>
+
+<p>但是，由于此更改，Rust 2018的一项好处可能会丢失。 有一定比例的潜在Rust用户可能对Rust感兴趣，但兴趣不足以跟进每个<code>Edition</code>并跟踪发生了什么变化。 对于这些用户，一篇博客文章列出了Rust 2018以来发生的所有令人振奋的事情，足以说服他们尝试一下Rust。 我们可以通过发布回顾过去几年的回顾来解决这个问题。 但是，我们不必将此回顾与<code>Edition</code>联系在一起，因此，此RFC中未对此进行描述。</p>
+
+<h3 id='小结'>小结</h3>
+
+<p>通过以上内容，我想你应该对目前官方的 Rust 2021 Edition 工作内容有所了解。目前该 RFC 还在持续且激烈的讨论中，更多内容可以移步<a href='https://github.com/rust-lang/rfcs/pull/3085'>该 RFC 的 PR</a>中参看。</p>
+
+<p>在官方的 <a href='https://doc.rust-lang.org/edition-guide/rust-next/index.html'>Edition Guide</a> 文档中，已经增加了 <a href='https://doc.rust-lang.org/edition-guide/rust-next/index.html#the-next-edition'>Next Edition</a> 可能发布的功能集合，感兴趣可以自行关注。</p>
+]]></content:encoded></item><item><title>前端入门 ｜ Rust 和 WebAssembly </title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_wasm_frontend.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='前端入门_｜_rust_和_webassembly'>前端入门 ｜ Rust 和 WebAssembly</h1>
+
+<p>作者: 陈鑫(lencx) / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='wasm是什么?'>Wasm是什么?</h2>
+
+<p>&gt; &gt; <a href='https://developer.mozilla.org/en-US/docs/WebAssembly'>MDN官方文档</a>是这样给出定义</p>
+
+<p><code>WebAssembly</code>(为了书写方便，简称<code>Wasm</code>)是一种新的编码方式，可以在现代的网络浏览器中运行 － 它是一种低级的类汇编语言，具有紧凑的二进制格式，可以接近原生的性能运行，并为诸如C / C ++等语言提供一个编译目标，以便它们可以在Web上运行。它也被设计为可以与JavaScript共存，允许两者一起工作。</p>
+
+<p>对于网络平台而言，WebAssembly具有巨大的意义——它提供了一条途径，以使得以各种语言编写的代码都可以以接近原生的速度在Web中运行。在这种情况下，以前无法以此方式运行的客户端软件都将可以运行在Web中。</p>
+
+<p>WebAssembly被设计为可以和JavaScript一起协同工作——通过使用WebAssembly的JavaScript API，你可以把WebAssembly模块加载到一个JavaScript应用中并且在两者之间共享功能。这允许你在同一个应用中利用WebAssembly的性能和威力以及JavaScript的表达力和灵活性，即使你可能并不知道如何编写WebAssembly代码。</p>
+
+<h2 id=''></h2>
+
+<h2 id='环境安装及简介'>环境安装及简介</h2>
+
+<h3 id='1._rust'>1. <a href='https://www.rust-lang.org/zh-CN/learn/get-started'>Rust</a></h3>
+
+<p>&gt; &gt; 一门赋予每个人 <br />&gt; 构建可靠且高效软件能力的语言。</p>
+
+<p>安装</p>
+
+<pre><code class="language-`bash"># macOS
+curl --proto &#8217;=https&#8217; --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# 其他安装方式
+# https://forge.rust-lang.org/infra/other-installation-methods.html</code></pre>
+
+<p>常用命令</p>
+
+<pre><code class="language-`bash"># 版本更新
+rustup update
+
+# 查看版本
+cargo --version
+
+# 构建项目
+cargo build
+
+# 运行项目
+cargo run
+
+# 测试项目
+cargo test
+
+# 为项目构建文档
+cargo doc
+
+# 将库发布到 crates.io
+cargo publish</code></pre>
+
+<pre><code class="language-`bash"># nightly rust
+rustup toolchain install nightly
+
+rustup toolchain list
+
+rustup override set nightly</code></pre>
+
+<h3 id='2._node.js'>2. <a href='https://nodejs.org/en/download'>Node.js</a></h3>
+
+<p>&gt; &gt; Node.js是基于Chrome的V8 JavaScript引擎构建的JavaScript运行时</p>
+
+<h3 id='3._wasm-pack'>3. <a href='https://github.com/rustwasm/wasm-pack'>wasm-pack</a></h3>
+
+<p>&gt; &gt; 用于构建和使用您希望与JavaScript，浏览器或Node.js互操作的Rust生成的WebAssembly。</p>
+
+<p>安装</p>
+
+<pre><code class="language-`bash"># macOS
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# 其他安装方式
+# https://rustwasm.github.io/wasm-pack/installer</code></pre>
+
+<p>常用命令</p>
+
+<pre><code class="language-`bash"># 创建
+# https://rustwasm.github.io/docs/wasm-pack/commands/new.html
+wasm-pack new &lt;name&gt; --template &lt;template&gt; --mode &lt;normal|noinstall|force&gt;
+
+# 构建
+# https://rustwasm.github.io/docs/wasm-pack/commands/build.html
+wasm-pack build
+  [--out-dir &lt;out&gt;]
+  [--out-name &lt;name&gt;]
+  [--&lt;dev|profiling|release&gt;]
+  [--target &lt;bundler|nodejs|web|no-modules&gt;]
+  [--scope &lt;scope&gt;]
+  [mode &lt;normal|no-install&gt;]
+
+# 测试
+# https://rustwasm.github.io/docs/wasm-pack/commands/test.html
+wasm-pack test
+
+# 发包
+# https://rustwasm.github.io/docs/wasm-pack/commands/pack-and-publish.html
+# npm pack
+wasm-pack pack
+# npm publish
+wasm-pack publish</code></pre>
+
+<h3 id='4._vite'>4. <a href='https://vitejs.dev'>Vite</a></h3>
+
+<p>&gt; &gt; 下一代前端工具</p>
+
+<p><strong><a href='https://github.com/lencx/vite-plugin-rsw'>vite-plugin-rsw</a>：vite插件，简称<code>Rsw</code> - 集成<code>wasm-pack</code>的CLI</strong></p>
+
+<ul>
+<li>支持rust包文件热更新，监听<code>src</code>目录和<code>Cargo.toml</code>文件变更，自动构建</li>
+
+<li>vite启动优化，如果之前构建过，再次启动<code>npm run dev</code>，则会跳过<code>wasm-pack</code>构建</li>
+</ul>
+
+<pre><code class="language-`bash"># 在vite项目中安装
+npm i -D vite-plugin-rsw
+# or
+yarn add -D vite-plugin-rsw</code></pre>
+
+<h3 id='5._create-xc-app'>5. <a href='https://github.com/lencx/create-xc-app'>create-xc-app</a></h3>
+
+<p>&gt; &gt; 脚手架 - ⚡️在几秒钟内创建一个项目！维护了多种项目模板。</p>
+
+<pre><code class="language-`bash"># 根据命令行提示，输入项目名称，选择模板初始化项目
+# template: `wasm-react` or `wasm-vue`
+npm init xc-app</code></pre>
+
+<p><img src='./wasm_fronted/rust_wasm_frontend-xc-app.png' alt='xc-app' /></p>
+
+<h2 id='快速开始'>快速开始</h2>
+
+<ul>
+<li>在原有<code>vite</code>项目中使用，只需安装配置<code>vite-plugin-rsw</code>插件即可。</li>
+
+<li>新项目可以使用<code>vite</code>提供的<code>@vitejs/app</code>初始化项目，然后安装配置<code>vite-plugin-rsw</code>。</li>
+
+<li>或者使用脚手架<code>create-xc-app</code>初始化项目，模板包含<code>wasm-react</code>和<code>wasm-vue</code>，会定期更新维护相关版本依赖。</li>
+</ul>
+
+<h3 id='项目结构'>项目结构</h3>
+
+<pre><code class="language-`bash"># 推荐目录结构
+[my-wasm-app] # 项目根路径
+|- [wasm-hey] # npm包`wasm-hey`
+|    |- [pkg] # 生成wasm包的目录
+|    |    |- wasm-hey_bg.wasm # wasm文件
+|    |    |- wasm-hey.js # 包入口文件
+|    |    |- wasm-hey_bg.wasm.d.ts # ts声明文件
+|    |    |- wasm-hey.d.ts # ts声明文件
+|    |    |- package.json
+|    |    `- ...
+|    |- [src] # rust源代码
+|    | # 了解更多: https://doc.rust-lang.org/cargo/reference/cargo-targets.html
+|    |- [target] # 项目依赖，类似于npm的`node_modules`
+|    | # 了解更多: https://doc.rust-lang.org/cargo/reference/manifest.html
+|    |- Cargo.toml # rust包管理清单
+|    `- ...
+|- [@rsw] # npm 组织包
+|     |- [hey] # @rsw/hey, 目录结构同`wasm-hey`
+|     `- ...
+|- [node_modules] # 前端的项目包依赖
+|- [src] # 前端源代码(可以是vue, react, 或其他)
+| # 了解更多: https://nodejs.dev/learn/the-package-json-guide
+|- package.json # `npm`或`yarn`包管理清单
+| # 了解更多: https://vitejs.dev/config
+|- vite.config.ts # vite配置文件
+| # 了解更多: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+|- tsconfig.json # typescript配置文件
+` ...</code></pre>
+
+<p>乍一看，可能会觉得目录有点复杂，其实它就是一个标准的基于<code>vite</code>前端项目，然后，在根路径下去添加我们需要构建的wasm包(一个rust crate会对应生成一个wasm包，可单独发布到npm上)</p>
+
+<h3 id='创建wasm包'>创建Wasm包</h3>
+
+<pre><code class="language-`bash"># 两种方式创建
+
+# 1.
+# 如果报错，可查看：https://github.com/rustwasm/wasm-pack/issues/907
+wasm-pack new &lt;name&gt;
+
+# 2.
+# name可以是npm组织
+# 例：cargo new --lib @rsw/hello
+# 需要手动配置Cargo.toml
+cargo new --lib &lt;name&gt;</code></pre>
+
+<p><img src='./wasm_fronted/rust_wasm_frontend-wasm-pack-new.png' alt='wasm-pack new' /> <img src='./wasm_fronted/rust_wasm_frontend-caro-new.png' alt='cargo new' /></p>
+
+<h3 id='项目配置'>项目配置</h3>
+
+<p>&gt; &gt; 以react项目为例</p>
+
+<p><strong>Step1: 配置Vite插件</strong> - <code>vite.config.ts</code></p>
+
+<pre><code class="language-`js">import reactRefresh from &#8217;@vitejs/plugin-react-refresh&#8217;;
+import { defineConfig } from &#8217;vite&#8217;;
+import ViteRsw from &#8217;vite-plugin-rsw&#8217;;
+
+export default defineConfig({
+  plugins: [
+    reactRefresh(),
+    // 查看更多：https://github.com/lencx/vite-plugin-rsw
+    ViteRsw({
+      // 支持开发(dev)和生产模式(release)
+      // 生产模式会对wasm文件的体积进行优化
+      mode: &quot;release&quot;,
+      // 如果包在`unLinks`和`crates`都配置过
+      // 会执行，先卸载(npm unlink)，再安装(npm link)
+      // 例如下面会执行
+      // `npm unlink wasm-hey rsw-test`
+      unLinks: [&#8217;wasm-hey&#8217;, &#8217;rsw-test&#8217;],
+      // 项目根路径下的rust项目
+      // `@`开头的为npm组织
+      // 例如下面会执行:
+      // `npm link wasm-hey @rsw/hey`
+      // 因为执行顺序原因，虽然上面的unLinks会把`wasm-hey`卸载
+      // 但是这里会重新进行安装
+      crates: [&quot;wasm-hey&quot;, &quot;@rsw/hey&quot;],
+    }),
+  ],
+})</code></pre>
+
+<p><strong>Step2: 配置Rust项目清单</strong> - <code>wasm-hey/Cargo.toml</code></p>
+
+<pre><code class="language-`toml"># ...
+
+# https://github.com/rustwasm/wasm-pack/issues/886
+# https://developers.google.com/web/updates/2019/02/hotpath-with-wasm
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = [&quot;cdylib&quot;, &quot;rlib&quot;]
+
+[profile.release]
+opt-level = &quot;s&quot;
+
+[dependencies]
+wasm-bindgen = &quot;0.2.70&quot;</code></pre>
+
+<p><strong>Step3: 添加Rust代码</strong> - <code>wasm-hey/src/lib.rs</code></p>
+
+<pre><code class="language-`rust">use wasm_bindgen::prelude::*;
+
+// Import the `window.alert` function from the Web.
+#[wasm_bindgen]
+extern &quot;C&quot; {
+    fn alert(s: &amp;str);
+}
+
+// Export a `greet` function from Rust to JavaScript, that alerts a hello message.
+#[wasm_bindgen]
+pub fn greet(name: &amp;str) {
+    alert(&amp;format!(&quot;Hello, {}!&quot;, name));
+}</code></pre>
+
+<p><strong>Step4: React项目中调用Wasm方法</strong> - <code>src/App.tsx</code></p>
+
+<pre><code class="language-`jsx">import React, { useEffect } from &#8217;react&#8217;;
+import init, { greet } from &#8217;wasm-hey&#8217;;
+
+import logo from &#8217;./logo.svg&#8217;;
+import &#8217;./App.css&#8217;;
+
+function App() {
+  useEffect(() =&gt; {
+    // wasm初始化，在调用`wasm-hey`包方法时
+    // 必须先保证已经进行过初始化，否则会报错
+    // 如果存在多个wasm包，则必须对每一个wasm包进行初始化
+    init();
+  }, [])
+
+  const handleHey = () =&gt; {
+    // 调用greet方法
+    greet(&#8217;wasm&#8217;);
+  }
+
+  return (
+    &lt;div className=&quot;App&quot;&gt;
+      &lt;header className=&quot;App-header&quot;&gt;
+        &lt;img src={logo} className=&quot;App-logo&quot; alt=&quot;logo&quot; /&gt;
+        &lt;p&gt;Hello WebAssembly!&lt;/p&gt;
+        &lt;p&gt;Vite + Rust + React&lt;/p&gt;
+        &lt;p&gt;
+          &lt;button onClick={handleHey}&gt;hi wasm&lt;/button&gt;
+        &lt;/p&gt;
+        &lt;p&gt;Edit &lt;code&gt;App.tsx&lt;/code&gt; and save to test HMR updates.&lt;/p&gt;
+      &lt;/header&gt;
+    &lt;/div&gt;
+  )
+}
+
+export default App</code></pre>
+
+<h2 id='常见问题汇总'>常见问题汇总</h2>
+
+<h3 id='rsw插件'>Rsw插件</h3>
+
+<ul>
+<li>插件内部是通过<code>npm link</code>的形式实现的wasm包安装，在一些极端场景下会出现，找不到依赖的安装包，导入的包不存在等错误，可以根据提示路径删除其link的文件，重新启动<code>npm run dev</code>可以解决。</li>
+
+<li><code>npm link</code>命令会把包<code>link</code>到全局环境，如果在多个项目使用相同wasm包名，可能会导致报错，解决办法，在全局npm的<code>node_modules</code>中删除该包即可。推荐不同项目使用不同wasm包名避免此类异常。</li>
+
+<li>插件是处于Vite开发模式下运行构建，所以至少执行过一次<code>npm run dev</code>，生成<code>wasm</code>包之后，再执行<code>npm run build</code>，否则也会报错，到不到<code>.wasm</code>文件之类的。</li>
+
+<li>插件API可以配置需要卸载的包(仅限于之前通过插件配置<code>crates</code>中rust项目)</li>
+</ul>
+
+<h3 id='前端'>前端</h3>
+
+<pre><code class="language-`js">// init是wasm实例的初始化方法
+// 在调用其他方法之前，必须先调用一次init方法，否则会报错
+// init会请求`.wasm`文件并且返回一个`Promise`
+import init, { greet } from &#8217;wasm-test&#8217;;
+
+// -----------------------------------------
+
+// 调用init方法，有两种方式
+
+// 1.
+// 在react，vue3中可以将其抽离为`hook`组件,
+// 在进入生命周期时调用
+init();
+
+// 在调用过init方法之后，可以单独调用greet方法
+greet(&#8217;wasm&#8217;);
+
+// 2.
+// 在初始化之后直接调用方法
+init()
+  .then(wasm =&gt; wasm.greet(&#8217;wasm&#8217;));</code></pre>
+
+<hr><h2 id='相关链接'>相关链接</h2>
+
+<ul>
+<li><a href='https://github.com/lencx/learn-wasm'>Wasm学习项目: lencx/learn-wasm</a></li>
+
+<li><a href='https://github.com/lencx/vite-plugin-rsw'>Vite插件Rsw - lencx/vite-plugin-rsw</a></li>
+
+<li><a href='https://github.com/lencx/create-xc-app'>项目脚手架 - lencx/create-xc-app</a></li>
+
+<li><a href='https://mtc.nofwl.com/awesome/wasm.html'>WebAssembly相关资源清单</a></li>
+</ul>
+
+<hr><ul>
+<li><a href='https://webassembly.org'>WebAssembly官网</a></li>
+
+<li><a href='https://www.rust-lang.org'>Rust官网 - 一门赋予每个人 构建可靠且高效软件能力的语言</a></li>
+
+<li><a href='https://nodejs.org'>Nodejs官网 - 基于Chrome的V8 JavaScript引擎构建的JavaScript运行时</a></li>
+
+<li><a href='https://vitejs.dev'>Vite官网 - 下一代前端工具</a></li>
+
+<li><a href='https://rustwasm.github.io/wasm-pack'>wasm-pack - Rust =&gt; WebAssembly</a></li>
+
+<li><a href='https://developer.mozilla.org/en-US/docs/WebAssembly/Rust_to_wasm'>rust-to-wasm</a></li>
+
+<li><a href='https://github.com/rustwasm/wasm-bindgen'>wasm-bindgen</a></li>
+</ul>
+
+<hr><p>作者简介：</p>
+
+<p>陈鑫(lencx)</p>
+
+<p>{折腾 ⇌ 迷茫 ⇌ 思考]ing，在路上...</p>
+
+<ul>
+<li>公众号：浮之静</li>
+
+<li>Blog: https://mtc.nofwl.com</li>
+
+<li>GitHub: https://github.com/lencx</li>
+</ul>
+]]></content:encoded></item><item><title>实践案例 | 使用 Bevy 游戏引擎制作炸弹人</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/rust_game_bevy_bomber.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='实践案例_|_使用_bevy_游戏引擎制作炸弹人'>实践案例 | 使用 Bevy 游戏引擎制作炸弹人</h1>
+
+<p>作者：Cupnfish / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h3 id='目录'>目录</h3>
+
+<ul>
+<li><a href='#引擎简介'>Bevy 引擎简介</a></li>
+
+<li><a href='#前言'>前言</a></li>
+
+<li><a href='#开发动机'>开发动机</a></li>
+
+<li><a href='#rust开发环境推介'>rust开发环境推介</a></li>
+
+<li><a href='#编译速度'>编译速度</a></li>
+
+<li><a href='#query-filter'>Query filter</a></li>
+
+<li><a href='#queryset'>QuerySet</a></li>
+
+<li><a href='#event'>Event</a></li>
+
+<li><a href='#timer'>Timer</a></li>
+
+<li><a href='#system的链接与代码复用'>`system`的链接与代码复用</a></li>
+
+<li><a href='#如何实现游戏的不同状态'>如何实现游戏的不同状态</a></li>
+
+<li><a href='#rapier简短笔记'>Rapier简短笔记</a></li>
+
+<li><a href='#通过rapier来实现碰撞过滤'>通过Rapier来实现碰撞过滤</a></li>
+
+<li><a href='#多平台支持'>多平台支持</a></li>
+
+<li><a href='#日志'>日志</a></li>
+
+<li><a href='#碎碎念'>碎碎念</a></li>
+</ul>
+
+<h3 id='引擎简介'>引擎简介</h3>
+
+<p>Bevy 是一款由Rust语言构建且简单明了的数据驱动的游戏引擎,永远开源免费!</p>
+
+<p>它的设计目标如下:</p>
+
+<ul>
+<li>功能:提供完整的2D和3D功能集</li>
+
+<li>简单:对于新手来说很容易上手，但是对于高级用户来说非常灵活</li>
+
+<li>以数据为中心:使用实体组件系统范式的面向数据的体系结构</li>
+
+<li>模块化:只使用你需要的。替换掉你不喜欢的东西</li>
+
+<li>快速:应用逻辑应该快速运行，并且在可能的情况下并行运行</li>
+
+<li>高效:变更应该能够快速编译…等待不是有趣的</li>
+</ul>
+
+<p><a href='https://bevyengine.org/'>官网了解更多</a>: https://bevyengine.org/</p>
+
+<h3 id='前言'>前言</h3>
+
+<p><a href='https://github.com/rgripper/rusty-bomber'>Rusty BomberMan</a>是著名的BomberMan小游戏的bevy复刻版。虽然说是复刻，但实际上和原本游戏长得完全不一样，原因是原版游戏的美术资源没搞到，所以另找了一些美术资源，十分感谢<a href='https://opengameart.org/'>opengameart.org</a>上<a href='https://github.com/rgripper/rusty-bomber#assets-and-attribution'>这些</a>美术资源。</p>
+
+<p>&gt; &gt; Changed: 1. 修正了之前刚体类型使用场景 2. 添加了目录，方便直接跳转想要阅读的内容。 3. 末尾加上了本人联系方式。 4. 原<code>Rapier</code>部分拆分成两个部分，更方便查阅。 5. 修正部分语句不通顺的地方。</p>
+
+<h3 id='开发动机'>开发动机</h3>
+
+<p>开发这个游戏的起因是当时我正在逛reddit，正好看到了<a href='https://github.com/rgripper'>@rgripper</a>发帖想找人一起写bevy项目，抱着学习、实践的心态，我和他联系之后一拍即合，随即开始了这个项目。</p>
+
+<h3 id='rust_开发环境推介'>Rust 开发环境推介</h3>
+
+<p>开发中使用最新版rust（建议nightly版本，bevy官网的快速开发迭代有推介用这个）。</p>
+
+<p>开发环境推介 <code>vscode</code> + <a href='https://github.com/rust-analyzer/rust-analyzer'>`rust-analyzer`</a>（建议安装最新发布版，尽量别用nightly版本，我喜欢自己下载源码编译。） + <a href='https://www.tabnine.com/'>`Tabline`</a>（可选），或者<code>Clion</code> + <a href='https://www.jetbrains.com/rust/'>`IntelliJ Rust`</a>。 前者可能需要自己折腾，后者开箱即用，不过<code>Clion</code>不是免费的。</p>
+
+<h3 id='编译速度'>编译速度</h3>
+
+<p>bevy的官网中有提到其编译速度很快，其中0.4版本发布的时候，由于添加了动态链接的feature，增量编译的编译速度确实快了几倍，但是需要进行一系列的配置。</p>
+
+<p>rust本身的编译速度实在不能说快，但在使用bevy进行开发迭代过程中，配置好快速编译的开发环境后，增量编译的速度令人十分满意。</p>
+
+<p>我笔记本的配置是：</p>
+
+<ul>
+<li>处理器	Intel(R) Core(TM) i5-8400 CPU @ 2.80GHz   2.81 GHz</li>
+
+<li>机带 RAM	16.0 GB (15.9 GB 可用)</li>
+</ul>
+
+<p>在开启动态链接的feature进行编译的情况下，每次增量编译的时间大概2.5秒左右，加入其它大型依赖之后，比如<code>bevy_rapier</code>，增量编译的速度会变长，但是仍然在可接受范围内，约3.5秒。在这次开发过程中，项目编译速度我很满意，开发体验十分良好。</p>
+
+<p>那么如何搭建一个快速编译的开发环境呢？</p>
+
+<p>官网里有详细的介绍了如何搭建一个快速开发环境：https://bevyengine.org/learn/book/getting-started/setup/ （在最后的<code>Enable Fast Compiles (Optional)</code>部分）</p>
+
+<p>在搭建环境的过程中,可能会出现一些奇怪的问题，比如这个：</p>
+
+<pre><code class="language-`">error: process didn&#8217;t exit successfully: `target\debug\bevy_salamanders.exe` (exit code: 0xc0000139, STATUS_ENTRYPOINT_NOT_FOUND)</code></pre>
+
+<p>解决方法是把该游戏项目下的<code>.cargo/config.toml</code>文件中这行改了：</p>
+
+<pre><code class="language-`toml">#before: 
+[target.x86_64-pc-windows-msvc]
+linker = &quot;rust-lld.exe&quot;
+rustflags = [&quot;-Zshare-generics=y&quot;]
+#after:
+[target.x86_64-pc-windows-msvc]
+linker = &quot;rust-lld.exe&quot;
+rustflags = [&quot;-Zshare-generics=off&quot;]</code></pre>
+
+<p>改了之后如果还有类似的奇怪错误，可以试着把<code>.cargo</code>这个文件夹直接删除，只使用动态链接就行，动态链接对编译速度提升是远远大于切换linker的。还有其它奇怪的没法解决的错误的话，那可以去提issue了。</p>
+
+<p>除此之外，每次运行的时候带一个<code>--features bevy/dynamic</code>也很麻烦，我喜欢在<code>cargo.toml</code>内部添加两个bevy，平时开发的时候注释掉另一个，直到要发布最终版本的时候才替换成另一个，大概像这样：</p>
+
+<pre><code class="language-`toml">bevy = { version=&quot;0.4&quot;, features = [&quot;dynamic&quot;] }
+# bevy = &quot;0.4&quot; </code></pre>
+
+<p>下面的这个平时注释掉，只有当要发布最终版的时候，才把上面的注释掉，切换成下面的这个。平时开发过程中基本是直接<code>cargo run</code>就可以了。</p>
+
+<h3 id='query_filter'>Query filter</h3>
+
+<p>Bevy内部提供了不少查询过滤器，0.4版本更新之后也更好用，易读性得到了提高。</p>
+
+<p>大致用法如下：</p>
+
+<pre><code class="language-`rust">fn movement_system(
+    query:Query&lt;(要查询的组件),(查询的过滤器)&gt;，
+    mut example_query:Query&lt;&amp;mut Transform,With&lt;Player&gt;&gt;
+){
+    for item in query.iter(){
+        // 对查询内容进行操作
+    }
+    for mut transform in example_query.iter_mut() {
+        // 就和迭代器一样使用
+    }
+}</code></pre>
+
+<p>常见的过滤器有<code>With&lt;T&gt;</code>,<code>Without&lt;T&gt;</code>,<code>Added&lt;T&gt;</code>,<code>Changed&lt;T&gt;</code>,<code>Mutated&lt;T&gt;</code>，<code>Or&lt;T&gt;</code>，其中<code>Mutated</code>是<code>Added</code>和<code>Changed</code>的集合，也就是说新添加的和改变了的都可以用<code>Mutated</code>来查到，而<code>Added</code>只查询新添加的组件，<code>Changed</code>只查询已经存在的组件中更改过的组件，这里面<code>Or</code>又比较特殊，使用其它几个过滤器基本都是减小查询范围，而使用<code>Or</code>却可以扩大过滤的范围，比如查询玩家和生物的位置与速度，就可以这样定义查询：</p>
+
+<pre><code class="language-`rust">    Query&lt;(&amp;Transform,&amp;Speed),Or&lt;(With&lt;Player&gt;,With&lt;Creature&gt;)&gt;&gt;</code></pre>
+
+<p>查询多于一个组件的时候需要用括号括起来，将多个组件作为一个元组进行参数传递,同样多个过滤器也以元组的形式传参。当然使用到Or，通常会和Option一起使用，比如既想查询玩家和生物的位置和速度，还想专门查询玩家专属的组件，玩家的力量，就可以这样写查询器：</p>
+
+<pre><code class="language-`rust">    Query&lt;(&amp;Transform,&amp;Speed,Option&lt;&amp;PlayerPower&gt;),Or&lt;(With&lt;Player&gt;,With&lt;Creature&gt;)&gt;&gt;</code></pre>
+
+<p>这样查询出来的结果带有<code>PlayerPower</code>的肯定是玩家，使用惯用的rust方式处理option就可以了。</p>
+
+<h3 id='queryset'>QuerySet</h3>
+
+<p>当一个<code>system</code>中的查询相互冲突时，编译后运行会触发一个<code>panic</code>：<code>xxx has conflicting queries</code>。这个时候就需要<code>QuerySet</code>来帮助我们了。</p>
+
+<p>&gt; &gt; 关于心智负担，我个人观点是写这部分代码时，完全不用带着审视的目光去查看所有的查询，只有在发生这种<code>panic</code>的时候，再去审视相关代码，将冲突的部分替换成<code>QuerySet</code>就可以了，正好对应rust中诸如所有权、生命期等情况。</p>
+
+<p>&gt; &gt; Note：关于哪些情况属于查询冲突，其实很好判断，在同一系统，多次可能查到同一结果的查询中，存在对组件的可变引用查询，那这个查询就是冲突的。</p>
+
+<p>比如以下两个查询：</p>
+
+<pre><code class="language-`rust">fn position(
+    mut q0: Query&lt;(&amp;Transform, &amp;mut Point)&gt;,
+    q1: Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+){
+    ...
+}</code></pre>
+
+<p>同时查询了<code>Transform</code>和<code>Point</code>,并且，<code>q1</code>很有可能查到<code>q0</code>的结果，但是因为重复查询的组件<code>Transform</code>没有可变引用，所以这两个查询放在一个系统内，并不会发生冲突。</p>
+
+<p>而以下两个查询：</p>
+
+<pre><code class="language-`rust">fn position(
+    mut q0: Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+    q1: Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+){
+    ...
+}</code></pre>
+
+<p>因为重复查询的组件<code>Transform</code>是有可变引用的，所以会发生冲突。</p>
+
+<p>发生查询冲突之后，就是<code>QuerySet</code>大展身手的地方了。</p>
+
+<p>考虑以下两个组件：</p>
+
+<pre><code class="language-`rust">pub struct Head;
+
+pub struct Point {
+    pub pre: Entity,
+}</code></pre>
+
+<p>假设我们需要写一个系统，让每一个点的位置根据前一个实体的位置而改变，可以有以下系统：</p>
+
+<pre><code class="language-`rust">fn position(
+    mut q0: Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+    q1: Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+) {
+    ...
+}</code></pre>
+
+<p>我们甚至没有给这个系统实现任何功能，直接添加到<code>App</code>中运行的话，就会直接触发查询冲突。</p>
+
+<p>而使用<code>QuerySet</code>的话，也十分简单：</p>
+
+<pre><code class="language-`rust">fn position(
+    points_query: QuerySet&lt;(
+        Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+        Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+    )&gt;,
+) {
+    ...
+}</code></pre>
+
+<p>在没有实现任何内容的情况下添加到<code>App</code>中运行，能够正常运行。使用起来也十分方便，只需要将之前的查询以元组的形式当作泛型传到<code>QuerSet</code>中即可。</p>
+
+<p>那实现具体的内容呢？ 如果不使用<code>QuerySet</code>我们实现的内容看起来应该是这样的：</p>
+
+<pre><code class="language-`rust">fn position(
+    q0: Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+    q1: Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+) {
+    for (mut transform, point) in q0.iter_mut() } {
+        if let Ok(pre_transform) = q1.get(point.pre)  {
+            *transform = Transform::from_translation(
+                pre_transform.translation - Vec3::new(1.0, 1.0, 0.0)
+            );
+        }
+    }
+}</code></pre>
+
+<p>那么使用<code>QuerySet</code>之后，我们的内容应该是这样的：</p>
+
+<pre><code class="language-`rust">fn position(
+    mut points_query: QuerySet&lt;(
+        Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+        Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+    )&gt;,
+) {
+    for (mut transform, point) in points_query.q0_mut().iter_mut() {
+        if let Ok(pre_transform) = points_query.q1().get(point.pre) {
+            *transform = Transform::from_translation(
+                pre_transform.translation - Vec3::new(1.0, 1.0, 0.0) * 30.0,
+            )
+        } else {
+            warn!(&quot;not find right transform!&quot;);
+        }
+    }  
+}</code></pre>
+
+<p>我们还没有运行我们的代码，<code>rust-analyzer</code>就已经给我们报错了，我们在<code>q0_mut()</code>这里将<code>points_query</code>的<code>&amp;mut</code>引用传了进去，按照借用规则，后续不能再把<code>points_query</code>的指针借用出去了，所以在这里我们就需要使用<code>unsafe</code>了。</p>
+
+<p>添加<code>unsafe</code>之后我们的代码变成这样：</p>
+
+<pre><code class="language-`rust">fn position(
+    mut points_query: QuerySet&lt;(
+        Query&lt;(&amp;mut Transform, &amp;Point)&gt;,
+        Query&lt;&amp;Transform, Or&lt;(With&lt;Point&gt;, With&lt;Head&gt;)&gt;&gt;,
+    )&gt;,
+) {
+    // Safety: 一般调用unsafe时，情况复杂的需要写下相关注释
+    for (mut transform, point) in unsafe { points_query.q0().iter_unsafe() } {
+        if let Ok(pre_transform) = points_query.q1().get(point.pre)  {
+            *transform = Transform::from_translation(
+                pre_transform.translation - Vec3::new(1.0, 1.0, 0.0) * 30.0,
+            )
+        } else {
+            warn!(&quot;not find right transform!&quot;);
+        }
+    }
+}</code></pre>
+
+<p>bevy几乎所有的<code>unsafe</code>都贴心的写出了<code>Safety</code>，使用这部分api时的内存安全由使用者来保证，而使用者只需要判断自己的调用情况是否符合<code>Safety</code>的要求，就能判断这个调用是否满足内存安全。比如该处的<code>Safety</code>要求就是这样的：</p>
+
+<p>&gt; &gt; This allows aliased mutability. You must make sure this call does not result in multiple mutable references to the same component</p>
+
+<p>我们已经能够明确，我们的两次查询，不会造成查询结果中，存在同一个组件的多个包含可变引用的引用，所以在这里调用该<code>unsafe</code>函数是<code>Safety</code>的！</p>
+
+<p>当你把借用的问题处理好之后，再次运行我们的<code>App</code>，就一切如你所愿了。</p>
+
+<p>谈谈<code>QuerySet</code>的体验，因为<code>rust-analyzer</code>对过程宏生成的Api支持不是很友好，对类似由宏生成的Api的代码补全体验可以说是很糟糕。而且出于减少总编译时间的考虑，这部分的过程宏只预备了五个参数的位置，也就说说除了<code>q0</code>到<code>q4</code>多出<code>q4</code>的部分，这个过程宏是没有预先生成相关函数的。当然我相信在实际应用的过程中，很少有出现这么极端的查询情况。总得来说掌握这个Api的使用并不难，而且在生产过程中也很实用。</p>
+
+<h3 id='event'>Event</h3>
+
+<p>0.4版本的bevy的<code>event</code>有个十分不好用的地方，看以下示例：</p>
+
+<pre><code class="language-`rust">pub fn game_events_handle(
+    game_events: Res&lt;Events&lt;GameEvents&gt;&gt;,
+    mut events_reader: Local&lt;EventReader&lt;GameEvents&gt;&gt;,
+) -&gt; Result&lt;()&gt; {
+    ...
+}</code></pre>
+
+<p>可能只看函数参数并不能感受到哪里不好用，可是如果你注意到这是一个事件处理系统，传递进来的参数居然同时需要<code>Events</code>和<code>EventReader</code>，并且使用的时候是这样的：</p>
+
+<pre><code class="language-`rust">    for event in events_reader.iter(&amp;game_events) {
+        match event {
+            ...
+        }
+    }</code></pre>
+
+<p>没错，<code>EventReader</code>不是一个真正的迭代器，在调用<code>iter()</code>的时候需要传递一个该事件的引用，这在使用的过程中感受到多余。</p>
+
+<p>好在<code>EventReader</code>在即将要发布的0.5版本当中已经得到了改善，在这个<a href='https://github.com/bevyengine/bevy/pull/1244'>PR</a>合并之后，<code>EventReader</code>的调用已经变成了这样：</p>
+
+<pre><code class="language-`rust">pub fn game_events_handle(
+    // 不再需要多余的Events作为EventReader参数
+    // game_events: Res&lt;Events&lt;GameEvents&gt;&gt;,
+    // mut events_reader: Local&lt;EventReader&lt;GameEvents&gt;&gt;,
+    // 不再需要指定Local，EventReader在Bevy中已经变成了更高级别的API
+    mut events_reader: EventReader&lt;GameEvents&gt;,
+) -&gt; Result&lt;()&gt; {
+    // 变得更像真实的迭代器
+    for event in events_reader.iter() {
+        match event {
+            ...
+        }
+    }
+}</code></pre>
+
+<p>需要注意的是，不仅仅是<code>EventReader</code>变成了更高级别的API（即成为真正的系统参数），<code>Events</code>也同样不再需要在其外部套一个<code>ResMut</code>了，写系统时直接写<code>Events&lt;T&gt;</code>作为参数。</p>
+
+<p>&gt; &gt; 可以这样改动的原因：之前的<code>Events</code>是作为<code>Resource</code>使用的，也就是说存在<code>Res</code>、<code>ResMut</code>两种状态。其中<code>Res&lt;Events&lt;T&gt;&gt;</code>只有给旧版的<code>EventReader</code>当作参数的存在意义，但是新版的<code>EventReader</code>已经不再需要这个参数，<code>Res</code>版本的<code>Events</code>失去了其存在意义，因此相对于<code>ResMut&lt;Events&lt;T&gt;&gt;</code>，索性改成了<code>Events&lt;T&gt;</code>，减少了用户API层面的复杂性。</p>
+
+<h3 id='timer'>Timer</h3>
+
+<p>bevy现版本的<code>Timer</code>是个值得争议的地方，先来看看具体用法：</p>
+
+<pre><code class="language-`rust">// 定义一个动画计时器组件：
+pub struct Animation(pub Timer);
+// 作为Player实体的组件添加到Player中：
+#[derive(Bundle)]// 使用Bundel派生宏可以将多个组件打包到一块，bevy官方指南也推介这样做，性能上似乎也比直接使用with更好
+pub struct PlayerBundle {
+    player: Player,
+    animation: Animation,
+    ...//省略了其它组件
+}
+// 初始化PlayerBundle
+impl Default for PlayerBundle {
+    fn default() -&gt; Self {
+        Self {
+            player: Player,
+            animation: Animation(Timer::from_seconds(0.3, true)),
+            ...//省略了其它组件
+        }
+    }
+}
+// Timer 在实例化的时候需要提供两个参数，一个是计时器计时的时间，另一个是该计时器是否重复计时。
+// 查询计时器进行相关修改：
+fn player_animation(
+    time: Res&lt;Time&gt;,// 使用计时器时必须用到时间去tick计时器
+    mut query: Query&lt;(&amp;mut Animation,&amp;Player)&gt;,
+) {
+    for (mut animation,player) in query.iter_mut(){
+        animation.0.tick(time.delta_seconds());
+        // animation.0是因为我们将Timer包裹在了Animation下
+        if animation.0.just_finished() {
+            ...// 相关操作
+        }
+    }
+}</code></pre>
+
+<p>以上基本就是计时器在使用时的流程，现在来回答几个问题。</p>
+
+<ul>
+<li>
+<p>为什么要使用一个结构体去包裹已有的计时器？</p>
+
+<blockquote>
+<p>大家应该注意到我们没有直接将计时器作为组件附加到<code>Player</code>上，而是通过一个结构体去包裹计时器之后再附加到<code>Player</code>上，这样做的其中一个原因是我们的<code>Player</code>实体可能需要不止一个计时器，所以我们需要给每个计时器不同的标识。</p>
+</blockquote>
+</li>
+
+<li>
+<p>为什么在调用计时器的<code>finished()</code>等相关计时API之前需要先调用<code>tick(time.delta_seconds())</code>?</p>
+
+<blockquote>
+<p>bevy的计时器本身相当于一个保存有当前时间量的结构体，本身没有时间流动的概念，只有tick的时候告诉它已经过去了多少时间，它才会把过去了多少时间加到它本身保存的状态上。</p>
+</blockquote>
+</li>
+</ul>
+
+<p><code>Timer</code>比较有争议的地方就是使用计时器时不能十分容易的给它添加标识，需要在计时器外部套一个结构体，目前有些<a href='https://github.com/bevyengine/bevy/pull/1151'>PR</a>提出了给<code>Timer</code>增加一个泛型的位置的想法，我个人不是很喜欢这种实现，理由很多，比如<code>@cart</code>大大的理由就是bvey内部有不少不需要特殊标识的计时器，如果添加泛型之后需要这样写：<code>Timer&lt;()&gt;</code>，相对于之前的<code>Timer</code>来说，实在是太丑了。</p>
+
+<p>出了标识的问题，还有目前的计时器使用的<code>f32</code>类型，应该替换成时间更常用的<code>Duration</code>，刚刚提到的PR在这个方面就已经完成了。</p>
+
+<h3 id='system_的链接与代码复用'><code>system</code>的链接与代码复用</h3>
+
+<p>之前<code>Events</code>部分有个系统例子和其它常规例子不一样：</p>
+
+<pre><code class="language-`rust">pub fn game_events_handle(
+    mut events_reader: EventReader&lt;GameEvents&gt;,
+) -&gt; Result&lt;()&gt; {
+    ...
+}</code></pre>
+
+<p>它拥有一个<code>Result</code>返回值，如果直接将这个系统添加到<code>App</code>中，会被<code>rust-analyzer</code>直接报错，因为bevy不支持带有返回值的系统。</p>
+
+<p>那如何让带有返回值的系统添加到<code>App</code>中去呢？当然是处理掉它的返回值，bevy给我们提供了一个<code>fn chain(self, system: SystemB)</code>函数，调用的时候大概像下面这样：</p>
+
+<pre><code class="language-`rust">    .add_system(game_events_handle.system().chain(error_handler.system()))</code></pre>
+
+<p>它可以‘无限续杯’，只要你愿意，你可以无限<code>chain</code>下去。</p>
+
+<p>那如何写一个可以<code>chain</code>的系统呢？考虑以下系统</p>
+
+<pre><code class="language-`rust">pub fn head_translation(query: Query&lt;&amp;Transform, With&lt;Head&gt;&gt;) -&gt; Option&lt;Vec3&gt; {
+    query.iter().map(|transform| transform.translation).next()
+}</code></pre>
+
+<p>该系统返回一个<code>Option&lt;Vec3&gt;</code>，因此能够处理该返回值的系统应该要带有一个<code>In&lt;Option&lt;Vec3&gt;&gt;</code>的参数：</p>
+
+<pre><code class="language-`rust">pub fn head_translation_handle(come_in: In&lt;Option&lt;Vec3&gt;&gt;) -&gt; Option&lt;Vec3&gt; {
+    if let In(Some(vec)) = come_in {
+        Some(vec + Vec3::new(1.0, 1.0, 0.0) * 30.0)
+    } else {
+        None
+    }
+}</code></pre>
+
+<p>出于教学目的，这里没有直接处理本不需要再返回出去的<code>Option&lt;Vec3&gt;</code>，而是为了验证多次链接是否有用：</p>
+
+<pre><code class="language-`rust">pub fn body_point_translation_handle(
+    come_in: In&lt;Option&lt;Vec3&gt;&gt;,
+    mut query: Query&lt;&amp;mut Transform, With&lt;BodyPoint&gt;&gt;,
+) {
+    if let In(Some(vec)) = come_in {
+        for mut transform in query.iter_mut() {
+            transform.translation = vec;
+        }
+    }
+}</code></pre>
+
+<p>没错，在每次链接的时候，你可以添加新的参数，这种设计大大增加代码的灵活性，同时也提高了代码复用率。</p>
+
+<p>这是bevy中我很喜欢的一个功能，既实用又灵活。虽然在本次项目中用到的地方不多，基本都用来做错误处理了，但是我相信在一个大型项目中，这种功能够充分发挥出它的优势，大概就是bevy中各处都彰显着类似这样设计的人体工程学，因此大家才为之感到兴奋。</p>
+
+<p>当然上面的代码可能有些地方让有强迫症的人感到不适，比如传出来的结果为啥是<code>Option</code>的，这样如果这个系统返回<code>None</code>的时候仍然一直在游戏中运行会不会很占资源？确实是会有这方面的考虑，所以现在已经有<a href='https://github.com/bevyengine/bevy/pull/1393'>PR</a>提出了异步系统的概念，如果真的实现出来的话，应该来大大减缓这种情况，编写出来的代码估计也会好看一些。</p>
+
+<h3 id='如何实现游戏的不同状态'>如何实现游戏的不同状态</h3>
+
+<p>我们的项目中实现了一个完整的游戏流程，包括开始游戏的菜单界面，游戏内部的暂停，玩家被炸弹炸死或者被生物触碰时的失败，以及玩家找到下一关的入口之后的胜利。如果有体验过我们的游戏，会发现关卡基本没有设计，仅仅只是实现了游戏中各种道具的效果，包括第一关与第二关的区别也仅仅是多了几只怪。作为游戏而言，我是对这部分的实现是很不满意的，但是作为体验、学习bevy而言，我觉得收获良多。我甚至还保留了一个随机的关卡实现接口，只不过没有真的去实现，roguelike的相关算法此前我都没有什么经验，只希望下一个项目能够在这方面得到提升。</p>
+
+<p>回到正题，为了实现这样一个完整的游戏流程，我参考了<a href='https://github.com/Bobox214/Kataster'>Kataster</a>的相关代码，将游戏整体流程放在了<code>AppState</code>这个枚举体内：</p>
+
+<pre><code class="language-`rust">pub enum AppState {
+    StartMenu,
+    Game,
+    Temporary,
+}</code></pre>
+
+<p>看上去我们的游戏有<code>StartMenu</code>、<code>Game</code>、<code>Temporary</code>三个状态，实际上只需要考虑前两个状态就好了，<code>Temporaty</code>这个状态只是为了方便修复游戏中的一个小bug而已。</p>
+
+<p>通常构建一个游戏的状态需要以下四个步骤：</p>
+
+<p>1.将我们的游戏状态以资源的方式添加到游戏中：</p>
+
+<pre><code class="language-`rust">app.add_resource(State::new(AppState::StartMenu))
+// 添加游戏状态资源时，需要特意指明初始化的状态，比如这里就指明了创建好的状态加载到游戏开始菜单的状态下</code></pre>
+
+<p>2.初始化StateStage</p>
+
+<pre><code class="language-`rust">// 接上第一步的部分
+    .add_stage_after(// 此处也很灵活，可以按照自己的喜好来
+        stage::UPDATE,// target，你可以把你的状态放到你想放的任何已有状态下
+        APP_STATE_STAGE,// name，名字也很灵活，可以自己取，这里是const APP_STATE_STAGE: &amp;str = &quot;app_state&quot;;
+        StateStage::&lt;AppState&gt;::default(),// 这里就挺固定了，需要将你的游戏状态枚举作为StateStage的一个泛型，以便初始化。
+    )</code></pre>
+
+<p>3.处理stage</p>
+
+<pre><code class="language-`rust">// 紧接上一步
+    .stage(APP_STATE_STAGE, |stage: &amp;mut StateStage&lt;AppState&gt;| {
+        // 通过这个闭包，可以给我们游戏的不同状态添加系统
+        stage
+            // start menu
+            // on_state_enter用来设置进入该State时调用的系统，通常用来加载资源。
+            .on_state_enter(AppState::StartMenu, start_menu.system())
+            // on_state_update用来设置该State下游戏更新时调用的系统。
+            .on_state_update(AppState::StartMenu, button_system.system())
+            // on_state_exit用来设置退出该State时调用的系统，通常用来清楚屏幕，更新相关游戏数据之类的。
+            .on_state_exit(AppState::StartMenu, exit_ui_despawn.system())
+            // in game
+            .on_state_enter(AppState::Game, setup_map.system()))
+            // 类似于on_state_update，不过可以同时设置多个。
+            .update_stage(AppState::Game, |stage: &amp;mut SystemStage| {
+                stage
+                // 以下的方法都不是SystemStage自带的，而是在我们游戏项目的各个模块下通过自定义trait给SystemStage实现的，只是为了方便管理各个模块。
+                // 这部分设计是有缺陷的，一般来说physics系统中的其中一部分是需要提前加载的，不然会造成现版本中出现查询错误的小bug
+                    .physics_systems()
+                    .player_systems()
+                    .bomb_systems()
+                    .buff_systems()
+                    .creature_systems()
+                    .portal_systems()
+            })
+            .on_state_exit(AppState::Game, exit_game_despawn.system())
+            .on_state_enter(AppState::Temporary, jump_game.system())
+    });</code></pre>
+
+<p>4.处理游戏状态跳转</p>
+
+<pre><code class="language-`rust">// 另外构建一个处理游戏状态的跳转的系统
+pub fn jump_state(
+    mut app_state: ResMut&lt;State&lt;AppState&gt;&gt;,
+    input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+    mut app_exit_events: ResMut&lt;Events&lt;AppExit&gt;&gt;,
+) -&gt; Result&lt;()&gt; {
+    // 使用模式匹配能够很清晰的将我们游戏状态跳转进行处理
+    match app_state.current() {
+        AppState::StartMenu =&gt; {
+            if input.just_pressed(KeyCode::Return) {
+                // set_next这个方法就是从当前状态跳转到指定状态
+                app_state.set_next(AppState::Game)?;
+                // game_state是原来处理游戏状态下的各种状态的，比如暂停、胜利、失败等，和app_state大同小异，因此此处都省略了，如果感兴趣可以直接看这部分源码，放到了src/events下
+                // game_state.set_next(GameState::Game)?;
+            }
+            if input.just_pressed(KeyCode::Escape) {
+                // 这个事件是bevy内置的事件，用来退出应用
+                app_exit_events.send(AppExit);
+            }
+        }
+        AppState::Game =&gt; {
+            if input.just_pressed(KeyCode::Back) {
+                app_state.set_next(AppState::StartMenu)?;
+                // game_state.set_next(GameState::Invalid)?;
+                map.init();
+            }
+        }
+        AppState::Temporary =&gt; {}
+    }
+    Ok(())
+}</code></pre>
+
+<p>通过以上四个步骤，就能够为你的游戏添加上不同的状态，现在我们来谈一下第三步，其实这部分很有可能在之后的版本中被<a href='https://github.com/bevyengine/bevy/pull/1144'>新的调度器</a>取代，但那还是久远之后的事，到那时需要新的blog去探讨。</p>
+
+<h3 id='rapier简短笔记'>Rapier简短笔记</h3>
+
+<p><code>rapier</code>作为物理引擎，它的内容十分丰富，本项目所涉及的内容，仅仅是其中的一小部分，本文也只是从中挑出了一些有意义的进行记录。如果想要深入学习<code>rapier</code>，我的建议是先看<a href='https://rapier.rs/docs/user_guides/rust/getting_started'>官方文档</a>，然后再去<a href='https://discord.gg/VuvMUaxh'>discord</a>的<code>bevy_rapier</code>群组去交流学习。</p>
+
+<p>rapier的常用组件有两个，一个是刚体（RigidBody），一个是碰撞体（Collider）。bevy中的每一个实体，只能有一个刚体，而碰撞体可以有多个，比如角色的头、胳膊、腿，这些部分都可以使用单独一个碰撞体来表示。</p>
+
+<p>创建刚体的方法很简单：</p>
+
+<pre><code class="language-`rust">// 创建一个运动学刚体，不受外部力影响，但是能单向影响动态刚体，需要通过专门设置其位置，常用于移动平台，如电梯
+RigidBodyBuilder::new_kinematic()
+.translation(translation_x, translation_y)
+// 创建一个静态刚体，不受任何外部力的影响，常用于墙体等静态物体
+RigidBodyBuilder::new_static()
+.translation(translation_x, translation_y)        
+// 创建一个动态刚体，受外部力的影响，常用于玩家控制的角色、游戏中的怪物等
+RigidBodyBuilder::new_dynamic()        
+.translation(translation_x, translation_y)        
+.lock_rotations()// （可选）让刚体锁定旋转    
+.lock_translations()// （可选）让刚体锁定位置</code></pre>
+
+<p>&gt; &gt; 创建刚体时需要明确指定其位置，因为<code>bevy_rapier</code>内部有一个系统专门用于转换刚体的位置和实体的<code>Transform</code>，相当于我们不再需要去管理实体中的<code>Transform</code>，只需要通过刚体来管理该实体的速度、位置、旋转、受力等就可以。</p>
+
+<p>创建碰撞体的方法也很简单：</p>
+
+<pre><code class="language-`rust">// 碰撞体实际上就是定义参与碰撞计算的形状，rapier有多种选择，因为我们的游戏项目中只用到两种，所以只谈这两类
+// 矩形，设置的时候需要提供它的半高和半宽
+ColliderBuilder::cuboid(hx, hy)
+// 圆形，设置的时候需要提供半径
+ColliderBuilder::ball(radius)</code></pre>
+
+<p>&gt; &gt; note：矩形碰撞体构建需要提供的参数是半高和半宽，而不是整高和整宽。</p>
+
+<p>对于单一碰撞体的直接讲刚体和碰撞体作为组件插入到已有实体即可：</p>
+
+<pre><code class="language-`rust">fn for_player_add_collision_detection(
+    commands: &amp;mut Commands,
+    query: Query&lt;
+        (Entity, &amp;Transform),
+        (
+            With&lt;Player&gt;,
+            Without&lt;RigidBodyBuilder&gt;,
+            Without&lt;ColliderBuilder&gt;,
+            Without&lt;RigidBodyHandleComponent&gt;,
+            Without&lt;ColliderHandleComponent&gt;,
+        ),
+    &gt;,
+) {
+    for (entity, transform) in query.iter() {
+        let translation = transform.translation;
+        commands.insert(
+            entity,
+            (
+                create_dyn_rigid_body(translation.x, translation.y),
+                create_player_collider(entity),
+            ),
+        );
+    }
+}</code></pre>
+
+<p>&gt; &gt; 如果只是单个碰撞体和刚体的组合，则用这种方法插入即可，但如果是多个碰撞体和单个刚体的组合，则稍微有所不同，详情可以看<a href='https://github.com/dimforge/bevy_rapier/blob/master/bevy_rapier2d/examples/multiple_colliders2.rs'>这里</a>。</p>
+
+<p>我们的游戏当中使用的是动态加载，也就是在所有地图资源加载之后，再给没有加上刚体和碰撞体的实体插入相应的刚体和碰撞体。</p>
+
+<p>比如上面给出的例子，可能大家会对查询的过滤器感到奇怪。因为我们是给没有刚体构建器和碰撞体构建器的实体插入刚体和碰撞体，所以再过滤器中有<code> Without&lt;RigidBodyBuilder&gt;</code>和<code>Without&lt;ColliderBuilder&gt;</code>并不让人奇怪。让人奇怪的地方是后两条过滤器<code>Without&lt;RigidBodyHandleComponent&gt;</code>和<code>Without&lt;ColliderHandleComponent&gt;</code>，这两条实际上是因为<code>bevy_rapier</code>内部有一个负责转换构建器（<code>Builder</code>）到句柄组件（<code>HandleComponent</code>）的系统，当我们给实体插入构建器之后，该系统就会通过一些内部的方法将其转换为句柄组件。所以为了防止我们查询到的结果当中存在已经插入过句柄组件的实体，所以需要再加入这条过滤。</p>
+
+<p>仅仅添加这些并不足以让物理引擎在我们的游戏里面运行起来，主要原因是现在的<code>bevy_rapier</code>仍然是作为一个外部crate引入到我们的游戏项目中，在将来如果集成到了<code>bevy</code>主体的物理引擎中，则不再需要以下操作。</p>
+
+<pre><code class="language-`rust">// 在app中添加物理引擎插件
+    app
+    ...// 初始化其它资源和添加其它插件
+        .add_plugin(RapierPhysicsPlugin)</code></pre>
+
+<p>这样简单设置之后，我们的游戏中就成功的启用了物理引擎。</p>
+
+<h3 id='通过rapier来实现碰撞过滤'>通过Rapier来实现碰撞过滤</h3>
+
+<p>还有一件事需要特别记录一下，在我们的游戏中，生物是可以互相碰撞的，那么如何实现这种效果呢？只需要在创建碰撞器的时候指明解算组或者碰撞组即可。</p>
+
+<pre><code class="language-`rust">    ColliderBuilder::cuboid(HALF_TILE_WIDTH, HALF_TILE_WIDTH)
+        // 用户数据，可以插入一些自定义的数据，但是只能以u128格式插入，通常用来插入实体，有了实体之后可以通过查询来获取该实体的其它组件
+        .user_data(entity.to_bits() as u128)
+        // 解算组，可以通过设定一个交互组（InteractionGroups）来让该碰撞器在该组规则下进行力的解算
+        .solver_groups(InteractionGroups::new(WAY_GROUPS, NONE_GROUPS))
+        // 碰撞组，同样设定交互组之后，让该碰撞器在该组规则下进行碰撞解算
+        .collision_groups(InteractionGroups::new(WAY_GROUPS, NONE_GROUPS))</code></pre>
+
+<p>在更进一步谈论解算组和碰撞组的区别之前，我们需要了解交互组的构建规则，交互组<code>new</code>的时候需要提供两个参数，第一个参数是设定该碰撞体属于哪一组，需要的参数类型是一个<code>u16</code>，第二个参数是设定该碰撞体和哪些组的碰撞体会产生交互，参数同样是一个<code>u16</code>。</p>
+
+<p>对于第二个参数，设定和单个碰撞体交互倒是挺好理解，但如果设定和多个碰撞体交互又该怎么设置呢？这正是参数的类型设定为<code>u16</code>的妙处，举个例子：</p>
+
+<pre><code class="language-`rust">const CREATURE_GROUPS: u16 = 0b0010;
+const PLAYER_GROUPS: u16 = 0b0001;
+const WALL_GROUPS: u16 = 0b0100;
+const WAY_GROUPS: u16 = 0b1000;
+const NONE_GROUPS: u16 = 0b0000;</code></pre>
+
+<p>以上常量皆是我们这次游戏中用到的交互组变量，而<code>0b0011</code>表示的就是生物组和玩家组两个组，而这个数就是用<code>CREATURE_GROUPS</code>和<code>PLAYER_GROUPS</code>通过<code>&amp;</code>运算出来的。</p>
+
+<p>至于解算组和碰撞组的区别，解算组解算的就是受力状况，与之交互的组都会参与到受力解算中。而碰撞组是管理碰撞事件的，碰撞事件可以通过<code>Res&lt;EventQueue&gt;</code>进行接收处理。</p>
+
+<p>还有<code>user_data</code>也是一个比较常用的，通常是在碰撞体插入的时候将该实体传入到碰撞体构建器当中，通过这个数据，可以使用以下命令获得实体：</p>
+
+<pre><code class="language-`rust">let entity = Entity::from_bits(user_data as u64);</code></pre>
+
+<p>那<code>user_data</code>又从哪里来呢？从碰撞事件中我们会获得一个索引，该索引可以通过<code>Res&lt;ColliderSet&gt;</code>的get方法获取器<code>user_data</code>，这方面比较繁琐，也是我认为目前<code>bevy_rapier</code>当中最不好用的部分。</p>
+
+<p>除此之外，如果你就此运行你的游戏，你会发现你的角色也好，画面中的其它动态刚体，除了你设定的之外，还会收到一个重力，这完全不符合你俯视2d游戏的初衷，所以我们需要将该重力给修改为零。</p>
+
+<p>当前版本是通过添加这样一个系统来修改物理引擎的重力的：</p>
+
+<pre><code class="language-`rust">fn setup(
+    mut configuration: ResMut&lt;RapierConfiguration&gt;,
+) {
+    configuration.gravity = Vector::y() * 0.0;
+}</code></pre>
+
+<p>将这个系统添加到<code>startup_system()</code>只需要在每次游戏启动之前运行一次就行。</p>
+
+<h3 id='多平台支持'>多平台支持</h3>
+
+<p>我们的游戏这次除了支持正常的桌面端平台以外，还做了<code>wasm</code>的支持，其中因为<code>bevy</code>的声音在<code>wasm</code>没有得到支持继而没有实现声音以外，总算是没什么遗憾。做完游戏之后发给小伙伴们玩了一下，都在问我有没有手机版本的。<code>bevy</code>的支持计划里面是有移动端的，而且就从桌面端迁移到移动端上要做出的改变来说是很少的，再说我们尚未支持的移动端之前，来看看我们是如何支持<code>wasm</code>版本的。</p>
+
+<p><code>bevy</code>的渲染后端用的是<code>wgpu</code>，虽然原生的<code>wgpu</code>渲染后端已经支持编译到<code>wasm</code>了，但是由于某些原因居然没有给<code>bevy</code>实装上，我们能够参考的已有的<code>bevy</code>的<code>wasm</code>版本项目基本上都是基于<code>bevy_webgl2</code>这个crate。</p>
+
+<p>添加<code>wasm</code>支持也十分方便，除了需要添加常规的html之类的文件，还需要做如下改动：</p>
+
+<pre><code class="language-`rust">// 添加webgl2的插件，添加这个插件之前需要关闭bevy的wgpu的feature
+    #[cfg(target_arch = &quot;wasm32&quot;)]
+    app.add_plugins(bevy_webgl2::DefaultPlugins);
+    #[cfg(not(target_arch = &quot;wasm32&quot;))]
+    app.add_plugins(DefaultPlugins);</code></pre>
+
+<p>关闭wgpu的feature：</p>
+
+<pre><code class="language-`toml">[features]
+# 这部分是native和wasm都会用到的bevy的feature
+default = [
+  &quot;bevy/bevy_gltf&quot;,
+  &quot;bevy/bevy_winit&quot;,
+  &quot;bevy/bevy_gilrs&quot;,
+  &quot;bevy/render&quot;,
+  &quot;bevy/png&quot;,
+]
+# 这部分是native会用到的wgpu的feature
+native = [
+  &quot;bevy/bevy_wgpu&quot;,
+  &quot;bevy/dynamic&quot;# （可选，开发的时候提高增量编译速度，编译真的十分快！）
+]
+# 这部分是wasm支持会用到的webgl2的feature
+web = [
+  &quot;bevy_webgl2&quot;
+]</code></pre>
+
+<p>基本上这样就设置好了，其余的设置是跟html有关的，需要稍微丢丢的wasm开发的知识。关于编译的时候用到的<code>cargo make</code>等工具链如何使用，同样是在那一丢丢的wams开发的知识里面学习。关于如何部署到github的page服务上，这个我是完全不会的，我们游戏的这部分部署是有我的搭档<code>@rgripper</code>完成的。</p>
+
+<p>对于移动端的支持，以安卓为例，如果不考虑触屏啊，按钮之类的，官方其实给了示例的，在桌面端的基础上迁移起来也十分方便。除了基本的安卓开发环境的搭配（这部分可以详情看<a href='https://github.com/BrainiumLLC/cargo-mobile'>`cargo mobile`</a>的READEME里面讲的十分详情），只需要做出下面这种改动，即可支持移动端，甚至如果以后修复了wgpu对wasm端的支持，应该同样也只是需要下面这种修改，即可对多端支持：</p>
+
+<pre><code class="language-`rust">// 对，就是添加这个过程宏之后，编译的时候使用对应平台的编译指令即可打包到相应平台
+#[bevy_main]
+fn main() {
+    App::build()
+        .insert_resource(Msaa { samples: 2 })
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .run();
+}</code></pre>
+
+<h3 id='日志'>日志</h3>
+
+<p>bevy内建了日志系统，使用起来也十分方便，同时也能和rust生态中的其它日志crate配合在一起使用，对于后续测试和收集数据有很重要的作用。</p>
+
+<p>这次项目中我们并没有深入使用日志功能，也没有和外部的日志crate深度结合使用，只是当作<code>println!</code>调试的时候用，所以这部分就不再探讨。</p>
+
+<h3 id='碎碎念'>碎碎念</h3>
+
+<p>这是本文的最后一个部分，也是谈谈开发下来的一些感受，上面基本是干货居多，感受这种东西并不是每个人的愿意看，所以也不愿意放在前面叨扰大家。总得来说做完整个项目总结之后，发现自己之前走了不少弯路，甚至有些地方都用错了（比如前几个版本中的切换游戏状态，受参考的源代码影响也用了一堆if-else，当时自己看的时候也是一头雾水的，改成match之后清晰明了），在这个项目之前，rust对于我来说只是刷题、刷教程趁手的工具，虽然学到了不少的知识，但总觉得缺乏自己的实践。但这样一趟走下来，实践经验确实增长不少，最重要的是还交到了<code>@rgripper</code>这样的好朋友，果然github是个大型在线交友平台，哈哈哈。</p>
+
+<p>使用<code>bevy</code>的开发体验在我这里被区分为两个部分，但总得来说是十分有趣的。</p>
+
+<p>而这个分界点就是在游戏里加入<a href='https://rapier.rs/'>rapier</a>前后，加入之前和加入之后是两种完全不同的开发体验。</p>
+
+<p>其中最主要原因还是因为自己之前没有使用过物理引擎，有不少生涩的词汇在开发中需要接触和学习，加上<code>bevy_rapier</code>当中不少接口放到<code>bevy</code>实际开发中体验并不良好，所以造成了使用<code>rapier</code>之后开发速率下降、开发心情糟糕等情况。</p>
+
+<p>当然对于最终我们的游戏中使用了<code>rapeir</code>这件事，我觉得是很值得的，在这样一个小游戏中使用物理引擎这件事并不值得。但如果是为了学习这个物理引擎，那就是值得的，而且也确实涨了不少知识（在这部分真的十分感谢<code>rapier</code>的作者<a href='https://github.com/sebcrozet'>@Sébastien Crozet</a>，在他的discord群组里，基本上大家问的问题都得到了解决，也很感谢群组里帮助我们提出思路的各个网友）。</p>
+
+<p>谈一下本次开发中的遗憾，游戏没有加入音频算一个遗憾，这部分的工作早先是由我的搭档去完成的，但是因为bevy的<a href='https://github.com/bevyengine/bevy/issues/88#issuecomment-753546363'>一些原因</a>，导致音频部分对wasm支持很差，所以我们放弃了。地图没有细致的去设计以及没有随机地图的支持这算两个遗憾。小怪的ai因为我们连个人此前都没写过游戏，因此对这方面不熟悉，导致有时候小怪会傻傻站着，和卡了bug一样，这也算一个。在游戏基本写完的时候<a href='https://github.com/joshuajbouw/bevy_tilemap'>`bevy_tilemap`</a>发布了，并且还有一个游戏动图，我们没能在一个网格游戏当中用到这种crate，也算是一个遗憾。游戏的资产加载没有专门做成一个状态，导致在网络差的情况下，网页版的游戏很有可能出现这个<a href='https://github.com/rgripper/rusty-bomber/issues/16'>issue</a>所说的游戏主体出现了但是游戏资产没有加载进来的诡异情况，这也算是一个遗憾。</p>
+
+<h2 id=''></h2>
+
+<p>作者介绍：</p>
+
+<p>&gt; &gt; Cupnfish，目前青岛某大学大四在校生一名。大二的时候因为自己主力语言是 python 和 C#（后面上课还学了Java，虽然很早之前就学过C，但不是很喜欢，刚接触指针的时候可懵逼了），所以很想学一门底层语言，当时看知乎不少关于Rust的讨论，对Rust产生了一些兴趣，恰好18年初张汉东老师的<code>Rust编程之道</code>正好上架，下单之后随即入坑Rust。2020年初疫情期间GAMES101课程在B站有录播，通过闫令琪老师的课程算是入门计算机图形学，同时期学了Wgpu，很想以后工作能从事 Rust 游戏开发，不过目前看来社区还得发展两三年。知乎上有不少人对Rust图形化编程方面呈悲观态势，起初只有Amethyst的时候我确实也很同意他们的观点，但是bevy给了rust社区中很多人希望，bevy不仅仅是想用Rust来做游戏引擎，同时也在鼓励使用Rust来编写游戏，这是区别于Amethyst等游戏引擎的，同时我想说，就目前bevy的ECS部分的Api来看，bevy做到了！这是梦想中的Rust，你几乎很少会用到生命期之类的Rust中一切繁琐的东西，bevy带给你的Rust开发体验是前所未有的，当然现在它仍然还很弱小，需要大家的呵护、照顾，它有很大的潜力，但同时也需要社区进行各方面的支持。</p>
+
+<p>你可以通过以下方式联系到我，无论是进行技术讨论，还是项目合作，都可以直接和我联系：</p>
+
+<ul>
+<li>邮箱：pointu@foxmail.com</li>
+
+<li>QQ：760280519</li>
+</ul>
+]]></content:encoded></item><item><title>io_uring | Linux 全新异步接口 io_uring 的 Rust 生态盘点 </title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/io_uring_intro.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='linux_全新异步接口_io_uring_的_rust_生态盘点'>Linux 全新异步接口 io_uring 的 Rust 生态盘点</h1>
+
+<p>作者：施继成@DatenLord / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>io_uring 无可置疑是近两年内核圈最火的话题之一，作为风头正劲的 Linux 异步 I/O 接口，其野心更大，不仅仅想将 Linux 的 I/O 操作全面异步化，还希望将所有<a href='https://lwn.net/Articles/810414/'>Linux系统调用异步化</a>。</p>
+
+<p>Rust 作为一门系统级编程语言，兼具安全和高性能的特点，大家也一定是想使用Rust语言 “尝鲜” io<em>uring。然而遗憾的是 io</em>uring 作者 Jens Axboe 仅仅维护一个<a href='https://github.com/axboe/liburing'>C语言的库</a>。用户想要用Rust调用，一方面还需要自己进行一些封装，另一方面 C 语言的接口还是太底层，想在 Rust 的异步框架中使用仍有许多工作要做。</p>
+
+<p>好消息是已经有一些 Rust 语言封装的 io<em>uring 库出现在 github 上，今天让我们来挑选一些使用人数较多（通过star数目来判断）的库进行分析，看看是否可以给大家使用 io</em>uring 带来便利。</p>
+
+<h1 id='tokio_io-uring'><a href='https://github.com/tokio-rs/io-uring'>Tokio io-uring</a></h1>
+
+<p>Tokio 是 github 上 Star 数目最多的异步框架，那么他们团队封装的io<em>uring lib如何呢？通过阅读代码不难发现，该 io</em>uring 库完全撇弃了 C 语言的 liburing 库，自己在 io_uring 系统调用上从零开始封装了一层，实现了submission queue，completion queue 和 submitter。</p>
+
+<p>上述的三层抽象比 C 语言的封装稍微高层一些，但仍然需用户将 request 放到submission queue上，将 response 从 completion queue 上取下，和同步读写方式区别巨大，且和 Rust 现有的异步 I/O 框架的设计相去甚远。以下是一个简单的样例代码：</p>
+
+<pre><code class="language-`rust">let mut ring = IoUring::new(256)?;
+let (submitter, mut sq, mut cq) = ring.split();
+
+let mut accept = AcceptCount::new(listener.as_raw_fd(), token_alloc.insert(Token::Accept), 3);
+
+// put request on the submission queue
+accept.push_to(&amp;mut sq);
+
+// submit the request
+match submitter.submit_and_wait(1) {
+    Ok(_) =&gt; (),
+    Err(ref err) if err.raw_os_error() == Some(libc::EBUSY) =&gt; (),
+    Err(err) =&gt; return Err(err.into()),
+}
+
+// get complete events from the completion queue
+for cqe in &amp;mut cq {
+    ...
+}</code></pre>
+
+<p>该 io_uring 库的优缺点分列如下：</p>
+
+<p>优点：</p>
+
+<ol type="1">
+<li>纯 Rust 封装，安全性更好。</li>
+
+<li>比 C 语言库封装高层，使用起来接口更加简单。</li>
+</ol>
+
+<p>缺点：</p>
+
+<ol type="1">
+<li>维护成本更高，需要根据kernel的更新手动追加新 feature，包括新数据结构。</li>
+
+<li>封装还不够彻底，暴露了底层实现的两个队列，用户使用难度较高。</li>
+</ol>
+
+<h1 id='spacejam_rio'><a href='https://github.com/spacejam/rio'>Spacejam rio</a></h1>
+
+<p>该 io<em>uring 库在 github 上的 star 数目在写稿时已经达到了 590 个，该库的作者还创建了 <a href='https://github.com/spacejam/sled'>sled</a> 嵌入式数据库。由于 sled 数据库也使用了这个 io</em>uring 库，所以我们有理由相信， rio 是一个经过实际项目验证的库，其更友好的用户接口更是降低了用户的使用难度。</p>
+
+<p>通过下面的简单示例，大家可以很容易感受到接口的易用性：</p>
+
+<pre><code class="language-`rust">/// Read file example
+let ring = rio::new().expect(&quot;create uring&quot;);
+let file = std::fs::open(&quot;file&quot;).expect(&quot;openat&quot;);
+let data: &amp;mut [u8] = &amp;mut [0; 66];
+let completion = ring.read_at(&amp;file, &amp;mut data, at);
+
+// if using threads
+completion.wait()?;
+
+// if using async
+completion.await?</code></pre>
+
+<p>rio 同时提供了针对 thread 和 async 两种编程模型的接口，在提供便利性的同时大大降低了使用者的约束，可以自由选择喜欢的编程模型。</p>
+
+<p>然而这个库是 unsoundness 的，即有可能被错误或者恶意使用。并且根据作者在 <a href='https://github.com/spacejam/rio/issues/25'>issue</a> 里面的回复，作者并不会对此进行修复。这将使得基于该库构建的软件都不安全。</p>
+
+<p>该 io_uring 库的优缺点分列如下：</p>
+
+<p>优点：</p>
+
+<ol type="1">
+<li>接口丰富且使用简单。</li>
+
+<li>有实际使用的项目验证。</li>
+</ol>
+
+<p>缺点：</p>
+
+<ol type="1">
+<li>Unsoundness，安全性不佳。</li>
+</ol>
+
+<h1 id='ringbahn'><a href='https://github.com/ringbahn/ringbahn'>ringbahn</a></h1>
+
+<p>ringbahn 的作者是 withoutboats, Rust 语言的核心开发者之一。该库由三个抽象层组成，第一层为 C 语言 libfuse 的 Rust 封装, 名称为 <a href='https://github.com/ringbahn/uring-sys'>uring-sys</a>；第二层为 Submission Queue 和 Completion Queue 等数据结构的封装，名称为 <a href='https://github.com/ringbahn/iou'>iou</a>；最后一层则封装了Rust 异步编程的接口。</p>
+
+<p>不难看出，ringbahn 从设计上考虑了更多，从接口易用性到安全性都更加优秀。以下为拷贝文件的示例：</p>
+
+<pre><code class="language-`rust">/// Copy File from props.txt to test.txt
+futures::executor::block_on(async move {
+    let mut input:  File = File::open(&quot;props.txt&quot;).await.unwrap();
+    let mut output: File = File::create(&quot;test.txt&quot;).await.unwrap();
+    let mut buf = vec![0; 1024];
+    let len = input.read(&amp;mut buf).await.unwrap();
+    output.write(&amp;mut buf[0..len]).await.unwrap();
+    output.flush().await.unwrap();
+});</code></pre>
+
+<p>该库也并非完美无缺，它也具有下列缺陷：</p>
+
+<ol type="1">
+<li>并发不友好，在 Submission Queue 上有一把大锁，每个提交任务的线程都会被串行化。</li>
+
+<li>读写操作会导致内存在用户态被拷贝，对于大数据量的操作而言，多余的内存拷贝会带来明显的性能下降。之所以要进行内存拷贝，是为了保证传给内核的memory buffer不会被用户态异步修改，保证安全性。</li>
+</ol>
+
+<p>作者也在 Readme 文件中说明了最上层的 ringbahn 封装只是一次尝试，并不适合在正式生产上使用。</p>
+
+<h1 id='datenlord_ring-io'><a href='https://github.com/datenlord/ring-io/tree/dev'>DatenLord ring-io</a></h1>
+
+<p>基于上述讨论，我们团队 Datenlord 也实现了自己的 io<em>uring Rust lib， 名称是 ring-io。现阶段的实现吸取了 Tokio io-uring 和 iou 的经验，同样实现了Submission Queue 和 Completion Queue 的抽象。具体的实现细节请参见王徐旸同学写的[文章](https://rustmagazine.github.io/rust</em>magazine<em>2021/chapter</em>1/io<em>uring</em>and_rust.html)。</p>
+
+<p>现阶段的实现也具有下列问题：</p>
+
+<ol type="1">
+<li>暴露了一些unsafe接口，提醒用户某些操作需要注意，和内核的错误交互会带来无法预知的结果。</li>
+
+<li>抽象层偏低，使用起来不方便。</li>
+</ol>
+
+<p>接下去，我们会针对一些特定的 buffer 类型实现异步 I/O 接口，方便用户的使用，且暴露 safe 的接口。在实现的过程中，我们也会将高效考虑在内，避免不必要的内存拷贝。<strong>和ringbahn 的方法不同，我们保证内存安全的方式为 Rust 提供的内存所有权转移，即用户在发送 I/O 请求之后就不在拥有 buffer 的所有权，直到 request 返回所有权才被归还</strong>。具体的实现细节我们会在下一篇文章中进行讨论，这里先给出设计的架构图：</p>
+
+<p><img src='./io_uring_intro/io_uring_arch.jpeg' alt='io uring architecture' /></p>
+
+<ul>
+<li>SQ submitter 负责将用户 Task 发送来的 I/O 请求通过 io_uring 发送到 kernel。</li>
+
+<li>CQ collector 负责将 kernel 完成任务的返回结果返回给用户。</li>
+
+<li>User Task 会 block 在各自的 channel 上，直到 I/O 任务完成，User Task 才会被重新调度。</li>
+</ul>
+
+<h1 id='总结'>总结</h1>
+
+<p>虽然 io_uring 非常火爆，国内外也有很多团队进行了 Rust 封装，但是仍然没有一个完美的方案，同时解决了安全性、高性能和易用性的问题。</p>
+
+<p>大家可以根据自己的情况选择一个符合需求的库，当然更希望大家积极贡献社区，提出自己的想法，创建出更好用、更安全和更快的 io_uring 库。</p>
+
+<h2 id='datenlord'>DatenLord</h2>
+
+<p><a href='https://github.com/datenlord/datenlord'>DatenLord</a>  是用 Rust 实现的新一代开源分布式存储，面向云原生场景提供高性能存储解决方案。</p>
+
+<p>一方面，在当今的硬件架构下，CPU 和 GPU 的计算的速度远远超过 IO 的速度，即便现在 NVMe SSD 的 IO 速度已经比从前机械硬盘的速度有了百倍的提升，网络的速度也有至少百倍提升，但还是常常碰到IO跟不上计算速度的问题，导致计算等待数据，降低了计算的性能。</p>
+
+<p>另一方面，操作系统的 IO 模型已经很久没有发生大的变化，仍然是以内核为主体来执行IO任务，这样的方式带来不少额外的开销，诸如数据拷贝、系统调用引起的阻塞以及进程上下文切换等等。</p>
+
+<p>为了提高 IO 性能，DatenLord 采用绕过内核 (bypass Kernel) 的方式，主要在用户态实现 IO 功能，避免内核执行 IO 任务带来的额外开销，从而实现高性能分布式存储。</p>
+]]></content:encoded></item><item><title>io_uring | 用 Rust 实现基于 io_uring 的异步随机读文件</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/io_uring_async_rw.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='io_uring_|_用_rust_实现基于_io_uring_的异步随机读文件'>io<em>uring | 用 Rust 实现基于 io</em>uring 的异步随机读文件</h1>
+
+<p>作者：迟先生（skyzh）/ 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>本文介绍了 <code>io_uring</code> 的基本使用方法，然后介绍了本人写的异步读文件库的实现方法，最后做了一个 benchmark，和 mmap 对比性能。</p>
+
+<h2 id='tl;dr'>TL;DR</h2>
+
+<p>一句话总结：在 <a href='https://github.com/skyzh/uring-positioned-io'>skyzh/uring-positioned-io</a> 中，我包装了 Tokio 提供的底层 <code>io_uring</code> 接口，在 Rust 中实现了基于<code>io_uring</code> 的异步随机读文件。你可以这么用它：</p>
+
+<pre><code class="language-`rust">ctx.read(fid, offset, &amp;mut buf).await?;</code></pre>
+
+<h2 id='io_uring_简介'>io_uring 简介</h2>
+
+<p><code>io_uring</code> 是一个由 Linux 内核的提供的异步 I/O 接口。它于 2019 年 5 月在 Linux 5.1 中面世，现在已经在各种项目中被使用。 比如：</p>
+
+<ul>
+<li><a href='https://github.com/facebook/rocksdb/pull/5881'>RocksDB 的 MultiRead</a> 目前就是通过 <code>io_uring</code> 做并发读文件。</li>
+
+<li>Tokio 为 <code>io_uring</code> <a href='https://github.com/tokio-rs/io-uring'>包装了一层 API</a>。在 Tokio 1.0 发布之际，开发者表示今后会通过 io_uring 提供真正的异步文件操作 (见 <a href='https://tokio.rs/blog/2020-12-tokio-1-0'>Announcing Tokio 1.0</a>)。 目前 Tokio 的异步文件操作通过开另外的 I/O 线程调用同步 API 实现。</li>
+
+<li>QEMU 5.0 已经使用 <code>io_uring</code> (见 <a href='https://wiki.qemu.org/ChangeLog/5.0'>ChangeLog</a>)。</li>
+</ul>
+
+<p>目前关于 <code>io_uring</code> 的测试，大多是和 Linux AIO 对比 Direct I/O 的性能 <a href='https://thenewstack.io/how-io_uring-and-ebpf-will-revolutionize-programming-in-linux/'>(1)</a> <a href='https://developers.mattermost.com/blog/hands-on-iouring-go/'>(2)</a> <a href='https://zhuanlan.zhihu.com/p/62682475'>(3)</a>。 <code>io_uring</code> 通常能达到两倍于 AIO 的性能。</p>
+
+<h2 id='随机读文件的场景'>随机读文件的场景</h2>
+
+<p>在数据库系统中，我们常常需要多线程读取文件任意位置的内容 <code>(&lt;fid&gt;, &lt;offset&gt;, &lt;size&gt;)</code>。 经常使用的 <code>read / write</code> API 无法完成这种功能（因为要先 seek，需要独占文件句柄）。 下面的方法可以实现文件随机读。</p>
+
+<ul>
+<li>通过 <code>mmap</code> 直接把文件映射到内存中。读文件变成了直接读内存，可以在多个线程中并发读。</li>
+
+<li><code>pread</code> 可以从某一位置 <code>offset</code> 开始读取 <code>count</code> 个字节，同样支持多线程并发读。</li>
+</ul>
+
+<p>不过，这两种方案都会把当前线程阻塞住。比如 <code>mmap</code> 后读某块内存产生 page fault，当前线程就会阻塞；<code>pread</code> 本身就是一个阻塞的 API。 异步 API (比如 Linux AIO / <code>io_uring</code>) 可以减少上下文切换，从而在某些场景下提升吞吐量。</p>
+
+<h2 id='io_uring_的基本用法'>io_uring 的基本用法</h2>
+
+<p><code>io_uring</code> 相关的 syscall 可以在 <a href='https://kernel.dk/io_uring.pdf'>这里</a> 找到。<a href='https://github.com/axboe/liburing'>liburing</a> 提供了更易用的 API。 Tokio 的 <a href='https://github.com/tokio-rs/io-uring'>io_uring crate</a> 在此基础之上，提供了 Rust 语言的 <code>io_uring</code> API。下面以它为例， 介绍 <code>io_uring</code> 的使用方法。</p>
+
+<p>要使用 <code>io_uring</code>，需要先创建一个 ring。在这里我们使用了 <code>tokio-rs/io-uring</code> 提供的 <code>concurrent</code> API， 支持多线程使用同一个 ring。</p>
+
+<pre><code class="language-`rust">use io_uring::IoUring;
+let ring = IoUring::new(256)?;
+let ring = ring.concurrent();</code></pre>
+
+<p>每一个 ring 都对应一个提交队列和一个完成队列，这里设置队列最多容纳 256 个元素。</p>
+
+<p>通过 <code>io_uring</code> 进行 I/O 操作的过程分为三步：往提交队列添加任务，向内核提交任务 \[注1]， 从完成队列中取回任务。这里以读文件为例介绍整个过程。</p>
+
+<p>通过 <code>opcode::Read</code> 可以构造一个读文件任务，通过 <code>ring.submission().push(entry)</code> 可以将任务添加到队列中。</p>
+
+<pre><code class="language-`rust">use io_uring::{opcode, types::Fixed};
+let read_op = opcode::Read::new(Fixed(fid), ptr, len).offset(offset);
+let entry = read_op
+            .build()
+            .user_data(user_data);
+unsafe { ring.submission().push(entry)?; }</code></pre>
+
+<p>任务添加完成后，将它提交到内核。</p>
+
+<pre><code class="language-`rust">assert_eq!(ring.submit()?, 1);</code></pre>
+
+<p>最后轮询已经完成的任务。</p>
+
+<pre><code class="language-`rust">loop {
+    if let Some(entry) = ring.completion().pop() {
+        // do something
+    }
+}</code></pre>
+
+<p>这样一来，我们就实现了基于 <code>io_uring</code> 的随机读文件。</p>
+
+<p>注 1: <code>io_uring</code> 目前有三种执行模式：默认模式、poll 模式和内核 poll 模式。如果使用内核 poll 模式，则不一定需要调用提交任务的函数。</p>
+
+<h2 id='利用_io_uring_实现异步读文件接口'>利用 io_uring 实现异步读文件接口</h2>
+
+<p>我们的目标是实现类似这样的接口，把 <code>io_uring</code> 包装起来，仅暴露给开发者一个简单的 <code>read</code> 函数。</p>
+
+<pre><code class="language-`rust">ctx.read(fid, offset, &amp;mut buf).await?;</code></pre>
+
+<p>参考了 <a href='https://github.com/hmwill/tokio-linux-aio'>tokio-linux-aio</a> 对 Linux AIO 的异步包装后，我采用下面方法来实现基于 <code>io_uring</code> 的异步读。</p>
+
+<ul>
+<li>开发者在使用 <code>io_uring</code> 之前，需要创建一个 <code>UringContext</code>。</li>
+
+<li><code>UringContext</code> 被创建的同时，会在后台运行一个（或多个）用来提交任务和轮询完成任务的 <code>UringPollFuture</code>。 (对应上一章节中读文件的第二步、第三步操作)。</li>
+
+<li>
+<p>开发者可以从 <code>ctx</code> 调用读文件的接口，用 <code>ctx.read</code> 创建一个 <code>UringReadFuture</code>。在调用 <code>ctx.read.await</code> 后：</p>
+
+<ol type="1">
+<li><code>UringReadFuture</code> 会创建一个固定在内存中的对象 <code>UringTask</code>，然后把读文件任务放进队列里，将 <code>UringTask</code> 的地址作为 读操作的用户数据。<code>UringTask</code> 里面有个 channel。</li>
+
+<li><code>UringPollFuture</code> 在后台提交任务。</li>
+
+<li><code>UringPollFuture</code> 在后台轮询已经完成的任务。</li>
+
+<li><code>UringPollFuture</code> 取出其中的用户数据，还原成 <code>UringTask</code> 对象，通过 channel 通知 <code>UringReadFuture</code> I/O 操作已经完成。</li>
+</ol>
+</li>
+</ul>
+
+<p>整个流程如下图所示。</p>
+
+<p><img src='https://user-images.githubusercontent.com/4198311/106355863-b53ca880-6335-11eb-9dfe-0682aefa1093.png' alt='uring' /></p>
+
+<p>这样，我们就可以方便地调用 <code>io_uring</code> 实现文件的异步读取。这么做还顺便带来了一个好处：任务提交可以自动 batching。 通常来说，一次 I/O 操作会产生一次 syscall。但由于我们使用一个单独的 Future 来提交、轮询任务，在提交的时候， 队列里可能存在多个未提交的任务，可以一次全部提交。这样可以减小 syscall 切上下文的开销 (当然也增大了 latency)。 从 benchmark 的结果观察来看，每次提交都可以打包 20 个左右的读取任务。</p>
+
+<h2 id='benchmark'>Benchmark</h2>
+
+<p>将包装后的 <code>io_uring</code> 和 <code>mmap</code> 的性能作对比。测试的负载是 128 个 1G 文件，随机读对齐的 4K block。 我的电脑内存是 32G，有一块 1T 的 NVMe SSD。测试了下面 6 个 case：</p>
+
+<ul></ul>
+
+<p>测试了 Throughput (op/s) 和 Latency (ns)。</p>
+
+<p>|case|throughput|p50|p90|p999|p9999|max| |----|----------|---|---|----|-----|---| |uring_8|104085.77710777053|83166|109183|246416|3105883|14973666| |uring_32|227097.61356918357|142869|212730|1111491|3321889|14336132| |uring_512|212076.5160505447|1973421|3521119|19478348|25551700|35433481| |mmap_8|109697.87025744558|78971|107021|204211|1787823|18522047| |mmap_32|312829.53428971884|100336|178914|419955|4408214|55129932| |mmap_512|235368.9890904751|2556429|3265266|15946744|50029659|156095218|</p>
+
+<p>发现 mmap 吊打 <code>io_uring</code>。嗯，果然这个包装做的不太行，但是勉强能用。下面是一分钟 latency 的 heatmap。每一组数据的展示顺序是先 mmap 后 <code>io_uring</code>。</p>
+
+<p><strong>mmap<em>8 / uring</em>8</strong> <img src='https://user-images.githubusercontent.com/4198311/106357357-a14a7400-6340-11eb-89df-72e876855557.png' alt='waterfall_mmap_8' /> <img src='https://user-images.githubusercontent.com/4198311/106357364-a60f2800-6340-11eb-9376-2d66ffa7098f.png' alt='waterfall_uring_8' /></p>
+
+<p><strong>mmap<em>32 / uring</em>32</strong> <img src='https://user-images.githubusercontent.com/4198311/106357361-a5769180-6340-11eb-8a85-80180df69ea8.png' alt='waterfall_mmap_32' /> <img src='https://user-images.githubusercontent.com/4198311/106357365-a6a7be80-6340-11eb-81e7-945758dd2092.png' alt='waterfall_uring_32' /></p>
+
+<p><strong>mmap<em>512 / uring</em>512</strong> <img src='https://user-images.githubusercontent.com/4198311/106357363-a5769180-6340-11eb-9704-7c97d9a577a6.png' alt='waterfall_mmap_512' /> <img src='https://user-images.githubusercontent.com/4198311/106357366-a6a7be80-6340-11eb-9b7e-ec4ff168962d.png' alt='waterfall_uring_512' /></p>
+
+<p><img src='https://user-images.githubusercontent.com/4198311/106357531-904e3280-6341-11eb-9577-fcd1a487e6db.png' alt='Throughput-2' /></p>
+
+<p><img src='https://user-images.githubusercontent.com/4198311/106357534-93e1b980-6341-11eb-8974-05575e63b2b7.png' alt='p50 Latency (ns)' /></p>
+
+<h2 id='一些可能的改进'>一些可能的改进</h2>
+
+<ul>
+<li>看起来现在 <code>io_uring</code> 在我和 Tokio 的包装后性能不太行。之后可以通过对比 Rust / C 在 <code>io_uring</code> nop 指令上的表现来测试 Tokio 这层包装引入的开销。</li>
+
+<li>测试 Direct I/O 的性能。目前只测试了 Buffered I/O。</li>
+
+<li>和 Linux AIO 对比。（性能不会比 Linux AIO 还差吧（痛哭</li>
+
+<li>用 perf 看看现在的瓶颈在哪里。目前 <code>cargo flamegraph</code> 挂上去以后 <code>io_uring</code> 没法申请内存。（占个坑，说不定能出续集</li>
+
+<li>目前，用户必须保证 <code>&amp;mut buf</code> 在整个 read 周期都有效。如果 Future 被 abort，会有内存泄漏的问题。 futures-rs 的类似问题见 https://github.com/rust-lang/futures-rs/issues/1278 。Tokio 目前的 I/O 通过两次拷贝（先到缓存，再给用户）解决了这个问题。</li>
+
+<li>或许可以把写文件和其他操作也顺便包装一下。</li>
+</ul>
+
+<hr><p>作者简介：</p>
+
+<p>迟先生（skyzh），上海交通大学大三学生，SJTUG 镜像站维护者，沉迷写 Rust。</p>
+]]></content:encoded></item><item><title>如何为 Rust 语言做贡献 | Part 1</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/contribute_to_the_rust_part1.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='如何为_rust_语言做贡献_|_part_1'>如何为 Rust 语言做贡献 | Part 1</h1>
+
+<p>作者：CrLF0710（野喵）/ 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='引文'>引文</h2>
+
+<p>&gt; &gt; 如果你想成为 Rust 贡献者，那看这系列文章会很有帮助。</p>
+
+<p>本系列文章主要是给大家介绍一下如何为 <code>Rust Project</code> （即 Rust 语言本身）做贡献。</p>
+
+<p>随着时间的推移，<code>Rust Project</code> 也在不断的演化，本文有效范围仅限于当前发表的时间点（2021.02）。</p>
+
+<p>接下来就随我一起熟悉 Rust Project 吧。</p>
+
+<h2 id='熟悉_rust_project'>熟悉 Rust Project</h2>
+
+<p>简单来说 <code>Rust Project</code> 的主要目标就是设计、开发、维护Rust这门编程语言。</p>
+
+<p><code>Rust Project</code> 主要由下列三部分构成：</p>
+
+<ol type="1">
+<li>第一部分是现有的技术积累，包括设计文档、代码仓库、文档教程和技术讨论的积淀。</li>
+
+<li>第二部分是 Rust 的项目组织及其延伸，包括整个 Rust 开发者社区。</li>
+
+<li>第三部分是 Rust 的配套资产（如 CI、服务器、域名，乃至于商标）和会议活动等等。</li>
+</ol>
+
+<h2 id='熟悉_rust_代码仓库'>熟悉 Rust 代码仓库</h2>
+
+<p>Rust 语言的设计文档、代码仓库、文档教程都是存储在Github上的rust-lang这个组织下的。其中<a href='https://github.com/rust-lang/rust'>rust-lang/rust</a>这个仓库是主入口。</p>
+
+<p>感兴趣的话，我们可以用git来直接下载一份下来。注意它是使用了<code>git submodule</code>的，相关联的仓库也都是需要的。</p>
+
+<p>代码仓库大概分成六部分:</p>
+
+<ul>
+<li>编译器源码：位于<code>compiler/</code>目录下，由五十多个crate构成。另外还有它会用到的llvm，位于src/llvm-project目录下。</li>
+
+<li>内置库源码：位于<code>library/</code>目录下，有十几个crate。我们平时会使用的core, alloc, std, test这些都在其中。</li>
+
+<li>其他开发工具：位于<code>src/librustdoc/</code>, <code>src/tools/</code>目录下，包括我们平时使用的rustdoc, cargo, miri, clippy 等等工具</li>
+
+<li>文档书架：位于<code>src/doc/</code>目录下，包括官方的the book, reference, nomicon等等的教程和参考文档。</li>
+
+<li>测试用例集：位于<code>src/test/</code>目录下，大部分是编译器的测试用例，也有少量一些rustdoc和其他工具的测试用例。</li>
+
+<li>部署工具和CI脚本：位于<code>src/bootstrap</code>, <code>src/build_helper</code>, <code>src/ci</code>, <code>.github/</code> 这几个地方，这些是用来自动化编译一套完整的rust工具链的。</li>
+</ul>
+
+<h2 id='编译一套_rust_工具链'>编译一套 Rust 工具链</h2>
+
+<p>下载好了<code>rust源码</code>之后，我们来试着自己编译一份<code>rust工具链</code>吧！</p>
+
+<p>首先要在你的机器上准备这些东西：<code>python3</code>, <code>ninja</code>, <code>cmake</code>，还有一套<code>c++</code>编译器(<code>g++</code>或者<code>windows</code>下用<code>visual studio</code>)。第一个是用来执行编译脚本的，后两个则是用来编译<code>llvm</code>的。</p>
+
+<p>准备好了之后，把<code>rust</code>目录里的<code>config.toml.example</code>拷贝一份，名叫<code>config.toml</code>。其中大部分内容都不用修改，但是我建议可以把增量编译启用，就是找到其中的<code>#incremental = false</code>这一行，去掉前面的<code>#</code>并且把后面的false改成true。</p>
+
+<p>其他配置选项参考如下，具体作用在配置文件中有注释说明：</p>
+
+<pre><code class="language-`rust">compiler-docs = false
+submodules = false
+configure-args = []
+debug = true
+codegen-units = 0
+default-linker = &quot;cc&quot;
+channel = &quot;nightly&quot;</code></pre>
+
+<p><strong>构建Rust的三个阶段：</strong></p>
+
+<p>Rust 是⼀个⾃举的编译器，需要通过旧的编译器来构建最新的版本。所以⼀般是分阶段来完成：</p>
+
+<ol type="1">
+<li><code>Stage0</code> 阶段。下载最新<code>beta</code>版的编译器，这些<code>x.py</code>会⾃动完成。你也可以通过修改配置⽂件来使⽤其他版本的Rust。</li>
+
+<li><code>Stage1</code> 阶段，使⽤<code>Stage0</code>阶段下载的<code>beta</code>版编译器来编译从<code>Git</code>仓库⾥下载的代码。最终⽣成<code>Stage1</code>版编译器。但是为了对其优化，还需要进⾏下⼀阶段。</li>
+
+<li><code>Stage2</code>，⽤<code>Stage1</code>版编译器继续对源码进⾏编译，以便⽣成Stage2版编译器。</li>
+</ol>
+
+<p>理论上，<code>Stage1</code>和<code>Stage2</code>编译器在功能上是相同的，但实际上还有些细微的差别。</p>
+
+<p>官⽅推荐的具体构建流程如下：</p>
+
+<ol type="1">
+<li><code>./x.py check</code> ，先执⾏此命令，检查编译器是否可以构建。</li>
+
+<li><code>./x.py build -i --stage 1</code> ，进⾏<code>Stage 0</code>和<code>Stage 1</code>阶段的构建，最终构建完成Stage1的编译器。</li>
+
+<li><code>./x.py build --stage 2 compiler/rustc</code>，在<code>Stage1</code>基础上进⾏增量式构建，最终编译出<code>Stage2</code>的编译器。</li>
+</ol>
+
+<p>整个过程是有点慢的，不考虑一开始的下载部分，编译时间随你的硬件配置不等，一般在20到60分钟左右。其中大约有一半的时间是在编译<code>llvm</code>。好在<code>llvm</code>只要编译一次，后续如果没有版本变化是不需要重新编译的。(<code>config.toml</code>里有个选项在版本变化的时候也不重新编译<code>llvm</code>)另外记得硬盘剩余空间要保证<code>30G</code>以上哦。</p>
+
+<p>然后将其加到Rustup⼯具链中:</p>
+
+<pre><code class="language-`rust">// your-target-tripe 类似：aarch64-apple-darwin/x86_64-apple-darwin 等。
+&gt; rustup toolchain link stage2 build/{your-target-tripe}/stage2</code></pre>
+
+<p>到此为⽌，准备⼯作就已经做好了。</p>
+
+<p>对这个话题感兴趣的可以继续读读官方准备的书籍<a href='https://rustc-dev-guide.rust-lang.org/'>Guide to Rustc Development</a>，里面有更多的讲解。这本书中文社区也在组织翻译<a href='https://github.com/RustcRustc/rustc-dev-guide-zh'>Guide to Rustc Development 中文版</a>，欢迎大家参与。</p>
+
+<h2 id='一起成为_rust_contributor_吧'>一起成为 Rust Contributor 吧</h2>
+
+<p>接下来，让我们试着为 Rust 项目来做点事情。<code>Rust Project</code>是非常欢迎大家参与的，参与的门槛是非常的低。</p>
+
+<p>对于想参与贡献的新手来说，可以从比较轻松的任务做起。由此，我来试着难度从低到高列出一些比较适合新手来做的事情。</p>
+
+<h3 id='no.1_改进标准库文档'>No.1 改进标准库文档</h3>
+
+<p>Rust 的每个标准库函数都在旁边有<code>markdown</code>语法的文档描述。对这一部分的调整改进是门槛最低的。可以多读读标准库的文档，顺便检查每个条目(item)和关联条目的文档描述是否足够的清晰。（特别是标注着<code>Experimental</code>的那些，往往会存在改进空间。）对于没有示例(<code>Example</code>)的部分，可以补充示例。对于标注了<code>unsafe</code>关键字的部分，可以检查下安全性(<code>Safety</code>)一节是否清晰的描述了使用时的约束条件。</p>
+
+<h3 id='no.2_改进语言参考手册'>No.2 改进语言参考手册</h3>
+
+<p>Rust 有一个相对冷门的资源叫<a href='https://github.com/rust-lang/reference'>The Rust Language Reference</a>，是语言的规格说明的雏形，实际上能做的事情相当多。但是因为人手有限，进度不是很快。对于新手，有很多参加编辑性修改的机会。实质性修改门槛会稍微高一点，需要对语言有比较全面深刻的了解。但是因为是有老手帮助review，对新人来说也是不错的提升自己的机会。缺点是<code>review</code>周期可能会相对较长。</p>
+
+<h3 id='no.3_重构、清理、增加测试用例类任务'>No.3 重构、清理、增加测试用例类任务</h3>
+
+<p>Rust里很多地方都有小型的重构、清理任务（而且很多都是故意留给新人练习的），包括<code>rustc</code>,<code>rustdoc</code>,<code>cargo</code>,<code>chalk</code>,<code>polonius</code>之类的地方都会有。可以多关注一下<code>E-easy</code>,<code>E-mentor</code>,<code>E-needs-test</code>这些标签下的问题条目，也不要忘了多去逛逛<code>cargo</code>,<code>chalk</code>等等的单独仓库。</p>
+
+<h3 id='no.4_完善编译器的诊断和代码质量检测'>No.4 完善编译器的诊断和代码质量检测</h3>
+
+<p>在编译器这一侧，最适合初学者学习的工作有两项，一个是诊断(<code>diagnostics</code>)，负责编译报错信息的完善，尽可能推断出用户的原本意图，并给出更好的错误提示。另一个就是代码质量检测(<code>lint</code>)。代码质量检测检查的是代码中那些不违反基本规则的那些写法，它们是可配置的，编译器可以配置为允许，警告，拒绝和严禁的形式进行响应。<a href='https://rustc-dev-guide.rust-lang.org/diagnostics.html'>Guide to Rustc Development中有专门的一节进行讲解</a>，可做的事情也是非常多的。对于一些非常具体情况的检测和反馈，也可以放到<code>clippy</code>这个专门的检测工具中。可以多关注一下<code>A-Diagnostics</code>, <code>A-suggestion-diagnostics</code>, <code>A-lint</code>这些标签下的问题条目，以及<code>clippy</code>仓库中的问题条目。</p>
+
+<h2 id='rust_pr_流程：从提交到合并'>Rust PR 流程：从提交到合并</h2>
+
+<p>要提交修改只要在<code>GitHub</code>上 fork 官方的<code>rust</code>仓库，把修改提交到自己的fork仓库里，然后建一个PR(Pull Request)就可以了。</p>
+
+<p>接下来我来试着讲讲提交之后会发生的事情。感兴趣可以了解下，不感兴趣也可以跳过。</p>
+
+<p><strong>PR CI 阶段</strong></p>
+
+<p>官方<code>rust</code>仓库有好几个自动交互机器人。我们首先会接触到的是一个叫<code>rust-highfive</code>的机器人。它负责欢迎新人，并且如果你的 PR 里没写由谁来<code>review</code>的话(格式是<code>r? @XXX</code>)，它会自动把我们的<code>PR</code>随机分配给它觉得合适的人来<code>review</code>。分配的方法是它会看你修改了仓库里哪些文件，然后在相应的负责人员列表里随机分配。并且给你的 PR 加上一个<code>S-waiting-for-review</code>的标签，表示正在等待<code>review</code>的状态。同时 PR CI 会开始运行，如果你的修改有格式问题(没有执行<code>rustfmt</code>之类的)、编译或者单元测试不通过，就会被 PR CI 拦下来，告诉你编译失败。你可以继续调整。</p>
+
+<p><strong>官方 Reviewer 审阅</strong></p>
+
+<p>接下来几天之内往往就会有官方 Reviewer 来审阅我们的修改了。Reviewer 都是官方某个团队的正式成员。因为 PR 都是公开的，在这期间，其他成员、社区爱好者也有可能会帮忙审阅你的代码，帮我们提出修改意见之类的。Reviewer 看了之后也可能要求我们修改。他们会把 PR 状态改成<code>S-waiting-for-author</code>。还有一种情况是这段时间里代码更新导致了合并冲突。机器人会来留言告诉你有合并冲突。这个时候你需要执行一个<code>git</code>的<code>rebase</code>操作，完成对合并冲突的解决，然后更新你的 PR 分支。</p>
+
+<p>很多 PR 会在这一阶段停留一段时间，官方有一个小的分类处理工作组(<code>T-release</code>/<code>WG-triage</code>)，会定期来检查各个 PR 的状态。对于等待作者处理的 PR，15 天左右会留言确认状态；如果 30 天左右没有响应，会留言并关闭 PR。对于等待<code>review</code>的 PR，会在 15 天左右整理成报告，部分会通知 reviewer 确认审阅进度。</p>
+
+<p><strong>PR 合并</strong></p>
+
+<p>Reviewer 觉得你的提交<code>ok</code>了之后就会进入下一阶段了。Reviewer 会给另一个名叫<code>bors</code>的机器人发指令标识审阅通过(<code>@bors r+</code>)。这个命令有俩参数，一个是优先级(<code>p</code>)，优先级高的会在排在队列靠前的位置。一个是是否参与批量合并(<code>rollup</code>)。如果你的贡献足够微小，Reviewer 会把<code>rollup</code>设置为<code>always</code>，永不参与单独测试合并。相反如果你的贡献可能会带来编译性能影响之类的，Reviewer 会把<code>rollup</code>设置为<code>never</code>，永不参与批量测试合并，这样万一以后需要<code>revert</code>的话会比较方便。</p>
+
+<p>接下来就是测试合并阶段了。<code>Bors</code>机器人管理着一个<a href='https://bors.rust-lang.org/queue/rust'>PR队列</a>。<code>Bors</code>机器人会按照队列的顺序一次一个 PR 来<strong>先合并</strong>，再测试，通过后推送远端分支并更新关闭相应的 PR。对于那些<code>rollup=always</code>的 PR，<code>bors</code>是不会合并的。官方的一些成员会轮流负责<code>Rollup</code>工作，每次控制<code>Bors</code>机器人来产生一个<code>8~12</code>个 PR 构成的一个高优先级的批量合并的 PR 加到队列里，由<code>bors</code>来测试合并。</p>
+
+<h2 id='小结'>小结</h2>
+
+<p>这次我们从一个开发者的视角，了解了参与rust项目所需要的一些基本知识和切入点，下一次我们会介绍一下项目组的总体结构以及如何参与一些更大型的工作。到时见！</p>
+
+<h2 id=''></h2>
+
+<p>作者介绍：</p>
+
+<p>CrLF0710，C++程序员/ Rust业余爱好者/ Rust Team版本发布团队分类处理工作组（负责参与 Rust Project 的issues 和 PR 分类管理）成员。</p>
+
+<p>业余时间写些<code>Rust</code>代码，也对<code>rustc</code>, <code>cargo</code>, <code>chalk</code>, <code>rustup</code>, <code>rustbook</code>等都做过一些代码贡献。偶尔在知乎Rust主题专栏<a href='https://www.zhihu.com/column/rust-quickstart'>《学一点Rust又不会怀孕》</a>上写一些文章。</p>
+]]></content:encoded></item><item><title>二月刊（February）</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_2/toc.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='二月刊'>二月刊</h1>
+
+<p><img src='../image/rust_magazine3.png' alt='logo' /></p>
+
+<h3 id='发刊通告'>发刊通告</h3>
+
+<ul>
+<li><a href='./announce.md'>发刊通告</a></li>
+</ul>
+
+<h3 id='本月社区动态简报'>本月社区动态简报</h3>
+
+<p>精选自《Rust日报》</p>
+
+<ul>
+<li><a href='./lang.md'>Rust官方动态</a></li>
+
+<li><a href='./hots.md'>社区热点</a></li>
+
+<li><a href='./projects.md'>推荐项目</a></li>
+
+<li><a href='./learns.md'>学习资源</a></li>
+
+<li><a href='./rust_laoke.md'>Rust 唠嗑室本月汇总</a></li>
+</ul>
+
+<h3 id='rust_问答精选'>Rust 问答精选</h3>
+
+<ul>
+<li><a href='./rust_zhihu.md'>知乎 Rust 圆桌年话专题问答精选</a></li>
+</ul>
+
+<h3 id='rust_in_production'>Rust in Production</h3>
+
+<ul>
+<li><a href='./huawei_rust.md'>华为 | 可信编程 -- 华为引领Rust语言开发的实践和愿景</a></li>
+
+<li><a href='./rust_trace.md'>PingCAP | TiKV 高性能追踪的实现解析</a></li>
+
+<li><a href='./rust_error_handle.md'>蚂蚁集团 CeresDB 团队 | 关于 Rust 错误处理的思考</a></li>
+
+<li><a href='./rust_error_handle_and_log.md'>华为 | Rust中的错误传递和日志记录</a></li>
+</ul>
+
+<h3 id='学习园地'>学习园地</h3>
+
+<ul>
+<li><a href='./rust_study.md'>新年新人新气象 | Rust 学习笔记</a></li>
+
+<li><a href='./cli_gameoflife.md'>「译」使用 Rust 实现命令行生命游戏</a></li>
+
+<li><a href='./actor_with_tokio.md'>「译」使用 Tokio 实现 Actor 系统</a></li>
+
+<li><a href='./rust_1.50.md'>解读 Rust 1.50 稳定版</a></li>
+
+<li><a href='./rust_2021_edition.md'>解读 Rust 2021 Edition RFC </a></li>
+</ul>
+
+<h3 id='wasm_专题'>WASM 专题</h3>
+
+<ul>
+<li><a href='./rust_wasm_frontend.md'>前端入门 ｜ Rust 和 WebAssembly </a></li>
+</ul>
+
+<h3 id='游戏专题'>游戏专题</h3>
+
+<ul>
+<li><a href='./rust_game_bevy_bomber.md'>实践案例 | 使用 `Bevy` 游戏引擎制作炸弹人</a></li>
+</ul>
+
+<h3 id='操作系统与网络编程专题'>操作系统与网络编程专题</h3>
+
+<ul>
+<li><a href='./io_uring_intro.md'>io_uring | Linux 全新异步接口 io_uring 的 Rust 生态盘点 </a></li>
+
+<li><a href='./io_uring_async_rw.md'>io_uring | 用 Rust 实现基于 io_uring 的异步随机读文件</a></li>
+</ul>
+
+<h3 id='rust_编译器专题'>Rust 编译器专题</h3>
+
+<ul>
+<li><a href='./contribute_to_the_rust_part1.md'>如何为 Rust 语言做贡献 | Part 1</a></li>
+</ul>
+]]></content:encoded></item><item><title>发刊通告</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/announce.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='发刊通告'>发刊通告</h1>
+
+<p>编辑：张汉东</p>
+
+<h3 id='三月发刊通告'>三月发刊通告</h3>
+
+<p>三月，万物复苏，万象更新。不知不觉，三月的最后一天到了，《 RustMagazine 中文精选 》2021 年第三期发布了!</p>
+
+<p>每次发布月刊，都会体会到时光流逝的无情。毕竟一年才十二个月，所以月刊一年一共才十二期，现在第三期已经发布了。更重要的是，当月刊发布的时候，也意味着三月即将过去。为了迎接四月的到来，大地作了太多的准备，你呢？你的四月又将为什么样的目标做准备呢？无论如何，加油吧！</p>
+
+<h3 id='社区协作项目动态介绍'>社区协作项目动态介绍</h3>
+
+<p><strong>介绍两个新创建的协作项目：</strong></p>
+
+<ol type="1">
+<li><a href='https://github.com/ZhangHanDong/star-rust'>Star Rust</a>。该项目用于记录 Rust 开源生态中的明星项目。不同于 awesome-rust ，该项目侧重于记录明星项目，及其介绍、架构、应用、源码解读。</li>
+
+<li><a href='https://github.com/ZhangHanDong/real-world-rust-design-pattern'>Real World Rust Design Pattern</a>。该项目用于挖掘 Rust 开源生态中知名项目的设计模式。</li>
+</ol>
+
+<p>以上项目是需要社区大家一起完成的，如果你是一个喜欢学习并且输出的人，并且对上面项目感兴趣，欢迎大家一起做贡献。</p>
+
+<p>将来这些内容，也会摘录到本刊中。</p>
+
+<p>\<em>\</em>【活动预告】2021.04.10 北京 Rust Meetup **</p>
+
+<p>报名链接 ：  <a href='http://hdxu.cn/ZxJjK'>http://hdxu.cn/ZxJjK</a></p>
+
+<p>该活动相关议题内容也请关注下期月刊。</p>
+
+<h3 id='上期（二月刊）访问数据统计小结'>上期（二月刊）访问数据统计小结</h3>
+
+<p><strong>用户数</strong></p>
+
+<ul>
+<li>总用户数 1670 （同比上升 268%)</li>
+
+<li>30天活跃用户数 464</li>
+</ul>
+
+<p><strong>浏览量：</strong></p>
+
+<ul>
+<li>网页浏览量 ：11,410 （同比上升 349.8%）</li>
+
+<li>唯一身份浏览量 ：7,410</li>
+</ul>
+
+<p><strong>读者分布地区排名：</strong></p>
+
+<ul>
+<li>中国 （同比上升 212%）</li>
+
+<li>中国香港（同比上升 369%）</li>
+
+<li>中国台湾（同比上升 257%）</li>
+
+<li>新加坡（同比上升 467%）</li>
+
+<li>北美（美国/加拿大）（同比上升 296%）</li>
+</ul>
+
+<p><strong>二月份比较受欢迎的文章 Top 5（按访问量依次排名）：</strong></p>
+
+<p>注： 一月刊的 《图解 Rust 所有权》文章依旧最受欢迎，作者：肖猛</p>
+
+<ul>
+<li>《 前端入门 ｜ Rust 和 WebAssembly》，作者: 陈鑫(lencx)</li>
+
+<li>《 实践案例 | 使用 Bevy 游戏引擎制作炸弹人》，作者：Cupnfish</li>
+
+<li>《 蚂蚁集团 CeresDB 团队 | 关于 Rust 错误处理的思考 》， 作者：evenyag</li>
+
+<li>《 华为 | 可信编程 -- 华为引领Rust语言开发的实践和愿景》，作者：俞一峻等三位</li>
+
+<li>《 DatenLord ｜ Linux 全新异步接口 io_uring 的 Rust 生态盘点》，作者：施继成</li>
+</ul>
+
+<p><strong>简报关注分类依次为：</strong></p>
+
+<p>热度基本和一月刊相差无几：</p>
+
+<ul>
+<li>学习资源</li>
+
+<li>Rust 官方动态</li>
+
+<li>推荐项目</li>
+
+<li>社区热点</li>
+
+<li>Rust 唠嗑室</li>
+</ul>
+
+<p>后续也期待大家投稿。欢迎大家直接使用本刊 mdbook 模版进行创作投稿发PR！</p>
+]]></content:encoded></item><item><title>Rust官方动态</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/lang.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rust官方动态'>Rust官方动态</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑： 张汉东</li>
+</ul>
+
+<hr><h2 id='建立_async_rust_的共同愿景'>建立 Async Rust 的共同愿景</h2>
+
+<p>2021年3月18日·Niko Matsakis 代表 <a href='https://rust-lang.github.io/wg-async-foundations/'>Async Foundations Working Group</a></p>
+
+<p>在 <a href='https://rust-lang.github.io/wg-async-foundations/'>异步基础工作组</a> 认为 Rust 能够成为最热门的选择之一为构建分布式系统，从嵌入式设备到基础云服务。无论他们将其用于什么，我们都希望所有开发人员都喜欢使用 Async Rust。为了实现这一点，我们需要将 Async Rust 移至目前的“MVP”状态之外，并使所有人都可以使用它。</p>
+
+<p>我们正在开展合作，为 Async Rust 构建共享的 <a href='https://rust-lang.github.io/wg-async-foundations/vision.html#-the-vision'>愿景文档</a> 。<code>我们的目标是让整个社区参与到集体的想象中</code>：我们如何才能使使用异步 I/O 的端到端体验不仅是一种务实的选择，而且是一种快乐的选择？</p>
+
+<p><a href='./async-vision-doc.md'>点此阅读该文中文翻译</a></p>
+
+<h2 id='rust_1.51_稳定版发布'>Rust 1.51 稳定版发布</h2>
+
+<p>$ rustup update stable</p>
+
+<p>该版本主要是带来了 ：</p>
+
+<ol type="1">
+<li>Const Generics MVP  ： https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html</li>
+
+<li>顺便  std::array::IntoIter 也稳定了</li>
+</ol>
+
+<pre><code class="language-`rust">pub struct IntoIter&lt;T, const N: usize&gt; {
+    data: [MaybeUninit&lt;T&gt;; N],
+    alive: Range&lt;usize&gt;,
+}
+
+impl&lt;T, const N: usize&gt; IntoIter&lt;T, N&gt; {
+
+}</code></pre>
+
+<ol type="3">
+<li>新的 cargo crate 依赖管理机制。 具体查看 RFC 2957。 简单来说，通过设置 resolver=&quot;2&quot; 来告诉 cargo 启用新的解析 features 方法，从而解决当前因为cargo 默认合并features带来的问题。概述：</li>
+</ol>
+
+<ul>
+<li>对于 dev dependencies： 当包（package）作为常规依赖项和开发依赖项共享时，仅当当前构建包含开发依赖项时，才启用开发依赖项features</li>
+
+<li>Host Dependencies ：当包作为 常规依赖 和 构建依赖或proc-macro共享时，用于常规依赖的features 将独立于构建依赖或proc-macro。</li>
+
+<li>Target Dependencies: 当包在构建图中多次出现，并且其中一个实例是特定于目标的依赖项时，仅当当前正在构建目标时，才启用特定于目标的依赖项的features。</li>
+</ul>
+
+<p>不过这样可能会导致编译时间加长（因为可能多次编译同一个crate），更详细内容可以看 Cargo Guide 的 &quot;Feature Resolver&quot; 小节。</p>
+
+<pre><code class="language-`rust">[package]
+resolver = &quot;2&quot;
+# Or if you&#8217;re using a workspace
+[workspace]
+resolver = &quot;2&quot;</code></pre>
+
+<ol type="4">
+<li>针对 MacOS 平台对 Debug 模式构建时间做了优化。去掉了之前通过 dsymutil 工具将debug信息收集到.dSYM目录下的方式，而使用新的方式，从而减少debuginfo的构建时间，并显着减少所使用的磁盘空间量。但还期待macOS 用户的更多构建报告。</li>
+</ol>
+
+<pre><code class="language-`rust">[profile.dev]
+split-debuginfo = &quot;unpacked&quot;</code></pre>
+
+<p>这样设置就可以启用新的行为</p>
+
+<ol type="5">
+<li>稳定了很多 API ，就不细说了。值得一提的是 <code>task::Wake</code>现在稳定了。</li>
+</ol>
+
+<p><a href='https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html'>https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html</a></p>
+
+<h2 id='rust_2021_edition_计划10月21号发布'>Rust 2021 Edition 计划10月21号发布</h2>
+
+<p>Rust 采用每六周一个小版本和每三年一个 Edition 版本的方式来迭代更新。相比于 2018 Edition，2021 Edition 会是一个相对小的版本，官方计划于 2021年10月21号（1.56）正式发布。目前并没有完全确定下来哪些功能将纳入 2021 Edition，但有部分特性是已经确定好的了，这些特性包括：</p>
+
+<p>Prelude 加入新的 <code>trait</code>：<code>TryFrom / TryInto</code>, <code>FromIterator</code></p>
+
+<p>更 ergonomic 的闭包变量捕获规则。</p>
+
+<p>现在的闭包变量捕获非常严格，就算你只引用了单个 struct 的字段，它也会把整个 struct 捕获进来。新的规则会做到尽量小范围的捕获变量，比如下面两个例子在 2018 Edition 编译不通过，但是 2021 Edition 是可以的：</p>
+
+<pre><code class="language-`rust">let _a = &amp;mut foo.a;
+|| &amp;mut foo.b; // (Edition 2018) Error! cannot borrow `foo`
+
+let _a = &amp;mut foo.a;
+move || foo.b; // (Edition 2018) Error! cannot move `foo`
+改善 or 模式匹配
+// 以前需要这么写的或规则匹配：
+Some(Enum::A) | Some(Enum::B) | Some(Enum::C) | Some(Enum::D) =&gt; ..
+
+// 2021 Edition 之后可以写成这样了！
+Some(Enum::A | Enum::B | Enum::C | Enum::D) =&gt; ..</code></pre>
+
+<p>统一 macro<em>rules 定义的宏的默认可见性，移除`#[macro</em>export]<code> 和 </code>#[macro_use]` 宏： Rust 所有类型可见性默认都是私有，只有加 pub 或 pub($PATH) 才能修改为公开可见，而 macro<em>rules 定义的宏却不是这样的，你需要使用 `#[macro</em>export]<code> 才能让这个宏公开。从 2021 Edition 开始，macro_rules 定义的宏默认为私有，同样需要加 pub 或 pub($PATH) 才能修改可见性。</code>#[macro<em>export] <code>和 </code>#[macro</em>use]` 这两个宏就没什么用了，直接移除。</p>
+
+<p><a href='https://blog.rust-lang.org/inside-rust/2021/03/04/planning-rust-2021.html'>链接</a></p>
+
+<h2 id='rust_编译器后端升级为_llvm_12'>Rust 编译器后端升级为 LLVM 12</h2>
+
+<p><a href='https://github.com/rust-lang/rust/pull/81451'>链接</a></p>
+
+<h2 id='gloo:_一个官方的_rustwasm_项目寻找_maintainer'>gloo: 一个官方的 rustwasm 项目寻找 maintainer</h2>
+
+<p>gloo 是 rustwasm 下的一个官方项目 (801星) , 由于作者不能再维护, 所以在寻找一个maintainer. 感兴趣的小伙伴可以尝试联系一下.</p>
+
+<p><a href='https://github.com/rustwasm/gloo/issues/119'>原始issue地址</a></p>
+
+<h2 id='miri运行在wasm上！'>Miri运行在wasm上！</h2>
+
+<p>现在已经有方法可以将miri编译到wasm了。</p>
+
+<p><a href='https://github.com/rust-lang/miri/issues/722#issuecomment-795763551'>issue </a></p>
+]]></content:encoded></item><item><title>社区热点</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/hots.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='社区热点'>社区热点</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：张汉东</li>
+</ul>
+
+<hr><h2 id='华为_|_openeuler_社区在_3_月_29_日正式成立了_rust_sig'>华为 | openEuler 社区在 3 月 29 日正式成立了 Rust SIG</h2>
+
+<p>近日，openEuler 社区正式成立了 Rust SIG 组织。在维护 openEuler 操作系统内 Rust 工具链相关软件包的同时，也致力于将上游 Rust 社区优秀开源项目引入到 openEuler 操作系统中。openEuler 社区未来会持续和国内 Rust 社区和相关厂商通力合作，推动 Rust 语言在国内的发展，吸引更多的开发者关注和使用 Rust 语言。</p>
+
+<p>欢迎订阅 rust@openeuler.org 邮件列表，参与到社区讨论中。</p>
+
+<p>订阅方法：</p>
+
+<p>https://openeuler.org/zh/community/mailing-list/ 在这个页面找到 Rust SIG，然后进去有 SubScribe 按钮，输入你到邮箱订阅。然后会收到一封邮件，你回复这封邮件即可。</p>
+
+<h2 id='niko_|_我们的_aws_rust_团队将如何为_rust_未来的成功做出贡献'>Niko | 我们的 AWS Rust 团队将如何为 Rust 未来的成功做出贡献</h2>
+
+<p>自今年年初以来，AWS Rust 团队一直在起草我们的章程和宗旨。 章程和宗旨是 AWS 团队用来定义我们的范围和优先事项的框架。 章程告诉你的团队该做什么，宗旨告诉你的团队将如何做到这一点。 由于我们的团队宗旨一直是公开和透明运作的，我们想与您分享我们的章程和宗旨，我们希望您知道我们在做什么。</p>
+
+<p>起草我们的章程很容易。 这只是一句话：AWS Rust 团队致力于让 Rust 为其所有用户提供高效、可靠的服务。 说得够多了！ 然而，撰写这些宗旨需要更多的工作。</p>
+
+<p>等等，AWS 有个 Rust 小组？</p>
+
+<p>是的! 事实上，至少从 2017 年开始，AWS 就在多项服务中使用 Rust。 例如，用 Rust 编写的 Firecracker 于 2018 年推出，提供支持 AWS Lambda 和其他无服务器产品的开源虚拟化技术。 最近，AWS 发布了用 Rust 编写的基于 Linux 的容器操作系统 Bottlerocket ，Amazon Elastic Compute Cloud(Amazon EC2) 团队使用 Rust 作为新的 AWS Nitro 系统组件(包括 Nitro Enclaves 等敏感应用程序)的首选语言。 随着在 AWS 中采用 Rust 的增长，我们对 Rust 项目和社区的投资也在增加。 2019年，AWS 宣布赞助 Rust 项目。 2020年，AWS 开始打造 Rust 维护者和贡献者团队，2021年，AWS 联合其他 Rust 用户和 Rust 项目发起了 Rust 基金会。 AWS Rust 团队首先找出了如何最好地与 AWS 和更广泛的开源社区建立联系。 我们知道，我们希望在公开的环境下运作，并成为整个社会的一份子。 与此同时，我们知道我们想要充分利用在 AWS 工作的机会。 起草章程和宗旨是我们找到两者兼顾的方法和过程的一部分。</p>
+
+<p><a href='./how-our-aws-rust-team-will-contribute-to-rusts-future-successes.md'>点此阅读该文的中文翻译</a></p>
+
+<h3 id='rust_for_linux_相关'>Rust for Linux 相关</h3>
+
+<p><strong>linux-next 分支现在已被合并。</strong></p>
+
+<p>Linus Torvalds 讨论 Rust 适合Linux 的场景</p>
+
+<p>关键内容：</p>
+
+<ol type="1">
+<li>Coreutils  的 Rust 版本已经被 Mozilla 主管 Sylvestre Ledru 移植到了 Linux 。有了这些，Ledru启动了Linux并运行了最受欢迎的Debian软件包。</li>
+
+<li>Linux Rust的支持者并不是： “提议将Linux内核重写为Rust“ 。 他们只是专注于向可能编写新代码的世界迈进。</li>
+
+<li>Rust支持的三个潜在方面是：利用内核中的现有API，体系结构支持，以及处理Rust和C之间的应用程序二进制接口（ABI）兼容性。</li>
+
+<li>Linus 目前到态度是： 等待和观察。 他对 Rust for Linux 是感兴趣的，就个人而言，他绝不会排挤 Rust，但Linus 认为目前这个事情是那些对 Rust 抱有强烈兴趣的人推动的（Linus比较冷静），他想看看最终 Rust 在实践中如何发挥作用。</li>
+
+<li>linux 认为 Rust 可能的场景：Rust的主要首要目标似乎是驱动程序，仅是因为在那里可以找到许多不同的可能目标，并且内核的这些各个部分相当小且独立。这可能不是一个非常有趣的目标。对某些人来说，但这是显而易见的。</li>
+
+<li>Kroah-Hartman 的观点：“一切都归结为如何将用C编写的内核核心结构和生存期规则之间的交互映射到Rust结构和生存期规则中”</li>
+
+<li>尽管几乎可以肯定不会很快看到Linux从C 迁移到Rust，但是接下来的几年估计会非常有趣： 引入基于 Rust 的用户空间程序/ 驱动程序/  基于 Rust 的 内核迁移到 Linux 等。</li>
+</ol>
+
+<p>相关链接合集，排序规则：最上面的是最新的</p>
+
+<p>Linux Kernel&#8217;s Preliminary Rust Code Seeing 64-bit POWER Support <a href='https://www.phoronix.com/scan.php?page=news_item&amp;px=Linux-Kernel-Rust-PPC64LE'>https://www.phoronix.com/scan.php?page=news_item&amp;px=Linux-Kernel-Rust-PPC64LE</a></p>
+
+<p><a href='https://www.phoronix.com/scan.php?page=news_item&amp;px=Rust-Hits-Linux-Next'>https://www.phoronix.com/scan.php?page=news_item&amp;px=Rust-Hits-Linux-Next</a></p>
+
+<p><a href='https://www.zdnet.com/article/linus-torvalds-on-where-rust-will-fit-into-linux/'>https://www.zdnet.com/article/linus-torvalds-on-where-rust-will-fit-into-linux/</a></p>
+
+<p><a href='https://lore.kernel.org/rust-for-linux/CANiq72nbNxpps+p4wYp03ncrbGH9FFoTfHQZwg_vGdPO41eGmQ@mail.gmail.com/t/'>https://lore.kernel.org/rust-for-linux/CANiq72nbNxpps+p4wYp03ncrbGH9FFoTfHQZwg_vGdPO41eGmQ@mail.gmail.com/t/</a></p>
+
+<p><a href='https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/rust?id=c77c8025525c36c9d2b9d82e4539403701276a1d'>https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/rust?id=c77c8025525c36c9d2b9d82e4539403701276a1d</a></p>
+
+<h2 id='linux_基金会_和_riscv_基金会_共同推出的_免费_riscv_课程'>Linux 基金会 和 RISCV 基金会 共同推出的 免费 RISCV 课程</h2>
+
+<p>课程发布在 edx.org 上，包括两个课程：</p>
+
+<ul>
+<li>Introduction to RISC-V (LFD110x)</li>
+
+<li>Building a RISC-V CPU Core (LFD111x)</li>
+</ul>
+
+<p><a href='https://www.zdnet.com/article/linux-foundation-risc-v-international-launch-free-risc-v-training-classes/'>https://www.zdnet.com/article/linux-foundation-risc-v-international-launch-free-risc-v-training-classes/</a></p>
+
+<h2 id='rust_and_llvm_in_2021'>Rust and LLVM in 2021</h2>
+
+<p>作者是 Rust 的核心团队成员, 之前就职于 Mozilla, 现就职于 Facebook. 写过最初的基于 LLVM 的 Rust 代码生成器, 以及很多 Rust 相关的工作.</p>
+
+<p>该 keynote 讲述的是 Rust 中 LLVM 相关工作:</p>
+
+<p>新的特性. 将LLVM 的提升带到 Rust 中. LLVM 相关的提升和修复. 未来的挑战. 对于 Rust 编译器层面感兴趣的小伙伴可以深入了解.</p>
+
+<p><a href='https://www.icloud.com/keynote/09ZXbPfbCKm8vCtAnWdfi2xIg#rust-llvm-cgo-2021'>keynote地址</a></p>
+
+<h2 id='rust版coreutils现在可以用来跑debian啦'>Rust版coreutils现在可以用来跑Debian啦</h2>
+
+<p>现在可以用Rust版的Coreutils (cp, chmod, ls, rm, tail, install..) 来运行Debian啦。</p>
+
+<ul>
+<li><a href='https://github.com/uutils/coreutils/'>GitHub项目地址</a></li>
+
+<li><a href='https://sylvestre.ledru.info/blog/2021/03/09/debian-running-on-rust-coreutils'>阅读更多</a></li>
+</ul>
+
+<h2 id='curl_工具一半的漏洞都是关于_c_语言的错误'><code>curl</code> 工具一半的漏洞都是关于 C 语言的错误</h2>
+
+<p>作者对这一问题进行了分析，并提到一个观点，如果用 Rust 来写 curl 的话，这些漏洞会减少一半。</p>
+
+<p><a href='https://daniel.haxx.se/blog/2021/03/09/half-of-curls-vulnerabilities-are-c-mistakes/'>链接</a></p>
+
+<h2 id='rust_和_c_速度比较'>Rust 和 C 速度比较</h2>
+
+<p>Rust 和 C 的编程风格差异很大，但两者开发的程序在运行速度和内存使用情况上大致相同。语言在理论上可以实现什么，但在实践中如何使用它们之间有很大的区别。作者总结了Rust 和 C 各自在哪些地方会更快。</p>
+
+<p>简而言之</p>
+
+<ul>
+<li>Rust 可以在必要时以足够底层的方式对其进行优化，使其达到与 C 一样的性能；</li>
+
+<li>Rust 拥有更高层次的抽象，便捷的内存管理和丰富的第三方库；</li>
+
+<li>Rust 最大的潜力在于无畏并发（fearless concurrency）能力。</li>
+</ul>
+
+<p><a href='https://kornel.ski/rust-c-speed'>文章链接</a></p>
+
+<h2 id='github_action_将_rust_warning_转为_review_comments'>GitHub Action 将 Rust warning 转为 review comments</h2>
+
+<p>Rust Action 可以在出发执行后，将 Rust check 的 warning 转为 code review 的 comments。</p>
+
+<p><a href='https://twitter.com/greyblake/status/1370117541436219393?s=20'>ReadMore</a></p>
+
+<h2 id='intellij_rust_changelog_#143'>INTELLIJ RUST CHANGELOG #143</h2>
+
+<p>为类似函数的程序宏提供初步支持。现在，插件可以扩展这种程序性宏调用；因此，它们自动获得声明性宏已经具备的一些功能：高亮显示、名称解析、有限的代码完成、意图等。</p>
+
+<p><img src='https://intellij-rust.github.io/assets/posts/changelog-143/function-like-proc-macro-support.gif' alt='gif' /></p>
+
+<h2 id='veloren_0.9'>Veloren 0.9</h2>
+
+<p>一款开源多人RPG游戏，今天发布了!会在3月20日格林威治时间18:00发布在公共服务器上!</p>
+
+<p>《Veloren》是一款多人体素RPG游戏。它的灵感来自《魔方世界》、《塞尔达传说:荒野之息》、《矮人要塞》和《我的世界》等游戏。</p>
+
+<p>Veloren是完全开源的，使用GPL 3授权。它使用原始图形，音乐和其他资产社区创建的资产。它的开发社区和用户社区都是受贡献者驱动的:开发者、玩家、艺术家和音乐家一起开发游戏。</p>
+
+<p><a href='https://veloren.net/'>文章链接</a></p>
+
+<h2 id='actix_actor_framework_v0.11_出來了'>Actix Actor Framework v0.11 出來了</h2>
+
+<p><code>~40%</code> 的效能改善，升级到 Tokio v1</p>
+
+<p><a href='https://github.com/actix/actix/blob/master/actix/CHANGES.md'>Actix 0.11 Change Log</a></p>
+
+<h2 id='知乎|_搜索引擎研发（rust)_工程师'>知乎| 搜索引擎研发（Rust) 工程师</h2>
+
+<p>岗位职责</p>
+
+<ul>
+<li>负责搜索引擎平台架构建设，优化系统稳定性，设计良好的架构支持业务快速迭代</li>
+
+<li>抽象通用的搜索引擎部署方案，用于快速支持各大垂直搜索引擎</li>
+
+<li>参与知乎搜索业务优化</li>
+</ul>
+
+<p>任职要求：</p>
+
+<ul>
+<li>有扎实的编程能力，有良好的数据结构和算法基础</li>
+
+<li>良好的团队合作精神，较强的沟通能力</li>
+
+<li>熟悉 Linux 开发环境，熟悉 Go/Rust 语言，熟悉网络编程、多线程编程</li>
+
+<li>熟悉搜索引擎，对 Elasticsearch、Kubernetes 有使用经验者优先</li>
+
+<li>有高可靠分布式系统架构设计经验者优先</li>
+</ul>
+
+<p>知乎搜索Rust 开源项目： https://github.com/zhihu/rucene</p>
+
+<p>联系邮箱:</p>
+
+<p><a href='zhihu.com'>zl 【at】 zhihu 点 com</a></p>
+
+<h2 id='蚂蚁集团校招开启：rust_实习生看过来'>蚂蚁集团校招开启：Rust 实习生看过来</h2>
+
+<p>@2021.11.1～2022.10.31毕业的应届生可看 ，要推荐的可以找我咨询 ，也可直接联系。</p>
+
+<p>招聘部门：</p>
+
+<ul>
+<li>
+<p>蚂蚁智能监控团队JD（内有联系方式）： <a href='https://mp.weixin.qq.com/s/mi5woh-btWEEsc8ruSww7Q'>https://mp.weixin.qq.com/s/mi5woh-btWEEsc8ruSww7Q</a></p>
+</li>
+
+<li>
+<p>蚂蚁机密计算部门: 直接联系方式：微信32713933， email shoumeng.ysm@antgroup.com</p>
+</li>
+</ul>
+
+<p>部门相关信息看下面链接：</p>
+
+<p><a href='https://mp.weixin.qq.com/s/9t6_RrgSujrosDVphlzebg'>https://mp.weixin.qq.com/s/9t6_RrgSujrosDVphlzebg</a></p>
+
+<h2 id='3.27_号_深圳_rust_meetup_视频和资料'>3.27 号 深圳 Rust Meetup 视频和资料</h2>
+
+<p>活动PPT和现场视频链接：</p>
+
+<ul>
+<li><a href='https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665'>https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665</a></li>
+</ul>
+
+<p>B 站：</p>
+
+<ul>
+<li><a href='https://b23.tv/aKsBq3'>https://b23.tv/aKsBq3</a></li>
+
+<li><a href='https://b23.tv/UR07IW'>https://b23.tv/UR07IW</a></li>
+</ul>
+]]></content:encoded></item><item><title>推荐项目</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/projects.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_推荐项目'>本月简报 | 推荐项目</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：杨楚天</li>
+</ul>
+
+<h2 id='lens-rs'>lens-rs</h2>
+
+<ul>
+<li><a href='https://github.com/TOETOE55/lens-rs'>仓库链接</a></li>
+
+<li><a href='https://zhuanlan.zhihu.com/p/358678675'>文章链接</a></li>
+</ul>
+
+<p>lens-rs 是一个 lens 的 rust 实现。</p>
+
+<h2 id='tinyvm'>tinyvm</h2>
+
+<ul>
+<li><a href='https://github.com/mkhan45/tinyvm'>仓库链接</a></li>
+</ul>
+
+<p>tinyvm 是一个堆栈字节码虚拟机的最小化可用实现。这个 VM  可以运行一个简单的图灵完备的指令集。核心代码只有 250 行，并且有大量注释。</p>
+
+<h2 id='maple'>maple</h2>
+
+<ul>
+<li><a href='https://github.com/lukechu10/maple'>仓库链接</a></li>
+</ul>
+
+<p>maple 是一个用 WASM 实现的响应式 DOM 库，没用到虚拟 DOM，而是在渲染过程中细粒度响应式地更新 DOM。</p>
+
+<h2 id='byo-linker'>byo-linker</h2>
+
+<ul>
+<li><a href='https://github.com/andrewhalle/byo-linker'>仓库链接</a></li>
+</ul>
+
+<p>byo-linker 是一个极简的链接器，用于帮助理解链接器的实现方法。</p>
+
+<h2 id='rs_pbrt'>rs_pbrt</h2>
+
+<ul>
+<li><a href='https://github.com/wahn/rs_pbrt'>仓库链接</a></li>
+
+<li><a href='https://www.janwalter.org/doc/rust/pbrt/index.html'>文档链接</a></li>
+
+<li><a href='https://www.rs-pbrt.org/blog/v0-9-0-release-notes/'>文章链接</a></li>
+</ul>
+
+<p>rs_pbrt 是经典书籍 <em>Physically Based Rendering: From Theory to Implementation</em> 的 rust 实现。</p>
+
+<h2 id='flume'>flume</h2>
+
+<ul>
+<li><a href='https://github.com/zesterer/flume'>仓库链接</a></li>
+</ul>
+
+<p>flume 是一个 mpmc 的 channel 库，其用法和 <code>std::sync::mpsc</code> 基本一致，代码里没包含任何 <code>unsafe</code>。</p>
+
+<h2 id='ferris-fetch'>ferris-fetch</h2>
+
+<ul>
+<li><a href='https://github.com/irevenko/ferris-fetch'>仓库链接</a></li>
+</ul>
+
+<p>ferris-fetch 可以用于获取 rust 工具链以及操作系统的信息。</p>
+
+<h2 id='station_iapetus'>Station Iapetus</h2>
+
+<ul>
+<li><a href='https://github.com/mrDIMAS/StationIapetus'>仓库链接</a></li>
+
+<li><a href='https://www.reddit.com/r/rust/comments/m8suco/station_iapetus_the_game_written_in_rust_based_on/'>文章链接</a></li>
+</ul>
+
+<p>Station Iapetus 是一个用 <a href='https://github.com/mrDIMAS/rg3d'>rg3d</a> 开发的第三人称射击游戏，仍处于早期开发阶段。</p>
+
+<h2 id='veloren'>Veloren</h2>
+
+<ul>
+<li><a href='https://github.com/veloren/veloren'>仓库链接</a></li>
+
+<li><a href='https://veloren.net/'>主页链接</a></li>
+</ul>
+
+<p>Veloren 是一个像素风的多人 RPG 游戏，其灵感来自《魔方世界》、《塞尔达传说:荒野之息》、《矮人要塞》和《我的世界》等游戏。</p>
+
+<h2 id='mlc'>mlc</h2>
+
+<ul>
+<li><a href='https://github.com/becheran/mlc'>仓库链接</a></li>
+</ul>
+
+<p>mlc 可以用于检查 html 和 markdown 中的无效链接。</p>
+
+<h2 id='kamu'>Kamu</h2>
+
+<ul>
+<li><a href='https://github.com/kamu-data/kamu-cli'>仓库链接</a></li>
+</ul>
+
+<p><img src='https://raw.githubusercontent.com/kamu-data/kamu-cli/master/docs/readme_files/dataset_graph.png' alt='img' /></p>
+
+<p>Kamu 是 <a href='https://github.com/kamu-data/open-data-fabric'>Open Data Fabric</a> 的 rust 实现。</p>
+
+<h2 id='miniwasm'>MiniWASM</h2>
+
+<ul>
+<li><a href='https://github.com/thedjinn/MiniWASM'>仓库链接</a></li>
+</ul>
+
+<p>MiniWASM 是一个极简的 Rust WebAssembly 的项目模版。</p>
+
+<h2 id='rkyv'>rkyv</h2>
+
+<ul>
+<li><a href='https://github.com/djkoloski/rkyv'>仓库链接</a></li>
+
+<li><a href='https://davidkoloski.me/blog/rkyv-is-faster-than/'>文章链接</a></li>
+</ul>
+
+<p>rkyv 是一个反序列框架，作者号称框架的速度比 serde_json 还要快。</p>
+
+<h2 id='ter'>ter</h2>
+
+<ul>
+<li><a href='https://github.com/schulke-214/ter'>仓库链接</a></li>
+</ul>
+
+<p>ter 是一个 cli 程序，可以用类似自然语言的命令去做一些文字处理工作，例如过滤或者替换。</p>
+
+<h2 id='ipipe'>ipipe</h2>
+
+<ul>
+<li><a href='https://github.com/Eolu/ipipe'>仓库链接</a></li>
+
+<li><a href='https://www.reddit.com/r/rust/comments/m0rh4p/im_making_a_crossplatform_namedpipe_api_in_rust/'>文章链接</a></li>
+</ul>
+
+<p>ipipe 是一个跨平台的命名管道库。</p>
+
+<h2 id='gloo'>Gloo</h2>
+
+<ul>
+<li><a href='https://github.com/rustwasm/gloo'>仓库链接</a></li>
+</ul>
+
+<p>Gloo 是一个模块化的工具箱库，可以用于 Wasm 项目的开发。</p>
+
+<h2 id='aws-lambda-rust-runtime'>aws-lambda-rust-runtime</h2>
+
+<ul>
+<li><a href='https://github.com/awslabs/aws-lambda-rust-runtime'>仓库链接</a></li>
+</ul>
+
+<p>aws-lambda-rust-runtime 是一个AWS Lambda Functions 的 runtime。</p>
+
+<p>其中包括：</p>
+
+<ul>
+<li><code>lambda-runtime</code> crate 用于提供 AWS Lambda 的 runtime</li>
+
+<li><code>lambda-http</code> crate 用来写 AWS Lambda 的 API 网关代理事件</li>
+</ul>
+
+<h2 id='synth'>synth</h2>
+
+<ul>
+<li><a href='https://github.com/openquery-io/synth'>仓库链接</a></li>
+</ul>
+
+<p>synth 是一个声明式的数据生成器，其主要特性有：</p>
+
+<ul>
+<li>数据即代码</li>
+
+<li>导入已有数据</li>
+
+<li>数据自动推导</li>
+
+<li>不限定特定数据库</li>
+
+<li>语义化数据类型</li>
+</ul>
+
+<h2 id='tifs'>TiFS</h2>
+
+<ul>
+<li><a href='https://github.com/Hexilee/tifs'>仓库链接</a></li>
+</ul>
+
+<p>TiFS 是一个基于 TiKV 的分布式 POSIX 文件系统，具有分区容限和严格的一致性。</p>
+
+<h2 id='一个基于_wasm+rust+simd_技术栈实现的音乐合成器'>一个基于 wasm+rust+simd 技术栈实现的音乐合成器</h2>
+
+<p><a href='https://notes.ameo.design/fm.html'>链接</a></p>
+
+<h2 id='influxdb_iox：_基于apache_arrow_开发的新的_influxdb_核心'>InfluxDB IOx： 基于Apache Arrow 开发的新的 InfluxDB 核心</h2>
+
+<ul>
+<li><a href='https://github.com/influxdata/influxdb_iox'>仓库链接</a></li>
+</ul>
+
+<p>InfluxDB是一个开源时间序列数据库</p>
+
+<p>目前频繁开发中，正处于项目早期，感兴趣的可以及早关注</p>
+
+<h2 id='speedy2d:_兼容_opengl_(es)_2.0+_的图像库'>Speedy2D: 兼容 OpenGL (ES) 2.0+ 的图像库</h2>
+
+<ul>
+<li><a href='https://github.com/QuantumBadger/Speedy2D'>仓库链接</a></li>
+</ul>
+
+<p>Speedy2D 是一个拥有硬件加速, 简单易上手的 API的图像库, 可以方便的绘制 各种形状, 图像 和 文本.</p>
+
+<p>目标:</p>
+
+<ul>
+<li>最简单的 Rust API 来创建 window, 渲染图像和文本, 处理输入.</li>
+
+<li>兼容任意带有 OpenGL 2.0+ 和 OpenGL ES 2.0+ 的设备</li>
+
+<li>非常快</li>
+</ul>
+
+<h2 id='idcard-cn_v0.0.1'>idcard-cn v0.0.1</h2>
+
+<ul>
+<li><a href='https://github.com/huangjj27/idcard-cn'>仓库链接</a></li>
+</ul>
+
+<p>过去的一周时间小编翻看了一些基于 Rust 的身份证识别库（如 https://crates.io/crates/rust-idcard ),基本上只提供了身份证证件号码和其他文本信息的读取，而缺少其他根据《中华人民共和国身份证法》需要提供的指纹和照片信息的读取。于是小编决定将这些信息结构化，并且统一为信息完全的特质库，并且提供了一些相应符合生活常识的类型对读取的身份信息进行处理</p>
+
+<h2 id='qovery_engine_-_rust库,可在云服务上自动化部署应用程序'>Qovery Engine - Rust库,可在云服务上自动化部署应用程序</h2>
+
+<ul>
+<li><a href='https://github.com/Qovery/engine'>仓库链接</a></li>
+</ul>
+
+<p>Qovery Engine是一个开源抽象层库，仅需几分钟，它就可以轻松地在AWS，GCP，Azure和其他云提供商上部署应用程序。Qovery引擎是用Rust编写的，并利用Terraform，Helm，Kubectl和Docker来管理资源。</p>
+
+<ul>
+<li>零基础架构管理： Qovery Engine为您初始化，配置和管理您的Cloud帐户。</li>
+
+<li>支持多个云：Qovery Engine可以在AWS，GCP，Azure和任何云提供商上使用。</li>
+
+<li>在Kubernetes之上： Qovery Engine在更高的抽象级别上利用了Kubernetes的功能。</li>
+
+<li>Terraform和Helm： Qovery Engine使用Terraform和Helm文件来管理基础结构和应用程序部署。</li>
+
+<li>强大的CLI：使用提供的Qovery Engine CLI在您的Cloud帐户上无缝部署您的应用程序。</li>
+
+<li>Web界面： Qovery通过qovery.com提供Web界面。</li>
+</ul>
+
+<h2 id='linfa_:_rust写的统计学习综合工具箱'>Linfa : Rust写的统计学习综合工具箱</h2>
+
+<ul>
+<li><a href='https://rust-ml.github.io/linfa/'>官网</a></li>
+
+<li><a href='https://github.com/rust-ml/linfa'>仓库地址</a></li>
+</ul>
+
+<h2 id='cargo-quickinstall_0.2.0版本发布'>cargo-quickinstall 0.2.0版本发布</h2>
+
+<p>\[cargo-quickinstall (https://crates.io/crates/cargo-quickinstall)] 有点类似于Homebrew的Bottles（二进制包）概念，但用于 Rust。</p>
+
+<p>示例：</p>
+
+<pre><code class="language-`">cargo quickinstall ripgrep</code></pre>
+
+<p>作者认为：在此之前，通常将二进制文件托管在Bintray（homebrew serves）上，但是该服务正在逐步淘汰，因此需要更换它。</p>
+
+<h2 id='rust编写的清理应用程序的_czkawka_3.0.0发布'>Rust编写的清理应用程序的 Czkawka 3.0.0发布</h2>
+
+<ul>
+<li><a href='https://github.com/qarmin/czkawka'>仓库地址</a></li>
+</ul>
+
+<p>完全用Safe Rust 和 gtk 实现，且跨平台，多功能应用程序，可查找重复项，空文件夹，相似图像等。</p>
+
+<h2 id='graphgate_0.3.2_发布.'>GraphGate 0.3.2 发布.</h2>
+
+<ul>
+<li><a href='https://github.com/async-graphql/graphgate'>仓库地址</a></li>
+</ul>
+
+<p>用 Rust 实现的GraphQL API网关。</p>
+
+<p>为什么要用Rust来实现？</p>
+
+<p>​Rust是我最喜欢的编程语言。它既安全又快速，很适合开发API网关。</p>
+
+<h2 id='libretranslate-rs'>libretranslate-rs</h2>
+
+<ul>
+<li><a href='https://github.com/DefunctLizard/libretranslate-rs/'>仓库地址</a></li>
+</ul>
+
+<p>一个可以替代谷歌翻译的自由/开源软件(Rust编写!)，使用的是 <a href='https://libretranslate.com/'>libretranslate.com</a>的 API。</p>
+
+<h2 id='tide-acme：通過let's_encrypt自動獲得https證書'>tide-acme：通過Let&#8217;s Encrypt自動獲得HTTPS證書</h2>
+
+<ul>
+<li><a href='https://github.com/http-rs/tide-acme'>仓库地址</a></li>
+</ul>
+
+<p>Let&#8217;s Encrypt 是個很常用的免費ssl證書服務</p>
+
+<p>作者結合了tide與Let&#8217;s Encrypt做了一個自動取得證書給tide使用的範例</p>
+
+<h2 id='cleanit:_rust实现的可以通过_grpc_控制_roomba_系列扫地机器人的框架'>CleanIt: Rust实现的可以通过 gRPC 控制 Roomba 系列扫地机器人的框架</h2>
+
+<ul>
+<li><a href='https://github.com/Sollimann/CleanIt'>仓库地址</a></li>
+</ul>
+
+<p>还在开发中。</p>
+
+<p>发现 <a href='https://www.irobot.cn/roomba/'>Roomba系列机器人吸尘器</a> 是中国广东的公司。</p>
+
+<h2 id='task-stream_一个能运行在no_std的全局异步任务spawner'>task-stream 一个能运行在no_std的全局异步任务spawner</h2>
+
+<ul>
+<li><a href='https://crates.io/crates/task-stream'>仓库地址</a></li>
+</ul>
+
+<p>task-stream是一个全局任务spawner，可以在no_std中运行。</p>
+
+<p>它提供了用于异步任务的spawner，以及异步延迟函数。</p>
+
+<p>它是为库作者设计的。 在第三方库中，可以生成子任务，而无需关心执行程序主程序使用的子任务。</p>
+
+<h2 id='shipyard_0.5了'>Shipyard 0.5了</h2>
+
+<ul>
+<li><a href='https://crates.io/crates/shipyard'>仓库地址</a></li>
+</ul>
+
+<p>這是一個ECS框架 速度比上一版增加快了2倍</p>
+]]></content:encoded></item><item><title>学习资源</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/learns.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='本月简报_|_学习资源'>本月简报 | 学习资源</h1>
+
+<ul>
+<li>来源：<a href='https://rustcc.cn/section?id=f4703117-7e6b-4caf-aa22-a3ad3db6898f'>Rust日报</a></li>
+
+<li>作者：<code>Rust</code>日报小组</li>
+
+<li>后期编辑：苏胤榕（DaviRain）</li>
+</ul>
+
+<h2 id='rust_常见疑问汇总'>Rust 常见疑问汇总</h2>
+
+<p>Rust tg 群 「Rust 众」总结了这份 Rust 常见疑问汇总。</p>
+
+<p>本期摘录：</p>
+
+<ol type="1">
+<li>如何在特质(trait)里添加异步函数？</li>
+</ol>
+
+<p>目前 Rust 不支持在特质里直接添加异步函数，但可以使用 <a href='https://crates.io/crates/async-trait'>async-trait</a> 这个库来实现。这个库会将异步函数改写为返回 <code>Pin&lt;Box&lt;dyn Future&gt;&gt;</code> 的普通函数以绕过目前语言层面的限制，但也因此有堆分配以及动态分发这两个额外的代价，所以不会被直接添加到 Rust 语言中。</p>
+
+<p>在特质里不支持使用异步函数是由于异步函数本质上是一个返回 <code>impl Future&lt;Output = T&gt;</code> 的函数，而目前 Rust 的类型系统还无法表达在特质的方法的返回类型上使用 impl Trait。有两个已经通过的 RFC 旨在解决这一问题：<a href='https://rust-lang.github.io/rfcs/1598-generic_associated_types.html'>RFC 1598</a> 泛型关联类型和 <a href='https://rust-lang.github.io/rfcs/2071-impl-trait-existential-types.html'>RFC 2071</a> <code>impl Trait</code> 存在类型，但它们的编译器支持还在实现中。</p>
+
+<ol type="2">
+<li>为什么 Rust 生成的程序体积比较大？如何最小化程序体积？</li>
+</ol>
+
+<p>有多个因素使得 Rust 在默认情况下有着相对较大的程序体积，包括了单态化、调试符号、标准库等。一般来说，Rust 偏向于为性能优化而非更小的体积。</p>
+
+<p>通常使用发布模式编译（--release），以及（在 Linux 和 macOS 下）使用 strip 删除符号信息可以在一定程度上缩小程序体积。更多方法可以参考 <a href='https://github.com/johnthagen/min-sized-rust'>`Minimizing Rust Binary Size`</a>，对这一问题有较完整的介绍。</p>
+
+<p>欢迎贡献：</p>
+
+<p>更多阅读： <a href='https://rust-zh.github.io/faq/'>https://rust-zh.github.io/faq/</a></p>
+
+<h2 id='c++_to_rust_-_or_how_to_render_your_mindset'>C++ to Rust - or how to render your mindset</h2>
+
+<p>作者打算使用 Rust 重新实现 C++教程 <code>&lt;&lt;Ray tracing in One Weekend&gt;&gt;</code>，本文目标人群是对于 Rust 感兴趣的，或者对图像渲染感兴趣的人。</p>
+
+<p>通过本教程，最终会得到下面的预览图。</p>
+
+<p>整个过程， 作者既给出了<code>C++</code>代码， 也给出了<code>Rust</code>代码，对于熟悉 C++的同学，可以更加清晰的了解两种语言的不同。</p>
+
+<p><a href='https://jduchniewicz.com/posts/2021/02/c-to-rust-or-how-to-render-your-mindset/'>链接</a></p>
+
+<h2 id='rust-algorithms_用_rust_写算法的教科书'>rust-algorithms 用 Rust 写算法的教科书</h2>
+
+<p>作者 @EbTech 是应用数学出生，因此本书提供的算法主要包括应用数学（傅里叶变换等）的算法以及图的算法使用 Rust 的实现。</p>
+
+<p><a href='https://github.com/EbTech/rust-algorithms'>仓库</a></p>
+
+<h2 id='回顾异步rust'>回顾异步Rust</h2>
+
+<p>parity 工程师 tomaka 这篇博文，总结了他在日常开发中遇到的 Rust 异步的一些关键问题，值得一读。</p>
+
+<p><a href='https://tomaka.medium.com/a-look-back-at-asynchronous-rust-d54d63934a1c'>阅读</a></p>
+
+<h2 id='rust:_提防转义序列_\n'>Rust: 提防转义序列 \n</h2>
+
+<p><a href='https://github.com/serde-rs/serde'>serde</a>是在Rust生态系统最流行的crate，一个用于高效地序列化和deseri一个LIZING数据结构。它支持多种数据格式，包括JSON，YAML，MessagePack等。与许多其他（反）序列化器不同，它不使用运行时反射，而是使用Rust的引人注目的特征系统。这使Serde异常有效，因为数据结构本质上知道如何序列化或反序列化自身，并且它们通过实现<code>Serialize</code>or<code>Deserialize</code>特性来实现。幸运的是，这要归功于大多数类型，这要归功于derive宏。您可能会像我一样遇到陷阱，在这篇博客文章中，作者想特别谈一谈：<strong>转义序列。</strong></p>
+
+<p><a href='https://d3lm.medium.com/rust-beware-of-escape-sequences-85ec90e9e243#ee0e-58229fc84d02'>ReadMore</a></p>
+
+<h2 id='bevy-physics-weekend_项目'>bevy-physics-weekend 项目</h2>
+
+<p>这个项目是使用 Rust 编程语言和 Bevy 游戏引擎对 <a href='https://gamephysicsweekend.github.io/'>Game Physics in a Weekend</a>这本书的实践。这对我来说是一个学习练习，以便更好地理解如何使用 Bevy 和数学库 glam 来实现物理引擎。项目</p>
+
+<p><a href='https://github.com/bitshifter/bevy-physics-weekend'>地址</a></p>
+
+<h2 id='rust_优化技巧'>Rust 优化技巧</h2>
+
+<p>如果您希望用 Rust 编写速度更快的代码，那么有好消息!Rust 让编写快速代码可以变得非常容易。对零成本抽象的关注、缺乏隐式装箱和静态内存管理意味着，即使是 naïve 代码也往往比其他语言中的同类代码要快，当然也比任何同等安全的语言的代码要快。但是，也许像大多数程序员一样，您在整个编程生涯中都不必担心机器的任何细节，而现在您想要更深入地了解并找出重写的 Python 脚本的真正原因。 Rust 的运行速度快了 100 倍，并使用了十分之一的内存。毕竟，它们都做相同的事情并在相同的 CPU 上 运行，对吧？</p>
+
+<p>因此，这里有一个优化指南，针对那些知道如何编程，但可能不知道代码如何 CPU 上映射到真实的 1 和 0 的人。我将尝试编写关于优化 Rust 代码的实用技巧，并解释为什么它比替代方法更快，最后我们将以 Rust 标准库中的一个案例研究作为结束。</p>
+
+<p><a href='https://gist.github.com/little-dude/674de61df7f48547bdcc5bbe2860563d'>原文地址</a></p>
+
+<h2 id='用rust给我的操作系统写乒乓（pong）'>用Rust给我的操作系统写乒乓（Pong）</h2>
+
+<p>我们上一讲结束了为我们的操作系统编写图形驱动程序和事件驱动程序。我们还添加了几个系统调用来处理绘图原语以及处理键盘和鼠标输入。现在我们将使用这些动画来制作简单的pong游戏。就像《hello world》是对所有编程语言的测试，《pong》也是对我们所有图形和事件系统的测试。</p>
+
+<p><a href='https://blog.stephenmarz.com/2021/02/22/writing-pong-in-rust/'>文章链接</a></p>
+
+<h2 id='rust_style_guidelines'>Rust Style Guidelines</h2>
+
+<p>rust-guidelines 收集了用于编写Rust代码的新出现的原理，约定，抽象和最佳实践。</p>
+
+<p><a href='https://doc.rust-lang.org/1.0.0/style/README.html'>Docs</a></p>
+
+<p><a href='https://github.com/rust-lang/rust-guidelines'>GitHub</a></p>
+
+<h2 id='避免使用rust进行单线程内存访问错误'>避免使用Rust进行单线程内存访问错误</h2>
+
+<p>在本文中，我们将研究单线程C ++中的几种内存访问错误，以及Rust如何防止我们犯这些错误。我写了一篇简短的文章，展示了C ++中的内存访问错误以及Rust如何阻止我们访问这些错误。目录：Returning references to temporariesShort lifetimesReferenes to container contentsTricky lifetime extensions</p>
+
+<p><a href='https://radekvit.medium.com/avoiding-single-threaded-memory-access-bugs-with-rust-for-c-developers-2b7fc9c877ec'>阅读原文</a></p>
+
+<h2 id='rust_web开发人员路线图'>Rust Web开发人员路线图</h2>
+
+<p>超详细 Rust Web 开发人员的路线图。</p>
+
+<p><img src='../image/web-rust-road.png' alt='' /></p>
+
+<p><a href='https://github.com/anshulrgoyal/rust-web-developer-roadmap'>github</a></p>
+
+<h2 id='rust_中返回引用的各种策略'>Rust 中返回引用的各种策略</h2>
+
+<p>本文总结了常见的返回引用的几种方式，强烈推荐。</p>
+
+<p><a href='https://bryce.fisher-fleig.org/strategies-for-returning-references-in-rust/'>原文链接</a></p>
+
+<h2 id='learning_rust:_structs_and_traits'>Learning Rust: Structs and Traits</h2>
+
+<p>这是一系列学习 Rust 视频的第三部分，<code>Structs and Traits</code>， 内容相对比较简单， 有喜欢看视频学习 Rust 的小伙伴可以翻墙看一下。</p>
+
+<p><a href='https://youtu.be/tYfA5rjrhqk'>油管视频</a></p>
+
+<h2 id='教程：如何在rust中实现一个迭代器'>教程：如何在Rust中实现一个迭代器</h2>
+
+<p>这篇教程中你将会学到如何为一个树结构实现迭代器。</p>
+
+<p><a href='https://aloso.github.io/2021/03/09/creating-an-iterator'>阅读更多</a></p>
+
+<h2 id='【博客】rust_命名空间'>【博客】Rust 命名空间</h2>
+
+<p>关于Rust中命名空间的内容讲解。</p>
+
+<p><a href='https://aloso.github.io/2021/03/10/rusts-universes.html'>链接</a></p>
+
+<h2 id='我是如何使用_rust_大幅提高笔记软件的性能的？'>我是如何使用 Rust 大幅提高笔记软件的性能的？</h2>
+
+<p><a href='https://github.com/giganotes'>Giganotes</a> 是作者开发的一个笔记软件，作者尝试使用 Rust 来提高软件的性能，并取得了很好的成效。</p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/m14agf/how_i_significantly_improved_giganotes_app/'>链接</a></p>
+
+<h2 id='learn_wgpu系列教程终于完全升级到了0.7版本！'>learn wgpu系列教程终于完全升级到了0.7版本！</h2>
+
+<p>wgpu 创建渲染管道的方式已经进行了改进。大多数属于自己的字段都被分组为结构，例如 <a href='https://docs.rs/wgpu/0.7.0/wgpu/struct.MultisampleState.html'>MultisampleState</a> 。这意味着简单的管道更容易创建，因为我们可以对我们不关心的字段使用<code>Default::Default()</code>或<code>None</code>。</p>
+
+<p><a href='https://sotrh.github.io/learn-wgpu/'>Read More</a></p>
+
+<p><a href='https://github.com/sotrh/learn-wgpu'>Github</a></p>
+
+<h2 id='教你如何用rg3d制作一个射击游戏！'>教你如何用Rg3d制作一个射击游戏！</h2>
+
+<p>教你如何用Rg3d制作一个射击游戏系列教程更新第二章了！</p>
+
+<p>Rg3d是一个使用Rust编写的游戏引擎，渲染后端用的是OpenGl的Rust绑定：glutin ，说到这个教程出现的原因，很心酸的想贴上这段话：</p>
+
+<p>&gt; &gt; I have a simple question for the community: what stops you from using the engine? The lack of tutorials, immaturity, different approaches (no-ecs for example, or maybe you have your reason you want to share? I need to know what should be done first to make engine more newcomer-friendly. I have ~10 years of experience in gamedev and some things may be not obvious to me, so I need your help.</p>
+
+<p>消息是Rg3d的作者在Discord上发布的，时间是2月16日的时候，发布之后有不少人表达了自己的想法，同时现在你看到的教程，也正是通过这次调查得到大家反馈之后才出的。作者本人在Discord上对大家的提问回复都很及时，Rust社区本身不是很大，同时Rust游戏社区就更小了，但是仍然有很多人对此不断耕耘，所以如果你对游戏开发很有兴趣，同时也是Rust厨的话，一直还没有去尝试过使用Rust开发游戏的你，一定要去感受一下使用Rust开发游戏！</p>
+
+<p><a href='https://rg3d.rs/tutorials/2021/03/09/tutorial2.html'>Read More</a></p>
+
+<h2 id='rust_异步不是有色函数！'>Rust 异步不是有色函数！</h2>
+
+<p>本篇blog名字是<code>Rust&#8217;s async isn&#8217;t f#@king colored!</code></p>
+
+<p>本篇blog衍生自15年的一篇著名blog：<a href='https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/'>What Color is Your Function?</a>，在这篇blog种将编程语言的函数调用区分为不同的颜色，特别指出多种语言种的异步调用和同步函数是两种不同的颜色，在编写程序的时候会给程序员造成一些痛苦。而文中所说go、java之类的则不属于这类语言，详细的可以去看看原文。</p>
+
+<p>而本篇blog也就沿着上面提到的这篇blog讨论了Rust异步编程种是否存在同样的问题。结论已经被标题出卖了，Rust异步不是有色函数！</p>
+
+<p><a href='https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/'>Read More</a></p>
+
+<p><a href='https://www.hobofan.com/blog/2021-03-10-rust-async-colored/'>Rust&#8217;s async isn&#8217;t f#@king colored!</a></p>
+
+<h2 id='看到toml文件，真是相见恨晚'>看到Toml文件，真是相见恨晚</h2>
+
+<p>有位作者在<code>Reddit</code>发表了一篇帖子：<code>I really love TOML files</code>。</p>
+
+<p>&gt; &gt; “我没在使用Rust之前，并不了解Toml文件。现在我想用它来做任何事。” 这不就是传说中的：相见恨晚嘛。</p>
+
+<p>为什么<code>Toml</code>文件会被人喜爱？下面有人评论： “对于许多简单的配置，它们真的很酷！ 它们没有YAML陌生性，也没有JSON的字符串性，并且它们大多是扁平的，几乎没有级别缩进。”</p>
+
+<p><a href='https://www.reddit.com/r/rust/comments/m37zya/i_really_love_toml_files/'>详细链接</a></p>
+
+<h2 id='使用rg3d编写的射击游戏'>使用rg3d编写的射击游戏</h2>
+
+<p>用Rust写游戏:神枪在手，说抖不抖。</p>
+
+<p>本教程是系列教程的后续部分，我们将使用rg3d游戏引擎制作3D射击游戏。</p>
+
+<p><a href='https://rg3d.rs/tutorials/2021/03/11/tutorial3.html'>详细链接</a></p>
+
+<h2 id='rust_和_c_速度比较'>Rust 和 C 速度比较</h2>
+
+<p>Rust 和 C 的编程风格差异很大，但两者开发的程序在运行速度和内存使用情况上大致相同。语言在理论上可以实现什么，但在实践中如何使用它们之间有很大的区别。作者总结了Rust 和 C 各自在哪些地方会更快。</p>
+
+<p>简而言之</p>
+
+<ul>
+<li>Rust 可以在必要时以足够底层的方式对其进行优化，使其达到与 C 一样的性能；</li>
+
+<li>Rust 拥有更高层次的抽象，便捷的内存管理和丰富的第三方库；</li>
+
+<li>Rust 最大的潜力在于无畏并发（fearless concurrency）能力。</li>
+</ul>
+
+<p><a href='https://kornel.ski/rust-c-speed'>文章链接</a></p>
+
+<h2 id='为什么_rust_和_go_一起更好？'>为什么 Rust 和 Go 一起更好？</h2>
+
+<p>简单，性能和开发者的生产力，使得 Go 成为创建面向用户应用服务的理想语言。更好的控制粒度使得 Rust 成为底层操作的理想语言。这并不意味着非得二选一，反而两者一起使用时会具有很高的灵活性和性能。</p>
+
+<p>本文讨论了 Rust 和 Go 的优缺点，以及如何互相补充支持。</p>
+
+<p><a href='https://thenewstack.io/rust-vs-go-why-theyre-better-together/?s=09'>文章链接</a></p>
+
+<h2 id='rust的异步是有颜色,_但没什么大不了'>Rust的异步是有颜色, 但没什么大不了</h2>
+
+<p>语言设计领域的一个争议点是 <code>有色函数</code>， 即将函数分为异步函数和非异步函数。这个术语来源于2015年一篇名为<code>《What Color is Your Function?》</code>的文章, 它用颜色来比喻JavaScript和其他带有显式异步函数的语言中的同步和异步函数之间常常令人痛苦的不匹配。</p>
+
+<p>Rust 中，也有很多人讨论这个问题， 比如前几天有一片文章 <code>Rust’s async isn’t f#@king colored!</code>。</p>
+
+<p>这里作者将通过原始的定义和实践，来表达自己的观点: Rust 是有颜色的。</p>
+
+<p><a href='https://morestina.net/blog/1686/rust-async-is-colored'>原文链接</a></p>
+
+<h2 id='使用_rust_写一个_postgres_sql_打印器:_part_i'>使用 Rust 写一个 Postgres SQL 打印器: Part I</h2>
+
+<p>这是作者<code>pg-pretty</code>项目项目的一系列文章第一篇。</p>
+
+<p>作者不能忍受非格式化的代码，对于大型项目来说，统一风格可以消除很多理解障碍。但是作者没有找到一个很好的 Postgres SQL 风格打印器，所以打算自己动手写一个。</p>
+
+<p><a href='https://blog.urth.org/2021/03/14/writing-a-postgres-sql-pretty-printer-in-rust-part-1/'>原文链接</a></p>
+
+<h2 id='crust_of_rust:_the_drop_check'>Crust of Rust: The Drop Check</h2>
+
+<p>这是 <code>Crust of Rust</code> 系列视频的最新一期: <code>The Drop Check</code>, 相信很多小伙伴对 Drop check 都很感兴趣，可以翻墙看一下。</p>
+
+<p><a href='https://youtu.be/Das3XSWo1GU'>油管视频</a></p>
+
+<h2 id='《rust_vs._go》:为什么它们一起会更好'>《Rust vs. Go》:为什么它们一起会更好</h2>
+
+<p>来自 Jonathan Turner and Steve Francia 的 blog，虽然其他人可能认为 Rust 和 Go 是有竞争力的编程语言，但 Rust 和 Go 团队都不这么认为。恰恰相反，我们的团队非常尊重其他人正在做的事情，并将这些语言视为对整个软件开发行业现代化状态的共同愿景的赞美。</p>
+
+<p>注 Steve Francia【@spf13】 是隔壁 go 社区大佬， <a href='https://thenewstack.io/rust-vs-go-why-theyre-better-together/'>更多请看</a></p>
+
+<h2 id='如何使用_rust_发邮件'>如何使用 Rust 发邮件</h2>
+
+<p>在 Rust 中发送电子邮件可以通过两种方式实现：使用 SMTP 服务器或使用带有 API 的第三方服务，如 AWS SES 或 Sendgrid。</p>
+
+<p><a href='https://kerkour.com/blog/rust-send-email/'>详细实现请看</a></p>
+
+<h2 id='构建async_rust的共同愿景'>构建Async Rust的共同愿景</h2>
+
+<p>近期，Rust官方博客推出了一篇文章，《Building a shared vision for Async Rust》：构建Async Rust的共同愿景。</p>
+
+<p>Rust Async基金会工作组认为,Rust可以成为构建分布式系统（从嵌入式设备到基础云服务）的最受欢迎选择之一。不管他们用它做什么，我们都希望所有的开发者都喜欢使用Async-Rust。为了实现这一点，我们需要将Async Rust从现在的“MVP”状态转移出去，尽可能让每个人都能使用。</p>
+
+<p><a href='https://blog.rust-lang.org/2021/03/18/async-vision-doc.html'>文章地址</a></p>
+
+<h2 id='rust_的_零大小类型(zst)_的神奇应用'>Rust 的 零大小类型(ZST) 的神奇应用</h2>
+
+<p>Rust 中有 零大小类型的概念，简称 <code>ZST</code> (Zero-Sized Types). 这些类型不会在他们的布局上包含任何的信息。 但是这并不意味着他们不重要,本文将深入解释 ZST 的设计理念和应用。 感兴趣的小伙伴可以看一下。</p>
+
+<p><a href='https://www.hardmo.de/article/2021-03-14-zst-proof-types.md'>原文链接</a></p>
+
+<h2 id='lens-rs_指路'>lens-rs 指路</h2>
+
+<p>来自 <code>脚趾头</code> 的知乎投稿。作者之前使用 <code>Rust</code> 实现了 <code>lens</code>， 本文主要说明如何来把玩这个库 <code>len-rs</code>。</p>
+
+<p><a href='https://zhuanlan.zhihu.com/p/358678675'>原文链接</a></p>
+
+<h2 id='使用_rust_构建_openstreetmap_应用:_part_vi'>使用 Rust 构建 OpenStreetMap 应用: Part VI</h2>
+
+<p><code>使用 Rust 构建 OpenStreetMap 应用</code> 的最新章节， 结合之前的内容， 本章结束会完成一个基本的应用。</p>
+
+<p><a href='https://blogg.bekk.no/building-an-openstreetmap-app-in-rust-part-vi-8cfc8c3f7798'>原文链接</a></p>
+
+<h2 id='使用_rust_iterator_的一些技巧'>使用 Rust Iterator 的一些技巧</h2>
+
+<p>作者总结了 Rust Iterator 相关的几条技巧，感觉还不错。</p>
+
+<p><a href='https://robinmoussu.gitlab.io/blog/post/2021-03-25_rust_iterators_tips_and_tricks/'>链接</a></p>
+
+<h2 id='pin_and_suffering'>Pin and suffering</h2>
+
+<p><code>Cool bear</code>系列的最新文章，可以让你深入的了解 <code>Rust</code> 中的 <code>async</code>。</p>
+
+<p><a href='https://fasterthanli.me/articles/pin-and-suffering'>原文链接</a></p>
+
+<h2 id='2021年去哪里学习_rust'>2021年去哪里学习 Rust</h2>
+
+<ol type="2">
+<li>年了，去哪里学习 Rust 呢？</li>
+</ol>
+
+<p>本文总结列出了一系列的 Rust 学习资料，想学习的 Rust 的小伙伴可以看看。</p>
+
+<p><a href='https://loige.co/where-to-go-to-learn-rust-in-2021/'>原文链接</a></p>
+
+<h2 id='rusts_module_system_explained'>Rusts Module System Explained</h2>
+
+<p>本文详细的介绍了 Rust 模块系统，从为什么需要模块系统？ 到如何使用的非常详细，希望对模块系统深入掌握的同学可以看看。</p>
+
+<p><a href='https://aloso.github.io/2021/03/28/module-system.html'>原文链接</a></p>
+
+<h2 id='libp2p_指南'>LibP2p 指南</h2>
+
+<p>这个教程展示如何使用Rust和出色的libp2p库构建一个非常简单的点对点应用程序。</p>
+
+<p><a href='https://blog.logrocket.com/libp2p-tutorial-build-a-peer-to-peer-app-in-rust/'>阅读</a></p>
+
+<p><a href='https://github.com/zupzup/rust-peer-to-peer-example'>示例代码</a></p>
+
+<h2 id='指南：_写一个_微ecs_（_entity_component_system）系统'>指南： 写一个 微ECS （ Entity Component System）系统</h2>
+
+<p>通过编写一个简单的 ECS 系统来学习什么是 ECS 。</p>
+
+<p><a href='https://ianjk.com/ecs-in-rust/'>阅读</a></p>
+
+<p>\##【系列文章】学会飞行：使用 Rust / 神经网络 / 遗传算法 来模拟进化</p>
+
+<ul>
+<li><a href='https://pwy.io/en/posts/learning-to-fly-pt1/'>Part I</a></li>
+
+<li><a href='https://pwy.io/en/posts/learning-to-fly-pt2/'>Part II</a></li>
+
+<li><a href='https://pwy.io/en/posts/learning-to-fly-pt3/'>Part III</a></li>
+</ul>
+]]></content:encoded></item><item><title>Rust 唠嗑室本月汇总</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust_laoke.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='rust_唠嗑室本月汇总'>Rust 唠嗑室本月汇总</h1>
+
+<ul>
+<li>来源：<a href='https://space.bilibili.com/25566598'>Rust 唠嗑室</a></li>
+
+<li>主持人：MikeTang</li>
+
+<li>后期编辑：高宪凤</li>
+</ul>
+
+<hr><h2 id='《rust唠嗑室》第19期_-_启动_openra-rs_项目+乱聊'>《Rust唠嗑室》第19期 - 启动 OpenRA-rs 项目+乱聊</h2>
+
+<p><strong>时间</strong>：2021/03/02 20:30-21:30</p>
+
+<p><strong>主讲人</strong>：Mike</p>
+
+<p><strong>内容</strong>：</p>
+
+<p><a href='https://github.com/OpenRA/OpenRA'>OpenRA</a> 是开源重制版红警，不过目前已经实现的部分只是红警1，红警2尚未完成。目前OpenRA是用C#写的。我们来憧憬一下，如果OpenRA用Rust重新实现会怎样？</p>
+
+<p>如果做，那就基于Rust最热的bevy游戏引擎来做。对Rust游戏开发感兴趣的都来出出主意吧。</p>
+
+<p>我们会先启动一个学习型的项目，openra-rs内部分享甚至会成为一个专门的视频系列。敬请期待。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1NU4y1p7B6'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<ul>
+<li>https://github.com/OpenRA/OpenRA</li>
+</ul>
+
+<hr><h2 id='《rust唠嗑室》第20期_-_软件选型方法，以rust为例'>《Rust唠嗑室》第20期 - 软件选型方法，以Rust为例</h2>
+
+<p><strong>时间</strong>：2021/03/16 20:30-21:30</p>
+
+<p><strong>主讲人</strong>：Andy</p>
+
+<p><strong>内容</strong>：软件选型方法</p>
+
+<p>跟大家聊聊软件选型的方法，内容：</p>
+
+<ol type="1">
+<li>基础模型：天上不会掉馅饼定理、丑小鸭定理、康威定律、包线；</li>
+
+<li>抽象：函数、对象、类型、Trait；</li>
+
+<li>架构：服务端开源组件的取舍；</li>
+
+<li>实例：ImmuxDB从v1到v2的架构调整。</li>
+</ol>
+
+<p>本次演示使用Rust作示例。</p>
+
+<p><a href='https://www.bilibili.com/video/BV1mN411Q7Mw'>查看回放</a></p>
+
+<p><strong>扩展资料</strong>：</p>
+
+<ul>
+<li>https://immux.cn</li>
+
+<li>https://github.com/immux/immux</li>
+</ul>
+]]></content:encoded></item><item><title>华为 | 基于Rust的下一代虚拟化平台-StratoVirt</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/hw_rust_stratovirt.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='华为_|_基于rust的下一代虚拟化平台-stratovirt'>华为 | 基于Rust的下一代虚拟化平台-StratoVirt</h1>
+
+<p>作者： 徐飞 / 后期编辑： 张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='stratovirt是什么'>StratoVirt是什么</h2>
+
+<p>Strato，取自stratosphere，意指地球大气层中的平流层，大气层可以保护地球不受外界环境侵害，而平流层则是大气层中最稳定的一层；类似的，虚拟化技术是操作系统平台之上的隔离层，既能保护操作系统平台不受上层恶意应用的破坏，又能为正常应用提供稳定可靠的运行环境；以Strato入名，寓意为保护openEuler平台上业务平稳运行的轻薄保护层。同时，Strato也承载了项目的愿景与未来： 轻量、灵活、 安全和完整的保护能力。</p>
+
+<p>StratoVirt是计算产业中面向云数据中心的企业级虚拟化平台，实现了一套架构统一支持虚拟机、容器、Serverless三种场景，在轻量低噪、软硬协同、安全等方面具备关键技术竞争优势。StratoVirt在架构设计和接口上预留了组件化拼装的能力和接口，StratoVirt可以按需灵活组装高级特性直至演化到支持标准虚拟化，在特性需求、应用场景和轻快灵巧之间找到最佳的平衡点。</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\StratoVirt.png&quot; width=&quot;280&quot; height=&quot;280&quot; /&gt;&lt;/div&gt;</p>
+
+<h2 id='为什么选择rust'>为什么选择Rust</h2>
+
+<p>在项目成立初期，我们调研了业界成熟基于C语言开发的虚拟化软件-QEMU，统计了在过去十几年中QEMU的CVE问题，发现其中有将近一半是因为内存问题导致的，例如缓冲区溢出、内存非法访问等等。如何有效避免产生内存问题，成为我们在编程语言选型方面的重要考虑。因此，专注于安全的Rust语言进入我们视线。</p>
+
+<ul>
+<li>Rust语言拥有强大的类型系统、所有权系统、借用和生命周期等机制，不仅保证内存安全，还保证并发安全，极大的提升软件的质量。在支持安全性的同时，具有零成本抽象特点，既提升代码的可读性，又不影响代码的运行时性能。</li>
+
+<li>
+<p>Rust语言拥有强大的软件包管理器和项目管理工具-Cargo</p>
+
+<ul>
+<li>Cargo能够对项目的依赖包进行方便、统一和灵活的管理。项目所有的依赖包都定义在Cargo.toml文件中，开发者可以按需使用来自Rust官方仓库crates.io的各类功能包。</li>
+
+<li>Cargo集成了完整的代码管理工具，例如项目创建（cargo new）、构建（cargo build）、清理（cargo clean）、测试（cargo test）、运行（cargo Run）等等。</li>
+
+<li>Cargo在代码静态扫描方面提供相应的工具，能够进一步提升开发者编码风格和代码质量。</li>
+
+<li>cargo fmt：使用符合rust-lang定义的Rust代码风格来规范Rust代码。</li>
+
+<li>cargo check：可以对本地项目库和所有依赖进行编译检查，它会通过对项目进行编译来执行代码检查。</li>
+
+<li>cargo clippy：一个Rust语言的lint工具集合包，包含了超过350种lint规则。</li>
+</ul>
+</li>
+</ul>
+
+<h2 id='stratovirt的优势'>StratoVirt的优势</h2>
+
+<p>StratoVirt是openEuler最稳定、最坚固的保护层。它重构了openEuler虚拟化底座，具有以下六大技术特点。</p>
+
+<ul>
+<li>
+<p>强安全性与隔离性</p>
+
+<ul>
+<li>采用内存安全语言Rust编写， 保证语言级安全性；</li>
+
+<li>基于硬件辅助虚拟化实现安全多租户隔离，并通过seccomp进一步约束非必要的系统调用，减小系统攻击面；</li>
+</ul>
+</li>
+
+<li>
+<p>轻量低噪</p>
+
+<ul>
+<li>轻量化场景下冷启动时间\&lt;50ms，内存底噪\&lt;4M；</li>
+</ul>
+</li>
+
+<li>
+<p>高速稳定的IO能力</p>
+
+<ul>
+<li>具有精简的设备模型，并提供了稳定高速的IO能力；</li>
+</ul>
+</li>
+
+<li>
+<p>资源伸缩</p>
+
+<ul>
+<li>具有ms级别的设备伸缩时延，为轻量化负载提供灵活的资源伸缩能力；</li>
+</ul>
+</li>
+
+<li>
+<p>全场景支持</p>
+
+<ul>
+<li>完美支持X86和Arm平台：X86支持VT，鲲鹏支持Kunpeng-V，实现多体系硬件加速；</li>
+
+<li>可完美集成于容器生态，与Kubernetes生态完美对接，在虚拟机、容器和serverless场景有广阔的应用空间；</li>
+</ul>
+</li>
+
+<li>
+<p>扩展性</p>
+
+<ul>
+<li>架构设计完备，各个组件可灵活地配置和拆分；</li>
+
+<li>设备模型可扩展，可扩展PCIe等复杂设备规范，实现标准虚拟机演进；</li>
+</ul>
+</li>
+</ul>
+
+<h2 id='stratovirt的架构'>StratoVirt的架构</h2>
+
+<p>StratoVirt核心架构自顶向下分为三层：</p>
+
+<ul>
+<li>OCI兼容接口：兼容qmp协议，具有完备的OCI兼容能力。</li>
+
+<li>BootLoader：抛弃传统的BIOS + GRUB启动模式，实现了更轻更快的BootLoader，并达到极限启动时延。</li>
+
+<li>MicroVM：充分利用软硬协同能力；精简化设备模型；低时延资源伸缩能力；</li>
+</ul>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\StratoVirt-arch.png&quot; width=&quot;500&quot; height=&quot;500&quot; /&gt;&lt;/div&gt;</p>
+
+<p>StratoVirt<a href='https://gitee.com/openeuler/stratovirt'>源码目录</a>解析主要分为四部分：</p>
+
+<ul>
+<li>address_space：地址空间模拟，实现地址堆叠等复杂地址分配模式。</li>
+
+<li>boot_loader：内核引导程序，实现快速加载和启动功能。</li>
+
+<li>device_model：仿真各类设备，可扩展，可组合。</li>
+
+<li>machine_manager：提供虚拟机管理接口，兼容QMP等常用协议，可扩展。</li>
+</ul>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\code_directory.png&quot; width=&quot;400&quot; height=&quot;400&quot; /&gt;&lt;/div&gt;</p>
+
+<p>当前StratoVirt开源代码中实现的是轻量化虚拟机模型，是能实现运行业务负载的最小的设备集合。因此LightMachine是StratoVirt最重要的顶层数据结构，它的逻辑上分为CPU模拟管理，地址空间管理，IO设备模拟管理（包括中断控制器和bus数据结构中管理各类仿真设备，例如virtio设备，serial设备等），如下图右侧所示：</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\light_machine.png&quot; /&gt;&lt;/div&gt;</p>
+
+<p>首先，我们先看一下address_space地址空间模拟实现功能：</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\address_space.png&quot; /&gt;&lt;/div&gt;</p>
+
+<ul>
+<li>内存地址空间通过Region组成树形层次关系，支持地址堆叠和优化级。</li>
+
+<li>通过快速映射算法形成扁平地址空间（Flat View)。</li>
+
+<li>通过设置Listener监听地址空间变化，执行相关回调函数。</li>
+</ul>
+
+<p>其次，我们再看一下CPU模拟实现功能：</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\CPU.png&quot; /&gt;&lt;/div&gt;</p>
+
+<ul>
+<li>基于KVM暴露接口实现虚拟CPU的硬件加速。</li>
+
+<li>通过ArchCPU结构隐藏体系架构（aarch64和x86_64）差异，具体实现位于体系架构相关目录中。</li>
+
+<li>Arc反向索引该CPU所属的LightMachine虚拟机对象，使得后续在虚拟机内扩展设备时，CPU可访问该对象。</li>
+</ul>
+
+<p>最后，我们再看一下IO设备模拟功能：</p>
+
+<p>轻量化虚拟机的主要设备均通过VirtioMMIO协议实现，下图右侧是VirtioMmioDevice的通用数据结构。</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\IO.png&quot; /&gt;&lt;/div&gt;</p>
+
+<p>在IO设备初始化阶段，通过VirtioMMIO协议协商前后端都可以访问的virtio queue、中断事件以及通知事件等等。当前端VM有IO请求时，将请求数据写入virtio queue中，通过通知事件告知后端StratoVirt；后端监听通知事件发生时，读取virtio queue中的请求数据，根据请求数据进行IO处理，IO请求处理完成后，并以中断事件方式通知前端VM。</p>
+
+<p>&lt;div align=center&gt; &lt;img src=&quot;.\sratovirt-images\IO_process.png&quot; width=&quot;500&quot; height=&quot;300&quot; /&gt;&lt;/div&gt;</p>
+
+<h2 id='stratovirt未来'>StratoVirt未来</h2>
+
+<p>StratoVirt的发展路标为，通过一套架构，支持轻量虚拟机和标准虚拟机两种模式：</p>
+
+<ul>
+<li>轻量虚拟机模式下，单虚机内存底噪小于4MB，启动时间小于50ms，且支持ms级时延的设备极速伸缩能力，当前已经开发完毕，2020年9月已经在openEuler社区开源；</li>
+
+<li>标准虚拟机模式下，可支持完整的机器模型，启动标准内核镜像，可以达成Qemu的能力，同时在代码规模和安全性上有较大优势。</li>
+</ul>
+
+<h2 id='关注我们'>关注我们</h2>
+
+<p>StratoVirt当前已经在openEuler社区（openEuler是一个开源、免费的Linux发行版平台，将通过开放的社区形式与全球的开发者共同构建一个开放、多元和架构包容的软件生态体系）开源。在未来的一段时间我们将开展一系列主题的分享，让大家更加详细的了解StratoVirt实现，非常期待您的围观和加入！</p>
+
+<p>项目地址：https://gitee.com/openeuler/stratovirt</p>
+
+<p>项目wiki：https://gitee.com/openeuler/stratovirt/wikis</p>
+
+<p>项目交流：<a href='https://mailweb.openeuler.org/postorius/lists/virt.openeuler.org/'>virt邮件列表</a>或是提交一个<a href='https://gitee.com/openeuler/stratovirt/issues'>issue</a>。</p>
+]]></content:encoded></item><item><title>华为 | Rust 科学计算多维数组运算库的分析与实践</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/hw_ndarray.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='华为_|_rust_科学计算多维数组运算库的分析与实践'>华为 | Rust 科学计算多维数组运算库的分析与实践</h1>
+
+<p>作者： 李原 / 后期编辑： 张汉东</p>
+
+<p>&gt; &gt; 此文来自于 3.27号 深圳 Meetup 大会 &gt; 3月27日活动PPT和现场视频链接：  <a href='https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665'>https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665</a></p>
+
+<h2 id=''></h2>
+
+<h3 id='介绍'>介绍</h3>
+
+<p>Rust ndarray是一个由Rust官方团队中资深科学计算专家bluss开发的开源项目，实现了基于rust的矩阵和线性运算。目标是在Rust中建立类似于numpy和openblas的科学计算社区。它是机器视觉、数据挖掘、生物信息等多类科学计算库的基础，社区中的主要用户为一些相关技术的高校或者研究所。笔者参与该开源项目的整体规划为面向社区中的各种场景，打通ndarray的南向技术栈，利用编译器、并行化、软硬件协同等技术实现功能、性能的突破，为整个Rust科学计算生态打下扎实的底座。</p>
+
+<p>而ndarray目前来自于社区的需求有嵌入式环境的适配、基础机制的完善以及空间利用率、运算性能上的提升等。为了nostd、灵活步长、广播机制及并行计算等。下面具体展开介绍。</p>
+
+<h3 id='no_std化'>no_std化</h3>
+
+<p>首先是ndarray的no<em>std化工作，它主要解决ndarray在嵌入式环境下的适配问题。std是Rust标准库的简称，由核心库和其他一些功能模块组成。其中核心库包含了类型、指针、同步、内存管理等语言核心功能，其余部分则包含了文件管理、操作系统适配、线程管理、网络等非核心或硬件架构相关功能。Rust编译器在编译和生成最终二进制文件(rlib)时会默认将标准库全部包含进去。而no</em>std就是指让编译器在编译时不主动引入标准库，而是由编程人员按需引入相关功能模块。这一机制主要是用在嵌入式开发中，除了标准库在无操作系统的裸机环境下可能无法编译的因素外，更是因为在嵌入式环境中，文件存储占用的资源是非常宝贵的，为了降低成本必须要尽可能得节省空间。no_std环境下，每个生成的rlib文件会比std环境下生成的节省200kb左右的空间。而一个项目一般会依赖多个rlib文件，所以可以从总体上节省很多资源。</p>
+
+<p>除了这种方法，还可以通过将整个标准库编译成动态链接库的方法，在有多个rlib存在时使他们链接到同一个动态链接库，也能显著得降低空间占用。这里我们只分享第一种，也就是no_std的方法。</p>
+
+<p>我们要让一个Rust库支持no_std环境主要做的事有两件：</p>
+
+<p>第一件事是解决自身对std的依赖。</p>
+
+<p>主要方法有三条：</p>
+
+<ol type="1">
+<li>在使用语言核心功能时，使用核心库代替标准库</li>
+
+<li>当需要使用核心库没有的功能时，手动引入额外功能模块</li>
+
+<li>使用条件编译进行功能裁剪。</li>
+</ol>
+
+<p>Rust中的条件编译主要由开发者自定义的feature实现，通过在程序的各个部分添加属性，判断不同的feature类型实现条件编译。</p>
+
+<p>第二件事是解决依赖库对std的依赖。主要方法有两个，首先肯定是修改依赖模块，让其也实现no<em>std化，技术实现上和第一步相同，但面对的问题会呈递归式增加，因为要实现依赖模块的no</em>std化，就还要实现依赖模块的依赖模块的no<em>std化，以此类推。所以这里一般是采用第二种方法，也就是使用Cargo的条件引入功能，相信做过Rust开发的人都知道每个项目都有一个Cargo.toml文件，就是通过修改这个配置文件，让Cargo根据不同的feature判断是否引入no</em>std的替代版本。</p>
+
+<p>用ndarray的no<em>std化来举例说明。ndarray作为一个开源项目，对no</em>std的需求，其实也是来源于社区用户。这一需求在去年被RustCV社区（一个专门从事于用rust开发计算机视觉算法的开源社区）的owner提出，他的想法是将ndarray应用于嵌入式环境下的机器人芯片上，从而在机器人上搭载基于ndarray开发的各种CV算法。笔者也参与了相关的issue讨论并承担了这个任务。所做的工作和上面讲的步骤可以一一对应。这里有一个小技巧，就是在项目的lib.rs文件里加入这么一句use core as std就能很方便地在整个项目中用核心库代替标准库，而不用修改所有use std的语句。除了核心库之外，ndarray还大量使用了标准库alloc模块中的Vec、Slice等功能，因此需要在lib.rs中手动引入alloc模块。而对于无法通过单个模块导入的浮点数计算功能，比如求对数、指数函数等，就通过加入属性来实现条件编译，只有在std环境下才编译带有该属性的程序实体。这里程序实体在狭义上就是指各个函数，因为和C的基于宏的条件编译不同，Rust的条件编译是基于属性的，所以无法在函数内部像C一样通过使用宏而选择编译各条语句，而是根据属性的不同判断带有这个属性的程序实体是否要被编译。</p>
+
+<p>对于ndarray的各依赖模块，其中矩阵乘法模块是专门对其进行了no<em>std化。而其他的库，如BLAS、Serde序列化、rayon多线程，都使用了Cargo的条件引入功能，在no</em>std环境下要么引入相应的no_std版本，要么使其不可用。</p>
+
+<h3 id='灵活步长'>灵活步长</h3>
+
+<p>接下来介绍多维数组中步长的使用。这里需要首先介绍一下ndarray中多维数组的内存模型。该内存模型包含数据，数据指针，维度和步长四个部分。它和numpy一个显著的区别就是使用静态维度，也就是1至6维的维度和步长全部由固定长度的数组表示，这是因为Rust语言本身的特性，之后会继续展开。当然ndarray本身也是支持动态可扩展的数组作为维度的。静态维度的数组运算速度比动态维度要快很多，但是缺点是不同维度之间的交互逻辑比较不便和复杂。</p>
+
+<p>而步长顾名思义，就是每一列的相邻索引位置在内存中的距离，它决定了指针遍历数组的顺序。ndarray的重要功能之一，就是可以通过不同的步长表示，表达出物理结构相同，而逻辑结构不同的数组，这样做最大的好处，就是可以节省新建数组的时间和空间开销，在数据量大的应用场景，比如各种大数据应用、生物信息研究中，这样的好处无疑是巨大的。 而在某些场景下，步长的不同也会显著地影响算法和程序运行的效率。</p>
+
+<p>最经典的例子便是C风格数组和Fortune风格数组的区别。C风格数组的最后一列上的元素在内存上是相邻的，第一列上的元素是内存上相隔最远。而Fortune刚好相反，第一列上的元素在内存上相邻，最后一列最远。这两种不同风格的数组排布，在不同的运算场景下，效率会有巨大的差异，因为数组遍历时的空间连续性，对访问的速度会有显著的影响，如果运算逻辑是以第一列为优先，那一定是Fortune排布更快，反之则是C风格更快。另一个角度来理解，在内存排布相同的情况下，C风格的数组和Fortran风格的数组在逻辑结构上互为转置。</p>
+
+<p>在上述基础上，负步长的定义和作用便油然而生。即当我们想以相反的顺序访问数组的某一列时，只需要将该列的步长调整为原来的负值即可，而不用重新申请内存空间存放顺序相反的数据。例如我们想求一张图片的翻转，因为图片数据一般是长、宽、RGB三个维度组成的数组，所以只需将水平轴的步长改为原来的相反数，便可以得到翻转后的图片数据而不用复制一张同样大小的图片。而非连续步长也可以理解为一种方便的切片表示方法，他通过让指针在内存中跳跃而非依次遍历的方式得到原来数组的切片。这在神经网络训练的提取特征点场景中使用相当广泛。而更为特殊的还有零步长的形式，相当于是将某一切片复制了许多份。这是之后要讲的广播特性的实现基础。</p>
+
+<p>而要实现这些步长使用方法，主要要解决下面三个问题：即步长的合法性、连续性判断以及寻址算法。合法性保证了在自定义步长时的程序是安全的，其中最重要的就是保证指针在依据步长在内存中移动时，不能在不同的坐标指向相同的内存，否则会造成读写错误。连续性是指该步长表示下的数组在内存排布上是否是连续的。如果是连续的，那么在复制和遍历时就能当做一整块内存来处理，效率会快很多很多。另外还有寻址算法，这一部分也很重要，因为如果寻址错误会导致访问到数组数据之外的内存数据，造成程序漏洞。具体的计算分为计算指针位置和计算寻址时的偏移量两部分，在此不再展开。</p>
+
+<h3 id='广播特性'>广播特性</h3>
+
+<p>在多维数组运算中，广播是一个极其重要的概念，它定义了不同维度的数组之间的交互逻辑。举个最简单的例子，一个二维数组和一维数组相乘时，将一维数组重复多次，就扩展成了一个二维数组，再将两个二维数组对应元素相乘，就得到了想要的结果。这样的运算是很常见的，比如地理上计算多个地标到原点的距离、数据挖掘聚类时的离散度计算等。而当多个不同维度的数组进行运算时，广播机制会按照类似的规则将每个数组扩展到同样的维度长度，然后再进行运算，在机器学习中常常会计算两个一维输入之间的协方差矩阵，那么就需要用到这样的机制。</p>
+
+<p>ndarray社区早在六年前就提出要实现广播机制，但直到21年都没有人解决它。其实这并不是因为广播不重要，而是由于Rust语言本身的语法限制问题。</p>
+
+<p>具体来说，当两个数组进行广播时，是无法确定返回值的类型的——之前说过ndarray采用的都是静态维度，也就是长度固定的数组，比如一维就是\[usize;1]，二维就是\[usize;2]。对Rust来说，\[usize;1]和\[usize;2]是不同的类型，这是出于对内存安全的考虑。另外还有不固定长度的usize数组。而不固定长度的usize数组不能作为返回值，因为它的空间大小是运行时确定而非编译时确定，而Rust要求函数的参数、返回值大小都必须是编译时确定的，这是为了保证函数调用时程序堆栈的大小确定。所以n维数组作为返回值时它的维度也必须是确定的——要么是1，要么是2、3。。。或者聪明一点，和第一个输入值的维度相同，或者和第二个输入值的维度相同。这在广播里是不够的，因为它要返回的是两个输入维度之间的较长者，这个逻辑听起来很简单，但对编译器来说根本做不到，因为其并没有在函数声明中进行推断的功能。C语言是没有这个问题的，因为C中根本就没有静态维度的概念，不管是多长的数组，都只是一个地址的引用而已。其他的动态语言类似Java，Python也没有这个问题，因为它们的所有对象几乎都是引用类型，这也导致了它们在每次访问对象时都会进行一次解引用，效率当然就没有C和Rust那么快。那Rust能不能想C一样返回地址的引用？也不可以，这是因为Rust作为一门内存安全语言有所有权的限制，在广播这个函数内创建的n维数组，是不能返回它的地址的，因为它的所有权在函数结束时就消亡了。那返回所有权呢？更不行，因为刚才说了，它的大小无法在编译时确定。</p>
+
+<p>所以这个问题有没有解决方法呢？之前说过ndarray也是支持动态数组作为维度的，动态数组是指如vec，box等类型，它们使用智能指针使得虽然他们持有的内存空间动态变化，但是本身大小是固定的，所以能作为返回类型。笔者也在社区中提出过在广播中使用动态数组作为返回值的维度，但马上就被owner否决掉了，因为Rust里的动态数组运行效率太过缓慢。</p>
+
+<p>但是万事都有解决的途径， 如果我们让编译器不用自己执行这个判断两个输入数组之中哪个维度更大的过程，而是直接告诉它应该返回什么大小维度的数组，那么广播就可以实现。具体来说，维度有零维到六维加上动态维度8种类型，如果我们写一个宏，为它们之间8\*8=64种交互的情况都分别实现一个广播函数，那么在每一种情况中返回维度大小都是能够确定的。这种方法理论上是可行的，但实现起来却会遇到更大的问题。试想一下，如果一个函数需要使用两个数组的广播，此时数组维度是不确定的，那么它该调用哪个广播函数？难道再将这个函数为64种情况全部都实现一遍吗？显然不现实。</p>
+
+<p>但是这个问题可以通过Rust语法中特有的聚合类型来解决。我们把数组间广播的实现放在一个自定义的trait里，这个trait用一个泛型参数来代表将要与trait实体进行广播的数组，并且在内部用一个聚合类型Output表示进行广播后输出的数组。然后使用宏为所有类型的数组都实现该trait。这样，我们在进行任意维度的数组间的广播时，只需要在where语句中添加一个限定条件，即数组实现了该trait，就能使用广播特性。实际上对Rust编译器有深入了解的人应该知道，编译器在单态化过程中会将所有泛型展开成具体的类型，每一次展开都会生成单独的一份代码。所以这种方法和上面那种方法其实在本质上是一样的。不过目前Rust编译器团队正在尝试多态化的实现，可以在编译过程中为类似的函数只生成一份代码，有兴趣的话可以自行研究。</p>
+
+<p>但是这样的方法会限定广播间的数组必须含有同样的数据类型，这样的限制有点严格，而且函数声明看起来也过于冗长。所以在此思路上，我们再进行简化，只为数组的维度实现该trait，并且将该trait命名为DimMax，顾名思义就是两个维度之间的较大者。</p>
+
+<p>那么，还能不能再简化，把where语句中额外的限定条件也去掉？即为两个任意长度的维度D1和D2实现该trait。这听起来很美好，但是又会再次受到Rust语法的限制——聚合类型也必须在定义时就确定——要么是手动确定，要么来自于输入值中的其他聚合类型。但我个人觉得这个问题可以解决——能不能修改编译器的特征实现机制，让其变得更聪明一点，比如在进行trait实现的编译过程中，允许进行静态常量的计算。因为静态维度的长度肯定是一个常量。所以在编译时对该常量进行计算，比如获取两个常量之间的最大值，然后获得一个确定的聚合类型，应该也是可行的。当然这只是我个人目前的猜想，能不能实现还需要对Rust编译器进行更深入的研究。不过目前还是可以在某些常见的情况下省去该限制，即相同维度间进行广播以及和与零维进行广播，在这两种情况下广播结果的维度都是本身，所以可以直接添加到对维度的定义中，在这两种特定情况下就能避免添加where语句的限制。</p>
+
+<h3 id='并行计算加速'>并行计算加速</h3>
+
+<p>最后，我想分享一下ndarray在并行计算方面的现状及发展。ndarray目前使用rayon库在部分场景下实现了多线程并行加速。rayon是一个基于迭代器实现的多线程并行库。它的核心思想是将一个迭代器拆成数个不同方向的子迭代器，同时将迭代的任务分配到各个子迭代器上，再用work-stealing算法分配到多个线程实现并行化。它要求迭代器必须满足以下三点：1.可以按从前向后和从后向前两个方向进行迭代2.可以随时求出剩余元素的个数3.可以从中间索引分割成两个互斥的，和父迭代器相同性质的子迭代器，如图所示。</p>
+
+<p>ndarray在数组的单个元素遍历、按某一特定维度遍历、以及多数组运算对应元素操作时按元素遍历这几种场景下实现了多线程加速。其后又增加了Lanes迭代器并行。Lanes直译过来是泳道，如果我们将一个N维的数组去掉某一维，看成一个N-1维的数组，那这个数组的每一个元素就变成了一个一维向量，这个向量就叫做泳道。它的主要应用场景是在二维以上的矩阵乘法中，此时结果矩阵中的每一个元素都是两条泳道的向量积，这种计算在文本分类、自然语言处理等深度学习场景中也是很常见的。</p>
+
+<p>除了多线程，还有另一个重要的并行加速方法，就是simd（Single instruction, multiple data）单指令多数据加速。即在一条机器指令的执行期间执行多个数据的计算操作。举个简单的例子，arm架构下的vaddq_s32指令，就可以在一条指令执行时间内，计算两个128位向量的和，每个向量各包含4个32位整数，因此相比于普通的循环加法要快了4倍。不同的硬件架构都有相适配的simd指令集，比如x86架构的avx、avx512、SSE指令集，arm的neon、asimd指令集等等。想要通过simd指令给ndarray中的n维数组运算加速，需要三个步骤：1.让Rust标准库支持各种架构simd指令。这个正是官方的simd工作组在做的事情。这是一项工作量很大的事，光是支持arm架构代码量就在10w行以上，x86更是接近20w行，还不包括一些要对编译器的修改。2.基于各种指令实现通用运算的simd加速。比如诞生于OpenCV的universal intrinsic，它提供了诸如向量点乘、矩阵乘法、距离计算、排序等多种通用计算接口及它们的实现，可以通过这些接口将计算转换成simd向量的计算以实现算法的加速。但universal intrinsic对一般开发者而言并不好用，因为它不能自动生成适配cpu向量寄存器长度的simd指令，需要用户手动来选择，因此可能造成simd性能利用不全或者因指令不适配而导致程序崩溃。这就引出了第3个步骤，也就是cpu的simd配置的自动检测和simd指令的自动适配，让所有simd指令对用户透明化。最后，还有潜在的第4个步骤，也就是编译器的自动向量化，使所有的运算都能通过编译器自动生成simd指令。这是一个极为艰深的方向，目前有很多LLVM的成员在研究这方面的实现，但也是困难重重，读者感兴趣的话可以尝试研究。</p>
+
+<p>这里再介绍一下Rust标准库中的stdarch仓库，这个库作为标准库的一部分为所有Rust开发者提供了各种常见硬件架构的simd指令集，由官方的simd工作组和库团队成员负责开发和维护，但目前除了x86平台的各种特性在去年年末刚刚稳定(stable)之外，其他架构都还处于unstable状态，因此整个simd特性还不能在稳定的Rust版本中使用，也需要各方开发者前来贡献。stdarch和Rust编译器、LLVM都有密切的联系。stdarch负责对不同架构、不同版本的指令集进行模块分类、封装和测试，并提供给用户相应的函数接口。底层的汇编实现和汇编优化是在Rust编译器和LLVM中，因此stdarch需要对编译器和LLVM的实现进行封装。这里分为两种情况，一种是各架构通用的simd接口，例如加减乘除、位运算等，这些指令会在编译器的代码生成部分静态调用LLVM的相关接口进行实现，再由stdarch使用extern “platform-intrinsics”关键字进行引入和封装。另一种是各架构提供的专用指令，例如x86的vcomi指令、arm的vsli指令等，一般是针对特定的计算场景提供，比如vsli代表向左位移再插入相应元素。这种情况下需要通过静态链接的形式调用llvm中的相关实现并进行封装。而stdarch中提供的接口依然是区分架构和向量寄存器长度的，而我提到的simd透明化或者说usimd，就是在此基础上向用户屏蔽掉硬件差异，以提供更通用的计算接口。</p>
+
+<p>此文主要由一些n维数组运算库ndarray的具体问题及技术解决展开，引出一些对Rust语言、以及科学计算领域技术的延伸和思考。希望对大家的Rust学习和开发有所帮助。</p>
+]]></content:encoded></item><item><title>华为 | 基于 TVM Rust Runtime 和 WASM 沙箱运行 AI 模型</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/hw_rust_rvm_wasm_ai.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='华为_|_基于_tvm_rust_runtime_和_wasm_沙箱运行_ai_模型'>华为 | 基于 TVM Rust Runtime 和 WASM 沙箱运行 AI 模型</h1>
+
+<p>作者： 王辉 / 后期编辑： 张汉东</p>
+
+<p>&gt; &gt; 此文来自于 3.27号 深圳 Meetup 大会 &gt; 3月27日活动PPT和现场视频链接：  <a href='https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665'>https://disk.solarfs.io/sd/6e7b909b-133c-49f7-be0f-a51f65559665</a></p>
+
+<h2 id=''></h2>
+
+<h1 id='基于tvm_rust_runtime和wasm沙箱运行ai模型'>基于TVM Rust Runtime和WASM沙箱运行AI模型</h1>
+
+<h2 id='说明'>说明</h2>
+
+<p>本文介绍了一种WASM与TVM在AI领域的结合方案：依托TVM端到端深度学习编译全栈的能力，将AI框架训练好的模型编译成WASM字节码，然后在运行时环境中通过Wasmtime进行图加载进而实现模型的无缝迁移部署。</p>
+
+<h2 id='图解tvm和wasm技术'>图解TVM和WASM技术</h2>
+
+<h3 id='tvm与rust运行时'>TVM与Rust运行时</h3>
+
+<p>&lt;img src=&quot;https://tvm.apache.org/assets/images/about-image.svg&quot; alt=&quot;TVM Framework&quot; width=&quot;800&quot;/&gt;</p>
+
+<p>作为Apache基金会的顶级开源项目，TVM是用于深度学习领域的一个全栈编译器，旨在高效地在任何硬件平台进行模型的编译优化和部署工作。通过统一的中间表示层（包括Relay和Tensor IR两层），TVM可将AI框架训练的模型编译成与后端硬件架构无关的计算图表达，然后基于统一运行时实现不同环境下的计算图加载和执行操作。</p>
+
+<p>为实现上述的图加载执行操作，TVM制定了一套抽象的运行时接口，并根据不同的运行时环境提供多种编程语言的接口实现（包括C++、Python、Rust、Go及Javascript等），本文主要介绍TVM Rust运行时的接口定义。TVM Rust运行时接口主要包含<code>tvm_rt</code>和<code>tvm_graph_rt</code>两个crate，前者完全实现了TVM runtime API的Rust接口，而后者则具体实现了TVM graph运行时的Rust版本；本文着重针对<code>tvm_graph_rt</code>的接口实现展开介绍。</p>
+
+<ul>
+<li>
+<p>结构体定义</p>
+
+<p>\| 结构体名称 | 功能介绍 | \| :--------- | :------- | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.DLTensor.html'>DLTensor</a> | Plain C Tensor object, does not manage memory. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.DsoModule.html'>DsoModule</a> | A module backed by a Dynamic Shared Object (dylib). | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.Graph.html'>Graph</a> | A TVM computation graph. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.GraphExecutor.html'>GraphExecutor</a> | An executor for a TVM computation graph. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.SystemLibModule.html'>SystemLibModule</a> | A module backed by a static system library. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/struct.Tensor.html'>Tensor</a> | A n-dimensional array type which can be converted to/from <code>tvm::DLTensor</code> and <code>ndarray::Array</code>. <code>Tensor</code> is primarily a holder of data which can be operated on via TVM (via <code>DLTensor</code>) or converted to <code>ndarray::Array</code> for non-TVM processing. |</p>
+</li>
+
+<li>
+<p>枚举定义</p>
+
+<p>\| 枚举名称 | 功能介绍 | \| :------- | :------- | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/enum.ArgValue.html'>ArgValue</a> | A borrowed TVMPODValue. Can be constructed using <code>into()</code> but the preferred way to obtain a <code>ArgValue</code> is automatically via <code>call_packed!</code>. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/enum.RetValue.html'>RetValue</a> | An owned TVMPODValue. Can be converted from a variety of primitive and object types. Can be downcasted using <code>try_from</code> if it contains the desired type. | \| <a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/enum.Storage.html'>Storage</a> | A <code>Storage</code> is a container which holds <code>Tensor</code> data. |</p>
+</li>
+
+<li>
+<p>常量定义</p>
+
+<ul>
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/constant.DTYPE_FLOAT32.html'>DTYPE_FLOAT32</a></li>
+
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/constant.DTYPE_FLOAT64.html'>DTYPE_FLOAT64</a></li>
+
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/constant.DTYPE_INT32.html'>DTYPE_INT32</a></li>
+
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/constant.DTYPE_UINT32.html'>DTYPE_UINT32</a></li>
+</ul>
+</li>
+
+<li>
+<p>trait定义</p>
+
+<ul>
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/trait.Module.html'>Module</a></li>
+
+<li><a href='https://tvm.apache.org/docs/api/rust/tvm_graph_rt/trait.PackedFunc.html'>PackedFunc</a></li>
+</ul>
+</li>
+</ul>
+
+<h3 id='wasm与wasi'>WASM与WASI</h3>
+
+<p>&lt;img src=&quot;https://www.virusbulletin.com/files/cache/f1eb0edbac94a7c83b2d8dda10dbf716_f3050.jpg&quot; alt=&quot;WASM Introduction&quot; width=&quot;600&quot;/&gt;</p>
+
+<p><a href='https://webassembly.org/'>WebAssembly技术</a>（WASM）是一个基于二进制操作指令的栈式结构的虚拟机，其可以被编译为机器码，进而更快、高效地执行本地方法和硬件资源；当然凭借WASM强大的安全和可移植特性，其不仅可以嵌入浏览器增强Web应用，也可以应用于服务器、IoT等场景。</p>
+
+<p>由于浏览器领域天然具备屏蔽后端硬件平台的特点，WASM技术本身不需要考虑浏览器后端的运行时环境；但是面向非Web领域必须要针对不同的操作系统进行适配和兼容（文件读写、时钟同步、中断触发等），针对这种情况WASM社区提出了一套全新的WASI标准（WASM System Interface）。正如WASM是面向逻辑机层面的汇编语言一样，WASI是一套面向逻辑操作系统的标准接口，目的是为了实现WASM平台在不同操作系统间的无缝迁移运行。针对WASI标准的详细解读，请查阅<a href='https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/'>此博文</a>。</p>
+
+<h2 id='方案介绍'>方案介绍</h2>
+
+<h3 id='前期调研'>前期调研</h3>
+
+<p>当前业界针对WASM技术在AI领域已经有了比较多的探索：<a href='https://blog.tensorflow.org/2020/03/introducing-webassembly-backend-for-tensorflow-js.html'>TF.js社区</a>基于WASM编译传统手写算子提升执行速度；<a href='https://tvm.apache.org/2020/05/14/compiling-machine-learning-to-webassembly-and-webgpu'>TVM社区</a>基于WASM编译模型用于浏览器领域的模型推理；还有利用WASM可移植性解决算子库与硬件设备不兼容的问题（详见<a href='https://github.com/google/XNNPACK'>XNNPACK</a>）等等。</p>
+
+<h3 id='方案设计'>方案设计</h3>
+
+<p>之前我们团队分享了WASM与AI领域结合的初步思路（详见<a href='https://leonwanghui.github.io/machine-learning/2020/04/15/some-thoughts-on-using-wasm-in-ml.html'>此处</a>），正如TF.js和TVM社区开展的探索工作，我们发现WASM具有的可移植性天然地解决了AI模型在全场景落地的问题：针对传统深度学习框架定义的模型，用户在不同硬件环境上进行模型训练/推理时必须要进行额外的定制化开发工作，甚至需要单独开发一套推理引擎系统。</p>
+
+<p>那么如何利用WASM的可移植性实现硬件环境的统一呢？以MindSpore深度学习框架为例，如果我们把MindSpore模型分别从宏观和微观的角度来分析，宏观来看它就是一张基于MindSpore IR定义的<strong>计算图</strong>，微观来看它是一系列MindSpore<strong>算子</strong>的集合。那么我们就可以尝试分别从计算图和算子的维度将WASM与深度学习框架进行结合，也就是提出<code>WASM计算图</code>和<code>WASM算子库</code>这两种概念。</p>
+
+<ul>
+<li>
+<p>WASM计算图</p>
+
+<p>WASM计算图，顾名思义就是将训练好的模型（包括模型参数）编译成WASM字节码，然后在Runtime环境中通过WASM Runtime加载便可直接进行模型推理，借助WASM的可移植性可以实现任何环境下的模型推理工作：</p>
+
+<ul>
+<li>Web领域通过<code>Emscripten</code>工具将WASM字节码加载到JS Runtime中进而在浏览器中执行；</li>
+
+<li>非Web领域通过<code>Wasmtime</code>工具加载WASM字节码到系统环境中执行。 对于WASM计算图这种情况，由于训练好的模型（和参数）都是提前保存在系统环境中，因此需要引入<code>WASI</code>接口与系统资源进行交互，进而完成离线加载模型的操作。所以在选择WASM Runtime的时候需要选择支持WASI（WASM System Interface）标准的工具（例如<code>Wasmtime</code>），或者也可以像TVM社区那样简单粗暴地直接对Emscripten进行WASI扩展。</li>
+</ul>
+</li>
+
+<li>
+<p>WASM算子库</p>
+
+<p>WASM算子库相对来说比较好理解，就是把单个算子编译成WASM字节码，然后对上层框架提供一种封装好的算子调用接口。但是和传统手写算子的调用方式不同，框架需要通过一种类似于动态链接的方式来加载WASM算子，但考虑到当前WASM本身不支持动态链接的方式，因此需要提前将所有编译好的WASM算子进行整合，然后对框架层提供算子库的调用接口。</p>
+</li>
+</ul>
+
+<p>通过对上述两种思路进行分析比较，同时在<strong>借鉴了TVM社区已有工作</strong>的情况下，我们决定首先从<code>WASM计算图</code>这条路开始进行深入探索，最大程度地利用TVM全栈编译的能力快速实现方案的原型。</p>
+
+<h3 id='方案实现'>方案实现</h3>
+
+<p>&lt;img src=&quot;./hw-tvm/TVM-graph-solution.png&quot; alt=&quot;TVM Graph Solution&quot; width=&quot;800&quot;/&gt;</p>
+
+<ul>
+<li>
+<p>WASM图编译</p>
+
+<p>如上图所示，我们可以利用TVM Relay的Python接口直接把模型编译成<code>graph.o</code>的可执行文件，但是需要注意的是生成的graph.o文件无法直接被WASM runtime模块识别，必须首先要通过TVM的Rust runtime加载然后通过Rust编译器把图中所示的<code>WASM Graph Builder</code>模块直接编译成WASM字节码（即图中的<code>wasm_graph.wasm</code>文件）。为什么非得要经过这一步繁琐的转换呢？主要是因为<code>graph.o</code>文件中包含了Relay和TVM IR的原语，我们无法直接将这些原语转换成WASM的原语，具体转换的步骤这里就不做赘述了。</p>
+</li>
+
+<li>
+<p>WASM图加载</p>
+
+<p>图加载阶段（由上图看来）似乎是非常简单的，但是实际情况要复杂地多。首先，WASM的运行时针对WASM IR定义了一整套汇编层面的用户接口，这对于上层应用开发者来说是极度不友好的；其次，WASM当前只支持整数类型（例如i32、u64等）作为函数参数，这就导致深度学习领域的张量类型无法通过原生方式传入；更别说还要增加thread、SIMD128这些高级特性的支持等等。</p>
+
+<p>当然每个新领域的探索都离不开各种各样的问题，而且解决问题本身就是技术/科研人员的本职工作，所以我们没有寄希望于WASM社区而是主动尝试解决这些问题：既然WASM没有面向上层用户的高级API，我们就根据自己的需求开发一套；虽然WASM不支持传入Struct或Pointer，我们可以通过Memory机制将数据提前写入到WASM内存中然后将内存地址转成i32类型作为函数参数。虽然有些改动有点“反人类”，但是它可以清晰地展示出我们的思路和想法，这就已经足够了。</p>
+</li>
+</ul>
+
+<p>由于篇幅有限，此处附上项目实现的<a href='https://github.com/apache/incubator-tvm/tree/master/apps/wasm-standalone'>完整代码</a>，欢迎感兴趣的大佬进行交流讨论。</p>
+
+<p>如下展示的是项目整体的codebase：</p>
+
+<pre><code class="language-`">wasm-standalone/
+├── README.md
+├── wasm-graph      // WASM图生成模块
+│   ├── build.rs    // build脚本
+│   ├── Cargo.toml  // 项目依赖包
+│   ├── lib         // 通过TVM Relay API编译生成的计算图的存放目录
+│   │   ├── graph.json
+│   │   ├── graph.o
+│   │   ├── graph.params
+│   │   └── libgraph_wasm32.a
+│   ├── src         // WASM图生成模块源代码
+│   │   ├── lib.rs
+│   │   ├── types.rs
+│   │   └── utils.rs
+│   └── tools       // Relay Python API编译脚本的存放目录
+│       ├── build_graph_lib.py
+└── wasm-runtime    // WASM图生成模块
+    ├── Cargo.toml
+    ├── src         // WASM图生成模块源代码
+    │   ├── graph.rs
+    │   ├── lib.rs
+    │   └── types.rs
+    └── tests      // WASM图生成模块测试用例
+        └── test_graph_resnet50</code></pre>
+
+<p>为了让大家对该方案有一个更形象具体的理解，我们准备了一个简单的原型：通过TVM Relay API将基于ONNX生成的ResNet50模型编译成<code>wasm_graph_resnet50.wasm</code>文件，然后在运行时环境中通过Wasmtime加载WASM完成模型推理功能（具体操作流程详见<a href='https://github.com/apache/incubator-tvm/blob/master/apps/wasm-standalone/README.md#poc-guidelines'>此处</a>）。</p>
+
+<h2 id='未来规划'>未来规划</h2>
+
+<h3 id='tvm社区联动'>TVM社区联动</h3>
+
+<p>正如前面所说的，该方案仍处于<strong>试验</strong>阶段，因此我们会和TVM社区一起共同探索更多可能性，目前初步规划的特性有：</p>
+
+<ul>
+<li>支持基于SIMD128的数据并行处理；</li>
+
+<li>进一步完善TVM社区的Rust runtime API模块，使其能原生支持WASM Memory特性的对接；</li>
+
+<li>基于WASM后端的AutoTVM优化；</li>
+
+<li>更多网络支持。</li>
+</ul>
+
+<h3 id='wasm算子库'>WASM算子库</h3>
+
+<p>当前我们只是针对WASM计算图这个方向进行了深入探索，但如果要是将WASM技术与深度学习框架（比如MindSpore）相结合的话，WASM算子库的方向可能会释放更大的潜能。这里首先列举几个更适合WASM算子库的场景：</p>
+
+<ul>
+<li>很多深度学习框架本身已经定义了自己的IR以及编译流水线，只有WASM算子库可以无缝地与这些框架的图编译层相融合；</li>
+
+<li>WASM计算图只能用于模型推理，而WASM算子库可以适用于模型训练/验证/推理等场景；</li>
+
+<li>在可移植性这个层面，WASM计算图无法提供其内部算子的一致性保证，而WASM算子库真正实现了端边云全场景中算子的可移植性。</li>
+</ul>
+
+<p>&lt;img src=&quot;./hw-tvm/TVM-kernel-solution.png&quot; alt=&quot;TVM Kernel Solution&quot; width=&quot;800&quot;/&gt;</p>
+
+<p>如上图所示，我们计划从WASM算子库这个层面梳理出一套端到到的集成方案（优先覆盖上述几个场景），真正实现WASM技术在AI领域全场景的结合。</p>
+
+<h2 id='加入我们'>加入我们</h2>
+
+<p>为了更好地推动Rust编程语言生态在AI领域的落地，我们发起了一个叫Rusted AI的非商业性组织，任何对Rust和AI技术感兴趣的开发者均可申请加入，社区当前提供如下几种交流渠道：</p>
+
+<ul>
+<li><strong>Rusted AI微信群</strong>：欢迎添加小助手的微信（微信号：<code>mindspore0328</code>，备注：<code>Rusted AI</code>），认证通过后小助手会将您拉进Rusted AI讨论群</li>
+
+<li><strong>GitHub Teams</strong>：社区当前依托GitHub Teams提供公开讨论的渠道，由于GitHub Teams仅对组织成员开放，请以邮件形式发送<code>个人GitHub ID</code>至<a href='wanghui71leon@gmail.com'>wanghui71leon@gmail.com</a>，认证通过后即可参与<a href='https://github.com/orgs/tinyms-ai/teams/rustedai'>社区话题讨论</a></li>
+
+<li><strong>生态众筹项目</strong>：近期社区发布了<a href='https://github.com/tinyms-ai/awesome-rusted-ai'>awesome-rusted-ai</a>众筹项目，用于记录所有与Rust语言和AI领域联动相关的开源项目</li>
+</ul>
+]]></content:encoded></item><item><title>蚂蚁集团 CeresDB 团队 | Rust CPU Affinity 初探</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust_cpu_affinity.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='蚂蚁集团_ceresdb_团队_|_rust_cpu_affinity_初探'>蚂蚁集团 CeresDB 团队 | Rust CPU Affinity 初探</h1>
+
+<p>作者：Ruihang Xia / 后期编辑：张汉东</p>
+
+<h1 id='brief'>Brief</h1>
+
+<p>在看 <a href='https://cassandra.apache.org/'>Apache Cassandra</a> 的时候了解到 <a href='https://www.scylladb.com/'>ScyllaDB</a> 能在完全兼容它的情况下性能提升很多，通过进一步了解接触到了 thread per core 这种架构，这篇文章从一个简单的 cache 结构出发，实现了三个不同的方案，并对它们进行比较，最后给出了在这个过程中学习到的一些东西。</p>
+
+<p>Thread Per Core 简单来说就是将应用的每一个线程绑定到一个计算核心上，通过 sharding 的方式将计算拆解分配到对应的核上。这是一种 shared nothing 的方式，每个核单独持有计算所需要的数据，独立完成计算任务，从而避免掉多余的线程同步开销。同时每个核心和工作线程一一对应，减少上下文切换的开销。</p>
+
+<p>在 <a href='https://github.com/waynexia/shard-affinity'>waynexia/shard-affinity</a> 中，我分别用普通的不做限制调度、local set 给计算任务分组以及 绑定任务、核心与线程三种方式实现同一个目的的 cache 结构。这三种实现分别对应 <em>shard-affinity/load/src</em> 目录下的 <em>threading-rs</em>, <em>local_set-rs</em> 和 <em>affinity-rs</em> 三个文件。接下来将对这三种方法实现方法进行分析。下文提到的原始代码都在这个仓库里面，为了简洁进行了部分省略。</p>
+
+<h1 id='cache'>Cache</h1>
+
+<p>假设我们有一个类似 <code>Map&lt;Id, Data&gt;</code> 的结构，它缓存了我们所需要的数据，请求分为对它进行 <code>append()</code> 或者 <code>get()</code>，通过读写锁进行线程同步并提供内部可变性，对外暴露 <code>&amp;self</code> 的接口。</p>
+
+<pre><code class="language-`rust">pub struct CacheCell {
+    items: RwLock&lt;Map&lt;Id, RwLock&lt;Item&gt;&gt;&gt;,
+}
+
+impl CacheCell {
+    pub fn get(&amp;self, id: Id, size: usize) -&gt; Option&lt;Bytes&gt;{}
+    pub fn append(&amp;self, id: usize, bytes: Bytes) {}
+}</code></pre>
+
+<p>首先为了能让多个任务在同时操作 cache 的时候仍能得到符合预期的结果，我们可以使用 lock-free 的结构，或者对它加上一把锁将并发的操作串行化。而我们发现对不同的 id 进行的操作并不会互相影响。所以可以将线程同步所影响的结构粒度变小，以这个 cache 所参考的 gorilla in-memory data structure 为例，将 id 分为进行分组，由对应的 cell 进行管理。将锁的粒度变小，以支持更高的并发操作。</p>
+
+<p>&lt;img src=&quot;ceresdb/gorilla-fig7.png&quot; width=&quot;75%&quot;&gt;</p>
+
+<p>&gt; &gt; 图一，from <a href='https://www.vldb.org/pvldb/vol8/p1816-teller.pdf'>Gorilla</a> paper Fig.7: Gorilla in-memory data structure.</p>
+
+<p>选这个结构作为实例有两个原因，首先这是一个实际生产系统所使用的结构，比较有实际意义；并且它比较简单易于实现，而且本身就已经对 id 进行了 sharding，方便进行后续的使用。</p>
+
+<h1 id='threading'>Threading</h1>
+
+<p>先来看比较常见的做法，拿若干个 <code>cache</code> 放一起合成一个 <code>Vec&lt;Cache&gt;&gt;</code>，根据每次请求的 id 路由到对应的 cache 进行操作。</p>
+
+<pre><code class="language-`rust">impl ThreadingLoad{
+    pub fn append(&amp;self, id: Id, bytes: Bytes) {
+        self.shards[route_id(id)].append(id, bytes);
+    }
+}</code></pre>
+
+<p>而在使用的时候，则是开一个多线程的 tokio runtime，向里面 spawn 不同 id 的请求。</p>
+
+<pre><code class="language-`rust">let rt = Builder::new_multi_thread().build();
+let load = ThreadingLoad::new();
+
+rt.spawn(async move {
+    let id = random::&lt;usize&gt;();
+    load.append(id, bytes);
+})</code></pre>
+
+<p>在这之后，由 tokio 去调度任务执行，完成之后给我们结果，我们不用关心这个任务具体是怎样被调度的，产生的计算发生在哪个核上。而且我们底下的所有结构都付出了代价让它们 <code>Send</code> 和 <code>Sync</code>，也不用去担心一个对象同时被多个东西操作会出现奇怪的结果。</p>
+
+<h1 id='localset'>LocalSet</h1>
+
+<p>这里是使用 tokio 的 <a href='https://docs.rs/tokio/1.3.0/tokio/task/struct.LocalSet.html'>LocalSet</a> 来实现的。它能将指定的任务绑在同一个线程上进行执行。这样子带来的好处就是我们可以使用 <code>!Send</code> 的东西了。</p>
+
+<p>具体来说，由上面我们知道不同的 id 之间的操作不会互相影响，所以能够将锁粒度变小。同样的，不同 id 的任务计算所需要用到的数据也不会重叠，也就是避免了一份数据可能被多个内核同时访问的场景，从而不需要考虑我们的修改对其他内核的可见性。基于这一点，之前付出的性能代价来给数据实现 <code>Send</code> 和 <code>Sync</code> 也可以被节省下来。比如引用计数可以从 <code>Arc</code> 变成 <code>Rc</code>，或者说所有为了保证可见性所加的指令屏障都可以去掉。</p>
+
+<p>从实现来看，在我的这台有十六个逻辑核心的设备上，将所有的 shards 分给15个线程进行管理，另外一个来进行任务的分发，任务分发线程与其余每个线程之间都有一个 channel 来进行任务的传输。这里分发的任务有两种：</p>
+
+<pre><code class="language-`rust">enum Task {
+    Append(Id, Bytes, oneshot::Sender&lt;()&gt;),
+    Get(Id, usize, oneshot::Sender&lt;()&gt;),
+}</code></pre>
+
+<p>每个里面包含对应任务所需要的参数，以及一个用于通知任务完成的 channel。每次请求到来时，任务分发线程组装好所需要的参数，根据 id 发送给对应的执行线程，之后等待执行结果。</p>
+
+<pre><code class="language-`rust">pub async fn append(&amp;self, id: Id, bytes: Bytes) {
+    let (tx, rx) = oneshot::channel();
+    let task = Task::Append(id, bytes, tx);
+    self.txs[route_id(id)].send(task).unwrap();
+
+    rx.await.unwrap()
+}</code></pre>
+
+<h1 id='affinity'>Affinity</h1>
+
+<p>在上面的实现中，我们只是将一组任务所需要的数据和计算绑在了一起，避免线程同步的开销。在运行中核心之间负载不均衡的时候，能够观察到明显的操作系统调度的行为。这样子只减少了开始提到的两种开销中的一种，上下文切换的开销仍然还在。操作系统的调度很多时候并不能明白应用的行为，所以在第三种方法中我们将每个线程与核绑定起来，或者是说告诉操作系统要去如何调度我们的线程。</p>
+
+<p>线程的分配和上面 LocalSet 方案一样，将 shards 分配到除了一个分发线程之外的其余线程中，并每个线程绑一个核。通过 <a href='https://crates.io/crates/core_affinity'>core_affinity</a> crate 来设置 <a href='https://en.wikipedia.org/wiki/Processor_affinity'>cpu affinity</a>。</p>
+
+<pre><code class="language-`rust">let core_ids = core_affinity::get_core_ids().unwrap();
+core_affinity::set_for_current(_);</code></pre>
+
+<pre><code class="language-`rust">for core_id in core_ids {
+    thread::spawn(move || {
+        core_affinity::set_for_current(core_id);
+    });
+}</code></pre>
+
+<p>除了设置了 cpu affinity 之外，还有其他地方与上一种方案不同。首先这里在 channels 中分发的是已经构造好的 future，而不是分发参数之后再构造；其次这里的 runtime 是一个简单的 FIFO 队列；最后每个线程的 caches 通过 thread local storage 的方式存储。</p>
+
+<pre><code class="language-`rust">self.runtime.spawn(route_id(id), async move {
+    thread_local! (static SHARD:AffinityShard = AffinityShard::new() );
+
+    SHARD.with(|shard| {
+        shard.append(id, bytes);
+    });
+
+    tx.send(()).unwrap();
+});</code></pre>
+
+<p>这些区别只是单纯展现实现差异，并且由于 cache 内部的内存还是采用的默认分配器从堆上分配，这里的 TLS 实际上也没有起到什么作用，后文会继续提到这个点。</p>
+
+<p>在这种情况下，每个计算线程可以在一定程度上简化成一个单线程模型进行考虑，整个系统也变成了非抢占式、协作的调度，利用 rust 的 coroutine 由任务自己在需要等待资源的时候通过 await yield 出来。除了之前提到的那些方面之外相信还有许多其他可以开发的空间。</p>
+
+<p>以及这种 affinity 的方案也是一个能很好的在应用侧进行 NUMA 实践的场景，结合前面提到的 TLS，另一种方法就是使用一个感知 NUMA 的内存分配器。不过我的设备并不支持 NUMA，所以没有进行进一步的测试。</p>
+
+<h1 id='test'>Test</h1>
+
+<p>在 <em>shard_affinity/src</em> 下有三个 binary 代码文件，分别是对三种情况进行的一个简单的测试。工作负载的参数可以在 <em>shard_affinity/src/lib.rs</em> 下看到。在我的环境下，三个方案以 128 并发分别进行 1024 次写以及 4096 次读 16KB 的数据耗时如下。为了让数据集中，将 id 的范围设置到了 0 至 1023.</p>
+
+<p>&lt;img src=&quot;ceresdb/result.png&quot; width=&quot;75%&quot;&gt;</p>
+
+<p>&gt; &gt; 图二，本地进行测试结果。纵坐标为延时（毫秒），越低越好。</p>
+
+<p>可以看到，local set 和 affinity 两种方案的表现并不如 threading 的好。初步分析时在 local set 和 affinity 两种方案下都是由一个线程做入口进行任务生成和分发，即多出了额外的任务路由开销，在测试的时候能看到 cpu 的负载也是一高多底，而且由于模拟的任务单个执行时间都比较短，路由线程也会更先到达瓶颈。</p>
+
+<p>在将工作线程数都调整为 8 （逻辑核心数量的一半）之后，可以看到 threading 和 affinity 的差别有所减小。对于目前仍然存在的 gap，通过 flamegraph 分析可能是 affinity 需要对每个任务收发请求和结果带来的.</p>
+
+<p>&lt;img src=&quot;ceresdb/adjust-worker.png&quot; width=&quot;75%&quot;&gt;</p>
+
+<p>&gt; &gt; 图三，调整 worker 数量之后的结果。纵坐标为延时（毫秒），越低越好。</p>
+
+<p>由于所有的内存数据，即状态都被预先分散到各个核上，因此对 sharding 的方案也有要求。当 affinity 由于热点等原因出现负载不均衡时，进行 re-balance 一般会是一个比较耗时的操作，灵活性这方面不如 threading 模式。此外计算的分布方法也很重要，比如目前由一个线程向其他线程分发的方式就在测试中出现了问题。考虑到实际的系统计算负载的组成更加复杂，如何很好的分散计算任务也是需要慎重决定的。</p>
+
+<h1 id='others'>Others</h1>
+
+<p>在 affinity 的实现中，为了展示大部分组件都是手造的简单模型。而 thread per core 其实已经有许多优秀的框架能够简化在这种架构下开发的难度，比如开头提到的 <a href='https://www.scylladb.com/'>scylladb</a> 所使用的框架 <a href='http://seastar.io/'>seastar</a>，这篇文章的写作过程中也参考了它们的很多文档。rust 也有类似的框架 <a href='https://crates.io/crates/glommio'>glommio</a>，这是一个比较新的库，前不久刚放出第一个比较正式的 release。</p>
+
+<p>在 thread per core 架构下，除了应用的逻辑需要发生变化，许多常用的组件也都要产生改动，为了一般多线程场景设计的那些向线程同步付出了代价的结构如使用了 Arc 的地方是不是可以换成 Rc 等，这些都是需要考虑的。也希望能围绕这个发展出很好的生态。</p>
+
+<h1 id='conclusion'>Conclusion</h1>
+
+<p>在简单的对比过不同方法的实现和性能之后，从我的观点来看 thread per core 是一个非常值得尝试的方法，它能够在某种程度上简化开发时所考虑的场景，也很适合目前动辄几十上百核的服务器，而且也有 <a href='https://www.scylladb.com/'>scylladb</a> 这种成熟的实践。不过这个对于已经基本成型的系统来说所需要作的改动比较大。我们期望 thread per core 带来的提升是通过减小同步开销以及提高的缓存命中率实现更低的延时以及更平稳的性能，而且这些改动所能带来的提升与增加的复杂度，工作量和风险性相比则需要进行权衡。</p>
+
+<h1 id='关于我们'>关于我们</h1>
+
+<p>我们是蚂蚁智能监控技术中台的时序存储团队，我们正在使用 Rust 构建高性能、低成本并具备实时分析能力的新一代时序数据库，欢迎加入或者推荐，目前我们也正在寻找优秀的实习生，也欢迎广大应届同学来我们团队实习，请联系：jiachun.fjc@antgroup.com</p>
+]]></content:encoded></item><item><title>DatenLord | Rust实现RDMA</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust_rdma.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='datenlord_|_用_rust实现_rdma'>DatenLord | 用 Rust实现 RDMA</h1>
+
+<p>作者：王璞 / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>RDMA是常用于高性能计算(HPC)领域的高速网络，在存储网络等专用场景也有广泛的用途。RDMA最大的特点是通过软硬件配合，在网络传输数据的时候，完全不需要CPU/内核参与，从而实现高性能的传输网络。最早RDMA要求使用InfiniBand (IB)网络，采用专门的IB网卡和IB交换机。现在RDMA也可以采用以太网交换机，但是还需要专用的IB网卡。虽然也有基于以太网卡用软件实现RDMA的方案，但是这种方案没有性能优势。</p>
+
+<p>RDMA在实际使用的时候，需要采用特定的接口来编程，而且由于RDMA在传输数据的过程中，CPU/内核不参与，因此很多底层的工作需要在RDMA编程的时候自行实现。比如RDMA传输时涉及的各种内存管理工作，都要开发者调用RDMA的接口来完成，甚至自行实现，而不像在socket编程的时候，有内核帮忙做各种缓存等等。也正是由于RDMA编程的复杂度很高，再加上先前RDMA硬件价格高昂，使得RDMA不像TCP/IP得到广泛使用。</p>
+
+<p>本文主要介绍我们用Rust对RDMA的C接口封装时碰到的各种问题，并探讨下如何用Rust对RDMA实现safe封装。下面首先简单介绍RDMA的基本编程方式，然后介绍下采用Rust对RDMA的C接口封装时碰到的各种技术问题，最后介绍下后续工作。我们用Rust实现的RDMA封装已经开源，包括<a href='https://github.com/datenlord/rdma-sys'>rdma-sys</a>和<a href='https://github.com/datenlord/async-rdma'>async-rdma</a>，前者是对RDMA接口的unsafe封装，后者是safe封装（尚未完成）。</p>
+
+<h2 id='rdma编程理念'>RDMA编程理念</h2>
+
+<p>先首先简要介绍下RDMA编程，因为本文重点不是如何用RDMA编程，所以主要介绍下RDMA的编程理念。RDMA的全称是Remote Direct Memory Access，从字面意思可以看出，RDMA要实现直接访问远程内存，RDMA的很多操作就是关于如何在本地节点和远程节点之间实现内存访问。</p>
+
+<p>RDMA的数据操作分为“单边”和“双边”，双边为send/receive，单边是read/write，本质都是在本地和远程节点之间共享内存。对于双边来说，需要双方节点的CPU共同参与，而单边则仅仅需要一方CPU参与即可，对于另一方的CPU是完全透明的，不会触发中断。根据上述解释，大家可以看出“单边”传输才是被用来传输大量数据的主要方法。但是“单边”传输也面临这下列挑战：</p>
+
+<ol type="1">
+<li>
+<p>由于RDMA在数据传输过程中不需要内核参与，所以内核也无法帮助RDMA缓存数据，因此RDMA要求在写入数据的时候，数据的大小不能超过接收方准备好的共享内存大小，否则出错。所以发送方和接收方在写数据前必须约定好每次写数据的大小。</p>
+</li>
+
+<li>
+<p>此外，由于RDMA在数据传输过程中不需要内核参与，因此有可能内核会把本地节点要通过RDMA共享给远程节点的内存给交换出去，所以RDMA必须要跟内核申请把共享的内存空间常驻内存，这样保证远程节点通过RDMA安全访问本地节点的共享内存。</p>
+</li>
+
+<li>
+<p>再者，虽然RDMA需要把本地节点跟远程节点共享的内存空间注册到内核，以防内核把共享内存空间交换出去，但是内核并不保证该共享内存的访问安全。即本地节点的程序在更新共享内存数据时，有可能远程节点正在访问该共享内存，导致远程节点读到不一致的数据；反之亦然，远程节点在写入共享内存时，有可能本地节点的程序也正在读写该共享内存，导致数据冲突或不一致。使用RDMA编程的开发者必须自行保证共享内存的数据一致性，这也是RDMA编程最复杂的关键点。</p>
+</li>
+</ol>
+
+<p>总之，RDMA在数据传输过程中绕开了内核，极大提升性能的同时，也带来很多复杂度，特别是关于内存管理的问题，都需要开发者自行解决。</p>
+
+<h2 id='rdma的unsafe封装'>RDMA的unsafe封装</h2>
+
+<p>RDMA的编程接口主要是C实现的<a href='https://github.com/linux-rdma/rdma-core'>rdma-core</a>，最开始我们觉得用Rust的<a href='https://github.com/rust-lang/rust-bindgen'>bingen</a>可以很容易生成对rdma-core的Rust封装，但实际中却碰到了很多问题。</p>
+
+<p>首先，rdma-core有大量的接口函数是inline方式定义，至少上百个inline函数接口，bindgen在生成Rust封装时直接忽略所有的inline函数，导致我们必须手动实现。Rust社区有另外几个开源项目也实现了对rdma-core的Rust封装，但是都没有很好解决inline函数的问题。此外，我们在自行实现rdma-core的inline函数Rust封装时，保持了原有的函数名和参数名不变。</p>
+
+<p>其次，rdma-core有不少宏定义，bindgen在生成Rust封装时也直接忽略所有的宏定义，于是我们也必须手动实现一些关键的宏定义，特别是要手动实现rdma-core里用宏定义实现的接口函数和一些关键常量。</p>
+
+<p>再有，rdma-core有很多数据结构的定义用到了union，但是bindgen对C的union处理得不好，并不是直接转换成Rust里的union。更严重的是rdma-core的数据结构里还用到匿名union，如下所示：</p>
+
+<pre><code class="language-`C">struct ibv_wc {
+    ...
+	union {
+		__be32		imm_data;
+		uint32_t	invalidated_rkey;
+	};
+    ...
+};</code></pre>
+
+<p>由于Rust不支持匿名union，针对这些rdma-core的匿名union，bindgen在生成的Rust binding里会自动生成union类型的名字，但是bindgen自动生成的名字对开发者很不友好，诸如<code>ibv_flow_spec__bindgen_ty_1__bindgen_ty_1</code>这种名字，所以我们都是手动重新定义匿名union，如下所示：</p>
+
+<pre><code class="language-`Rust">#[repr(C)]
+pub union imm_data_invalidated_rkey_union_t {
+    pub imm_data: __be32,
+    pub invalidated_rkey: u32,
+}
+
+#[repr(C)]
+pub struct ibv_wc {
+    ...
+    pub imm_data_invalidated_rkey_union: imm_data_invalidated_rkey_union_t,
+    ...
+}</code></pre>
+
+<p>再次，rdma-core里引用了很多C的数据结构，诸如<code>pthread_mutex_t</code>和<code>sockaddr_in</code>之类，这些数据结构应该使用<a href='https://github.com/rust-lang/libc'>Rust libc</a>里定义好的，而不是由bindgen再重新定义一遍。所以我们需要配置bindgen不重复生成libc里已经定义好的数据结构的Rust binding。</p>
+
+<p>简单一句话总结下，bindgen对生成rdma-core的unsafe封装只能起到一半作用，剩下很多工作还需要手动完成，非常细碎。不过好处是，RDMA接口已经稳定，此类工作只需要一次操作即可，后续几乎不会需要大量更新。</p>
+
+<h2 id='rdma的safe封装'>RDMA的safe封装</h2>
+
+<p>关于RDMA的safe封装，有两个层面的问题需要考虑：</p>
+
+<ul>
+<li>如何做到符合Rust的规范和惯例；</li>
+
+<li>如何实现RDMA操作的内存安全。</li>
+</ul>
+
+<p>首先，关于RDMA的各种数据结构类型，怎样才能封装成对Rust友好的类型。rdma-core里充斥着大量的指针，绝大多数指针被bindgen定义为<code>*mut</code>类型，少部分定义为<code>*const</code>类型。在Rust里，这些裸指针类型不是<code>Sync</code>也不是<code>Send</code>，因此不能多线程访问。如果把这些裸指针转化为引用，又涉及到生命周期问题，而这些指针指向的数据结构都是rdma-core生成的，大都需要显式的释放，比如<code>struct ibv_wq</code>这个数据结构由<code>ibv_create_wq()</code>函数创建，并由<code>ibv_destroy_wq()</code>函数释放：</p>
+
+<pre><code class="language-`C">struct ibv_wq *ibv_create_wq(...);
+
+int ibv_destroy_wq(struct ibv_wq *wq);</code></pre>
+
+<p>但是用Rust开发RDMA应用的时候，Rust代码并不直接管理<code>struct ibv_wq</code>这个数据结构的生命周期。进一步，在Rust代码中并不会直接修改rdma-core创建的各种数据结构，Rust代码都是通过调用rdma-core的接口函数来操作各种RDMA的数据结构/指针。所以对Rust代码来说，rdma-core生成的各种数据结构的指针，本质是一个句柄/handler，这个handler的类型是不是裸指针类型并不重要。于是，为了在Rust代码中便于多线程访问，我们把rdma-core返回的裸指针类型都转换成<code>usize</code>类型，当需要调用rdma-core的接口函数时，再从usize转换成相应的裸指针类型。这么做听上去很hack，但背后的原因还是很显而易见的。进一步，对于在rdma-core中需要手动释放的资源，可以通过实现Rust的<code>Drop trait</code>，在<code>drop()</code>函数中调用rdma-core相应的接口实现资源自动释放。</p>
+
+<p>其次，关于RDMA的内存安全问题，这部分工作尚未完成。目前RDMA的共享内存访问安全问题在学术界也是个热门研究课题，并没有完美的解决方案。本质上讲，RDMA的共享内存访问安全问题是由于为了实现高性能网络传输、绕过内核做内存共享带来的，内核在内存管理方面做了大量的工作，RDMA的数据传输绕过内核，因此RDMA无法利用内核的内存管理机制保证内存安全。如果要把内核在内存管理方面的工作都搬到用户态来实现RDMA共享内存访问安全，这么做的话一方面复杂度太高，另一方面也不一定有很好的性能。</p>
+
+<p>在实际使用中，人们会对RDMA的使用方式进行规约，比如不允许远程节点写本地节点的共享内存，只允许远程节点读。但即便是只允许远程读取，也有可能有数据不一致的问题。比如远程节点读取了共享内存的前半段数据，本地节点开始更新共享内存。假定本地节点更新的数据很少而远程节点读取的数据很多，因此本地节点更新的速度比远程节点读取的速度快，导致有可能本地节点在远程节点读后半段数据前更新完毕，这样远程节点读取的是不一致的数据，前半段数据不包括更新数据但是后半段包括更新数据。远程节点读到的这个不一致的数据，既不是先前真实存在的某个版本的数据，也不是全新版本的数据，破坏了数据一致性的保证。</p>
+
+<p>针对RDMA内存安全问题，一个常见的解决方案是采用无锁(Lock-free)数据结构。无锁数据结构本质上就是解决并发访问下保证内存安全问题，当多个线程并发修改时，无锁数据结构保证结果的一致性。针对上面提到的远程读、本地写的方式，可以采用<a href='https://en.wikipedia.org/wiki/Seqlock'>Seqlock</a>来实现。即每块RDMA的共享内存空间关联一个序列号(sequence number)，本地节点每次修改共享内存前就把序列号加一，远程节点在读取开始和结束后检查序列号是否有变化，没有变化说明读取过程中共享内存没有被修改，序列号有变化说明读取过程中共享内存被修改，读到了有可能不一致的数据，则远程节点重新读取共享内存。</p>
+
+<p>如果要放宽对RDMA的使用规约，即远程节点和本地节点都可以读写共享内存的场景，那么就需要采用更加复杂的算法或无锁数据结构，诸如<a href='https://en.wikipedia.org/wiki/Copy-on-write'>Copy-on-Write</a>和<a href='https://en.wikipedia.org/wiki/Read-copy-update'>Read-Copy-Update</a>等。内核中大量使用Copy-on-Write和Read-Copy-Update这两种技术来实现高效内存管理。这方面的工作有不少技术难度。</p>
+
+<h2 id='后续工作'>后续工作</h2>
+
+<p>下一步在完成对RDMA的safe封装之后，我们规划用Rust实现对RDMA接口函数的异步调用。因为RDMA都是IO操作，非常适合异步方式来实现。</p>
+
+<p>对RDMA接口函数的异步处理，最主要的工作是关于RDMA的完成队列的消息处理。RDMA采用了多个工作队列，包括接收队列(RQ)，发送队列(SQ)以及完成队列(CQ)，这些队列一般是RDMA的硬件来实现。其中发送队列和接收队列的功能很好理解，如字面意思，分别是存放待发送和待接收的消息，消息是指向内存中的一块区域，在发送时该内存区域包含要发送的数据，在接收时该内存区域用于存放接收数据。在发送和接收完成后，RDMA会在完成队列里放入完成消息，用于指示相应的发送消息或接收消息是否成功。用户态RDMA程序可以定期不定期查询完成队列里的完成消息，也可以通过中断的方式在CPU收到中断后由内核通知应用程序处理。</p>
+
+<p>异步IO本质上都是利用Linux的epoll机制，由内核来通知用户态程序某个IO已经就绪。对RDMA操作的异步处理，方法也一样。RDMA是通过创建设备文件来实现用户态RDMA程序跟内核里的RDMA模块交互。在安装RDMA设备和驱动后，RDMA会创建一个或多个字符设备文件，<code>/dev/infiniband/uverbsN</code>，N从0开始，有几个RDMA设备就有几个<code>uverbsN</code>设备文件。如果只有一个那就是<code>/dev/infiniband/uverbs0</code>。用户态RDMA程序要实现针对RDMA完成队列的异步消息处理，就是采用Linux提供的epoll机制，对RDMA的<code>uverbsN</code>设备文件进行异步查询，在完成队列有新消息时通知用户态RDMA程序来处理消息。</p>
+
+<p>关于RDMA的封装，这块工作我们还没有完成，我们打算把RDMA的safe封装以及对RDMA的共享内存管理都实现，这样才能方便地使用Rust进行RDMA编程，同时我们欢迎有感兴趣的朋友一起参与。</p>
+]]></content:encoded></item><item><title>建立 Async Rust 的共同愿景</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/async-vision-doc.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='建立_async_rust_的共同愿景'>建立 Async Rust 的共同愿景</h1>
+
+<p>译者：<a href='https://github.com/NiZerin'>NiZerin</a></p>
+
+<p>&gt; &gt; 原文链接：<a href='https://blog.rust-lang.org/2021/03/18/async-vision-doc.html'>https://blog.rust-lang.org/2021/03/18/async-vision-doc.html</a></p>
+
+<h2 id=''></h2>
+
+<p>2021年3月18日·Niko Matsakis 代表 <a href='https://rust-lang.github.io/wg-async-foundations/'>Async Foundations Working Group</a></p>
+
+<p>在 <a href='https://rust-lang.github.io/wg-async-foundations/'>异步基础工作组</a> 认为 Rust 能够成为最热门的选择之一为构建分布式系统，从嵌入式设备到基础云服务。无论他们将其用于什么，我们都希望所有开发人员都喜欢使用 Async Rust。为了实现这一点，我们需要将 Async Rust 移至目前的“MVP”状态之外，并使所有人都可以使用它。</p>
+
+<p>我们正在开展合作，为 Async Rust 构建共享的 <a href='https://rust-lang.github.io/wg-async-foundations/vision.html#-the-vision'>愿景文档</a> 。<code>我们的目标是让整个社区参与到集体的想象中</code>：我们如何才能使使用异步 I/O 的端到端体验不仅是一种务实的选择，而且是一种快乐的选择？</p>
+
+<h3 id='愿景文件始于现状...'>愿景文件始于现状...</h3>
+
+<p>“视觉文档”以一连串字符开头。每个角色都取决于由其背景决定的特定 Rust 值（例如，性能，生产率等）；这种背景也告诉了他们使用 Rust 时所带来的期望。</p>
+
+<p>让我向您介绍一个角色，<a href='https://rust-lang.github.io/wg-async-foundations/vision/characters/grace.html'>格蕾丝（Grace）</a> 。作为一名经验丰富的 C 开发人员，Grace 习惯了高性能和控制能力，但是她喜欢使用 Rust 获得内存安全性的想法。这是她的传记：</p>
+
+<p>&gt; &gt; Grace 从事 C 和 C++ 的编写已经有很多年了。她习惯于破解许多底层细节，以哄骗自己的代码获得最大的性能。她还经历了由于 C 中的内存错误而导致的史诗般的调试会话。她对 Rust 感兴趣：她喜欢这样的想法：获得与 C 相同的控制和性能，但又从内存安全性中获得了生产力上的好处。她目前正在尝试将 Rust 引入她正在使用的某些系统中，并且她还在考虑将 Rust 用于一些新项目。</p>
+
+<p>对于每个角色，我们都会编写一系列<a href='https://rust-lang.github.io/wg-async-foundations/vision/status_quo.html'>“现状”故事</a> ，描述他们在尝试实现目标时面临的挑战（通常以戏剧性的方式失败！）。这些故事不是虚构的。它们是对使用 Async Rust 的人们的真实体验的综合，这是通过访谈，博客文章和推文向我们报告的。为了给您一个想法，我们目前有两个示例：一个示例，其中<a href='https://rust-lang.github.io/wg-async-foundations/vision/status_quo/grace_deploys_her_service.html'>Grace必须调试她编写的自定义未来</a> ，而另一个示例中，Alan（来自GC语言的程序员）<a href='https://rust-lang.github.io/wg-async-foundations/vision/status_quo/alan_runs_into_stack_trouble.html'>遇到堆栈溢出并必须调试原因</a> 。</p>
+
+<p>编写“现状”故事有助于我们弥补<a href='https://en.wikipedia.org/wiki/Curse_of_knowledge'>知识的诅咒</a> ：从事 Async Rust 工作的人们往往是 Async Rust 的专家。我们已经习惯了提高生产效率所需的<a href='https://github.com/rust-lang/async-book/tree/a927107bfe501a44dde1560a5942b1471c11c71d/src/07_workarounds'>解决方法</a> ，并且我们知道一些小技巧可以帮助您摆脱困境。这些故事可帮助我们评估所有剪纸对仍在学习中的人所产生的累积影响。这为我们提供了我们需要确定优先级的数据。</p>
+
+<h3 id='然后告诉我们我们将如何对其进行更改'>然后告诉我们我们将如何对其进行更改</h3>
+
+<p>当然，愿景文档的最终目标不仅是告诉我们我们现在在哪里，而且还要告诉我们我们要去往何处以及如何到达那里。一旦我们在现状故事方面取得了良好进展，下一步将是开始集思广益地讨论<a href='https://rust-lang.github.io/wg-async-foundations/vision/shiny_future.html'>“光明的未来”</a> 的故事。</p>
+
+<p>闪亮的未来故事讲述了异步世界在未来2或3年后会是什么样。通常，他们将重播与“现状”故事相同的场景，但结局会更好。例如，也许格蕾丝（Grace）可以使用调试工具，该工具能够诊断卡住的任务并告诉她阻止任务的未来类型，因此她不必遍历日志。也许编译器可以警告Alan有关可能的堆栈溢出的信息，或者（更好的是）我们可以调整设计以select首先避免出现此问题。这个想法是雄心勃勃的，并且首先将重点放在我们要创建的用户体验上；我们将找出整个过程中的步骤（如果需要的话，还可以调整目标）。</p>
+
+<h3 id='让整个社区参与'>让整个社区参与</h3>
+
+<p>异步愿景文档提供了一个论坛，在该论坛上，Async Rust 社区可以为 Async Rust 用户规划出色的整体体验。Async Rust 的设计初衷是不具有“一刀切”的思维方式，我们也不想改变这种状况。我们的目标是为端到端体验建立一个共同的愿景，同时保留我们已建立的松散耦合，面向探索的生态系统。</p>
+
+<p>我们用于编写愿景文档的过程鼓励积极协作和“积极的总和”思考。它从集思广益期开始，在此期间，我们旨在收集尽可能多的“现状”和“光明的未来”故事。这个头脑风暴期持续了六个星期，直到四月底。在前两个星期（直到2021-04-02），我们仅收集“现状”故事。之后，我们将接受“现状”和“光明的未来”这两个故事，直到头脑风暴期结束为止。最后，帽从头脑风暴时期，我们将选择优胜者奖项，如“最幽默的故事”或“必须扶持贡献者”。</p>
+
+<p>头脑风暴期结束后，工作组负责人将开始着手将各种故事和光明的未来汇编成一个连贯的草案。该草案将由社区和 Rust 团队进行审查，并根据反馈进行调整。</p>
+
+<h3 id='想帮忙？'>想帮忙？</h3>
+
+<p>如果您想帮助我们编写愿景文档，我们很乐意为您贡献自己的经验和愿景！目前，我们专注于创建现状故事。我们正在寻找人们撰写 PR 或谈论他们在问题或其他方面的经验。如果您想开始使用，请查看有关<a href='https://rust-lang.github.io/wg-async-foundations/vision/status_quo/template.html'>现状故事的模板</a> -它具有打开 PR 所需的所有信息。另外，您可以查看<a href='https://rust-lang.github.io/wg-async-foundations/vision/how_to_vision.html'>“如何实现愿景”</a> 页面，其中详细介绍了整个愿景文档过程。</p>
+]]></content:encoded></item><item><title>Niko | 我们的 AWS Rust 团队将如何为 Rust 未来的成功做出贡献</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/how-our-aws-rust-team-will-contribute-to-rusts-future-successes.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='我们的_aws_rust_团队将如何为_rust_未来的成功做出贡献'>我们的 AWS Rust 团队将如何为 Rust 未来的成功做出贡献</h1>
+
+<p>译者：<a href='https://github.com/NiZerin'>NiZerin</a></p>
+
+<p>&gt; &gt; 原文链接：<a href='https://aws.amazon.com/cn/blogs/opensource/how-our-aws-rust-team-will-contribute-to-rusts-future-successes/'>How our AWS Rust team will contribute to Rust’s future successes</a></p>
+
+<h2 id=''></h2>
+
+<p>自今年年初以来，AWS Rust 团队一直在起草我们的章程和宗旨。 章程和宗旨是 AWS 团队用来定义我们的范围和优先事项的框架。 章程告诉你的团队该做什么，宗旨告诉你的团队将如何做到这一点。 由于我们的团队宗旨一直是公开和透明运作的，我们想与您分享我们的章程和宗旨，我们希望您知道我们在做什么。</p>
+
+<p>起草我们的章程很容易。 这只是一句话：AWS Rust 团队致力于让 Rust 为其所有用户提供高效、可靠的服务。 说得够多了！ 然而，撰写这些宗旨需要更多的工作。</p>
+
+<p>等等，AWS 有个 Rust 小组？</p>
+
+<p>是的! 事实上，至少从 2017 年开始，AWS 就在多项服务中使用 Rust。 例如，用 Rust 编写的 Firecracker 于 2018 年推出，提供支持 AWS Lambda 和其他无服务器产品的开源虚拟化技术。 最近，AWS 发布了用 Rust 编写的基于 Linux 的容器操作系统 Bottlerocket ，Amazon Elastic Compute Cloud(Amazon EC2) 团队使用 Rust 作为新的 AWS Nitro 系统组件(包括 Nitro Enclaves 等敏感应用程序)的首选语言。 随着在 AWS 中采用 Rust 的增长，我们对 Rust 项目和社区的投资也在增加。 2019年，AWS 宣布赞助 Rust 项目。 2020年，AWS 开始打造 Rust 维护者和贡献者团队，2021年，AWS 联合其他 Rust 用户和 Rust 项目发起了 Rust 基金会。 AWS Rust 团队首先找出了如何最好地与 AWS 和更广泛的开源社区建立联系。 我们知道，我们希望在公开的环境下运作，并成为整个社会的一份子。 与此同时，我们知道我们想要充分利用在 AWS 工作的机会。 起草章程和宗旨是我们找到两者兼顾的方法和过程的一部分。</p>
+
+<h3 id='我们的宗旨'>我们的宗旨</h3>
+
+<p>在 AWS，开发人员对每件事都起草宗旨。 它们是传达团队、项目或其他类型的一种有效方式。 作为 AWS 的新手，我们中的一位(Niko)刚刚开始学习 Rust，他真的很着迷。 你可能会开始看到它们出现在各式各样的地方。 下面的每个原则都包含了一个核心信念或原则，这些信念或原则将指导我们团队的决策。 它们特定于我们的团队，帮助我们专注于交付价值。 这些宗旨不是用来写了就忘的。 它们在日常运营中被积极的使用，帮助指导我们找出如何解决权衡问题的方法。</p>
+
+<h4 id='宗旨0：我们是一个_aws_团队。'>宗旨0：我们是一个 AWS 团队。</h4>
+
+<p>&gt; &gt; 我们是 AWS 团队。 &gt; 我们主导了用于在云中构建运营服务的工具和开发机制。 &gt; 我们利用我们与 AWS 服务的近在咫尺来收集帮助我们改进 Rust 的见解。</p>
+
+<p>Rust 一直受益于它是一种“实践者”的语言。 起初，Rust 使用 Servo 项目来指导它；浏览器有非常苛刻的性能要求，因此将语言推向了许多有趣的方向。 随着 Rust 采用率的增长，由此产生的反馈帮助将 Rust 扩展到越来越多的领域。 为此，我们希望该团队充分利用 AWS 提供的功能。 在 AWS，Rust 被用于提供各种服务，例如 Amazon Simple Storage Service(Amazon S3)、Amazon Elastic Compute Cloud(Amazon EC2)、Amazon CloudFront 等。 我们可以与这些团队密切合作，了解哪些工作做得很好，哪些需要改进，然后将这些经验带回 Rust。 我们还可以与正在部署 Rust 内置系统的 AWS 客户合作，了解他们的需求。 这个宗旨还有另一个关键点。 作为一个 AWS 团队，我们有一个重点。 我们将自己的角色--与 Rust 社区中的其他人一起--视为帮助改进 Rust for the Cloud。 这是我们最了解的。 我们也很高兴看到 Rust 在所有其他领域都在增长，但我们认为最好是其他人在这方面发挥带头作用，由我们的团队担任辅助角色。</p>
+
+<h4 id='宗旨1：我们是一个开放团队。'>宗旨1：我们是一个开放团队。</h4>
+
+<p>&gt; &gt; 我们是一个开放团队。 &gt; 分享和协作我们的设计可以提高我们团队的质量和价值，包括 AWS。</p>
+
+<p>我们是 AWS 团队，但我们也是 Rust 的贡献者，这一宗旨意味着我们将本着开放和透明的精神运营。 例如，Niko 计划在想法完全成型之前继续在他的 BaySteps 博客上发布想法，他指望 Rust 社区继续在这些想法上探索。</p>
+
+<h4 id='宗旨2：我们帮助_rust_团队兑现承诺。'>宗旨2：我们帮助 Rust 团队兑现承诺。</h4>
+
+<p>&gt; &gt; 我们帮助 Rust 团队兑现承诺。 &gt; 我们和 Rust 团队的使命一样，不仅要使系统编程高效、安全和多产，而且要让新的开发者能够轻易上手。</p>
+
+<p>我们热爱 Rust，因为它专注于使人们能够构建具有强大安全保证的高性能、并发系统。</p>
+
+<ul>
+<li>一种系统级语言</li>
+
+<li>快速、并发、安全</li>
+</ul>
+
+<p>然而，除了它的技术属性之外，Rust 的另一个核心价值对我们来说非常重要：可访问性。 我们所说的可访问性，是指积极寻找进入壁垒，并拆除它们。 有时这些障碍是技术性的，而另一些时候，这些障碍是社会障碍。 无论哪种方式，我们都认同 Rust 的信念，即向更广泛的开发者开放系统编程。</p>
+
+<h4 id='宗旨3：我们支持我们所在的社区。'>宗旨3：我们支持我们所在的社区。</h4>
+
+<p>&gt; &gt; 我们支持我们所在的社区。 &gt; 我们做自己份内的“必要的事情”，比如对问题进行分类，整理积压工作，指导其他贡献者并让他们参与进来，参与设计讨论，以及修复错误。</p>
+
+<p>开源需要的不仅仅是程序员。 有很多工作要做；这并不总是很有趣，但很重要。 这一宗旨与第一个宗旨(“我们是AWS团队”)相辅相成。 在讨论这一原则时，我们提到了我们在云方面拥有第一手专业知识，但我们还希望其他领域能够起到带头作用。 这一宗旨是说，我们将帮助支持领导这项工作的人们，无论是通过审查、指导，还是仅仅通过参与讨论和提出我们的两点意见。</p>
+
+<h4 id='宗旨4：我们帮助连接_aws_和_rust_生态系统。'>宗旨4：我们帮助连接 AWS 和 Rust 生态系统。</h4>
+
+<p>&gt; &gt; 我们帮助连接 AWS 和 Rust 生态系统。 &gt; 我们帮助 AWS 团队驾驭 All Things Rust，并促进他们积极参与他们所依赖的项目。</p>
+
+<p>我们的部分工作是将其他 AWS 团队与 Rust 生态系统和 Rust 项目联系起来。 我们希望所有使用 Rust 的 AWS 开发人员都能参与维护和改进我们使用的库或编译器本身。 这一努力将会带来大量的好处。 当然，这将有助于维持库，并将确定优化或其他改进的机会，从而使我们的 AWS 服务受益。 双赢。</p>
+
+<h4 id='宗旨5：我们专注于我们最了解的事情；我们不会尝试做每件事。'>宗旨5：我们专注于我们最了解的事情；我们不会尝试做每件事。</h4>
+
+<p>&gt; &gt; 我们专注于我们最了解的事情；我们不会尝试做每一件事。 &gt; 我们的团队包括 Rust 编译器、语言设计和 Tokio 堆栈方面的领导者，这些都是我们能够产生最大影响的领域。</p>
+
+<p>这篇关于比较优势的文章有一个主题--我们的团队将专注于我们最擅长的事情，并支持其他人做同样的事情。 不过，这一原则的要点是强调句子中的“焦点”一词。 我们很容易把自己分散得太细，无法提供高价值，我们真的希望我们的团队避免这种情况。</p>
+
+<h4 id='除非你知道更好的…'>除非你知道更好的…</h4>
+
+<p>传统上，每条宗旨都以“除非你知道更好的信条”开头。 这个想法是，宗旨总是随着环境的变化而变化。 这些是我们目前的宗旨，我们希望随着我们更多地了解 AWS 和 Rust 社区合作的最佳方式，它们会不断发展。</p>
+]]></content:encoded></item><item><title>no_std 环境下的可执行文件</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/no_std_binary.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='no_std_环境下的可执行文件'><code>no_std</code> 环境下的可执行文件</h1>
+
+<p>作者: 吴翱翔@pymongo / 后期编辑： 张汉东</p>
+
+<p>&gt; &gt; 原文: <a href='https://pymongo.github.io/#/2021/03/statically_linked_executable.md'>no_std binary(static link)</a></p>
+
+<h2 id='引子'>引子</h2>
+
+<p>用 mac/windows 的读者可以试试<code>gcc -nostdlib main.c</code>能不能编译通过，</p>
+
+<p>如果连C语言的 no<em>std 可执行文件都编译不了，那 Rust 的 no</em>std 环境也不能编译可执行文件.</p>
+
+<p>目前无论是C语言还是 Rust, 仅在 linux 系统下能编译 no<em>std 的可执行文件，用 mac 或 windows 系统的读者要装 linux 虚拟机才能学习 no</em>std</p>
+
+<p>mac/windows 都能编译 no<em>std 的 library,但是 mac 运行 no</em>std 的 binary 会报错<code>illegal hardware instruction</code></p>
+
+<p>RustChinaConf 2020的<a href='https://www.bilibili.com/video/BV1Yy4y1e7zR?p=12'>Rust, RISC-V和智能合约</a>中展示了一个 Rust 最简单的 no_std 可执行文件</p>
+
+<p>我私下问过该topic演讲嘉宾，为什么 PPT 上的 no_std 代码在 mac 上运行会报错<code>illegal hardware instruction</code></p>
+
+<p>嘉宾建议我在 linux 系统下运行，我换 linux 后果然就正常运行了</p>
+
+<p>no<em>std 可执行文件意味着不能依赖操作系统的动态链接库，意味着可执行文件将是纯 statically</em>linked_executable</p>
+
+<p>推荐这个 <a href='https://fasterthanli.me/series/making-our-own-executable-packer'>Making our own executable packer</a>(linux) 系列文章:</p>
+
+<p>在介绍Rust如何编译运行 no<em>std 的可执行文件之前，先看看汇编和 C/C++ 是如何编译 no</em>std 的可执行文件</p>
+
+<h2 id='汇编语言编译可执行文件'>汇编语言编译可执行文件</h2>
+
+<p>x86 汇编主要有两种语法，一是 Unix 的 AT&amp;T syntax，另一个则是 windows 的 Intel syntax</p>
+
+<p>由于 AT&amp;T 有贝尔实验室，而 Unix 操作系统和 C 语言都是贝尔实验室发明的，所以 linux 的 gcc 和 as 都用 AT&amp;T 汇编语法</p>
+
+<p>如果想用 Intel 汇编语法可以用 llvm 或 nasm 工具</p>
+
+<p>rustc 生成的汇编默认是 Intel 语法，可以传入 llvm 参数让 rustc 生成 AT&amp;T 语法的汇编代码</p>
+
+<p>&gt; &gt; rustc --emit asm -C llvm-args=-x86-asm-syntax=att main.rs</p>
+
+<p>以这个网站<a href='https://cs.lmu.edu/~ray/notes/gasexamples/'>GNU Assembler Examples</a> 介绍的第一段汇编代码为准</p>
+
+<p>编译运行这段代码有两个方法:</p>
+
+<p>&gt; &gt; gcc -c s.s &amp;&amp; ld s.o &amp;&amp; ./a.out</p>
+
+<p>或者用as工具(GNU assembler (GNU Binutils))</p>
+
+<p>&gt; &gt; as s.s &amp;&amp; ld s.o &amp;&amp; ./a.out</p>
+
+<p>可以用ldd工具校验编译生成的可执行文件是不是 statically linked (没有引入任何动态链接库)</p>
+
+<p>汇编的劣势在于代码跟硬件架构绑定，gcc 编译这段代码时加上<code>-m32</code>参数指定生成32位的可执行文件时就会报错</p>
+
+<h2 id='c_编译_no_std_可执行文件'>C 编译 no_std 可执行文件</h2>
+
+<p>用<code>gcc -nostdlib</code>参数很容易生成无动态链接库的可执行文件</p>
+
+<pre><code class="language-`">[w@w-manjaro temp]$ echo &quot;int main(){return 0;}&quot; &gt; main.c &amp;&amp; gcc -nostdlib main.c &amp;&amp; ldd ./a.out
+/usr/bin/ld: warning: cannot find entry symbol _start; defaulting to 0000000000001000
+        statically linked</code></pre>
+
+<p>C 在 no<em>std 的环境下程序的入口函数名字不能是 main,要改成 \</em>start</p>
+
+<pre><code class="language-`">[w@w-manjaro temp]$ echo &quot;int _start(){return 0;}&quot; &gt; main.c &amp;&amp; gcc -nostdlib main.c &amp;&amp; ldd ./a.out
+        statically linked</code></pre>
+
+<p>当然也可以让 gcc 加上<code>-m32</code>参数生成32位的可执行文件</p>
+
+<h2 id='rust_编译_no_std_可执行文件'>Rust 编译 no_std 可执行文件</h2>
+
+<pre><code class="language-`rust">#![no_std]
+#![no_main]
+#![feature(lang_items,asm)]
+
+/// entry_point/start_address of process, since the linker looks for a function named `_start` by default
+#[no_mangle]
+extern &quot;C&quot; fn _start() -&gt; ! {
+    exit(0); // macOS: illegal hardware instruction
+}
+
+fn exit(code: isize) -&gt; ! {
+    unsafe {
+        asm!(
+            &quot;syscall&quot;,
+            in(&quot;rax&quot;) 60, // exit
+            in(&quot;rdi&quot;) code,
+            options(noreturn)
+        );
+    }
+}
+
+#[lang = &quot;eh_personality&quot;]
+extern &quot;C&quot; fn eh_personality() {}
+
+#[panic_handler]
+fn my_panic(_info: &amp;core::panic::PanicInfo) -&gt; ! {
+    loop {}
+}</code></pre>
+
+<p>源码在我<a href='https://github.com/pymongo/no_std_binary/blob/main/main.rs'>这个仓库</a>，linux 下的编译方法:</p>
+
+<p>&gt; &gt; rustc -C link-arg=-nostartfiles main.rs</p>
+
+<p>或者将以下两行写到<code>.cargo/config.toml</code>中</p>
+
+<pre><code class="language-`">[target.&#8217;cfg(target_os = &quot;linux&quot;)&#8217;]
+rustflags = [&quot;-C&quot;, &quot;link-arg=-nostartfiles&quot;]</code></pre>
+
+<hr><h2 id='总结'>总结</h2>
+
+<p>当前 Rust 的 no<em>std 生态仅在 linux 上比较完善，Rust/C/C++ 在 no</em>std 环境下想要打印<code>Hello World</code>还得用汇编指令 syscall 系统调用，需要开发者对汇编语言和操作系统有一定的了解才能在 no_std 环境下开发</p>
+]]></content:encoded></item><item><title>用 Rust 写智能合约 | Hello, Ink!  </title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/ink.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='用_rust_写智能合约_|_hello,_ink!'>用 Rust 写智能合约 | Hello, Ink!</h1>
+
+<p>作者：李大狗（李骜华）/ 后期编辑： 张汉东</p>
+
+<h2 id=''></h2>
+
+<h2 id='什么是_wasm_智能合约？'>什么是 WASM 智能合约？</h2>
+
+<p>以往，我们谈到智能合约，都是基于 EVM 的 Solidity 智能合约。</p>
+
+<p>目前，随着智能合约技术的发展，出现了一种新的可能性：WASM 智能合约，</p>
+
+<p>WASM 并非一门新的编程语言，而是一种全新的底层二进制语法。</p>
+
+<p>&gt; &gt; WASM（WebAssembly）是一种新的字节码格式，是一种全新的底层二进制语法，它所编译的代码指令体积小，可移植，加载快并兼容WEB的全新格式。WASM可以支持C/C++/RUST/GO等多种语言编写合约后编译出节码，且不同语言有附带丰富的底层标准库可供调用。 &gt; &gt; WASM 的优势： &gt; &gt; 作为一种全新的字节码格式，WASM通过自身的创新和优化，使得在使用其对所支持的语言进行编写后的代码指令具有体积小，可以在运存，硬盘存储，带宽占有上得到更多的优化，在节省了区块链网络资源，也明显的提升了网络传输效率。 &gt; &gt; 在智能合约上使用WASM，也将拥有以上特点，最明显的方面就是占用资源更少，运行合约更快速和稳定，并且网络传输信息更加高效。这可以使得区块链网络上部署更多的智能合约，也可以使得用户在使用智能合约时能获得更好的体验感。 &gt; &gt; ——WASM智能合约优势分析：https://zhuanlan.zhihu.com/p/344347968</p>
+
+<p>从目前的趋势上来看，Substrate、ETH 2.0等公链与多家联盟链，均表示将支持 WASM 智能合约。</p>
+
+<h2 id='可以用什么语言编写_wasm_智能合约？'>可以用什么语言编写 WASM 智能合约？</h2>
+
+<p>Wasm 扩展了智能合同开发者可用的语言系列，包括 Rust、C/C++、C#、Typescript、Haxe 和 Kotlin。这意味着你可以用你熟悉的任何语言编写智能合约。</p>
+
+<p>从适配性上来说，Rust 语言目前与 WASM 智能合约的适配性更好，工具链更全，而且写出来的智能合约更加安全。</p>
+
+<p>所以，本系列将以 Subtrate 上的 Ink! 智能合约为例，开始 WASM 智能合约的 101 课程。</p>
+
+<p>本文对 Ink! 官方教程有所参考：</p>
+
+<p>&gt; &gt; https://substrate.dev/substrate-contracts-workshop</p>
+
+<h2 id='rust_环境配置'>Rust 环境配置</h2>
+
+<h3 id='1.__rust_环境配置'>1.  Rust 环境配置</h3>
+
+<p>在 MacOS 或者 Ubuntu 等 Linux 操作系统上，我们可以通过一行命令很容易的安装 Rust：</p>
+
+<pre><code class="language-`">curl --proto &#8217;=https&#8217; --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+
+<p>除此之外还要安装<code>nightly</code>版本：</p>
+
+<pre><code class="language-`">rustup install nightly</code></pre>
+
+<p>Windows 下的安装，请参考：</p>
+
+<pre><code class="language-`">https://forge.rust-lang.org/infra/other-installation-methods.html</code></pre>
+
+<h3 id='2._将_rust_添加到环境中'>2. 将 Rust 添加到环境中</h3>
+
+<p>将如下语句添加到<code>~/.bashrc</code>或<code>~/.zshrc</code>中：</p>
+
+<pre><code class="language-`">export PATH=~/.cargo/bin:$PATH</code></pre>
+
+<p>然后：</p>
+
+<pre><code class="language-`">source ~/.bashrc # source ~/.zshrc</code></pre>
+
+<h3 id='3._换源'>3. 换源</h3>
+
+<p>通过设置如下环境变量，我们把 Rust 源切换到国内：</p>
+
+<pre><code class="language-`bash">export RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
+export RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup</code></pre>
+
+<p>在<code>~/.cargo/config</code>文件中写入如下内容：</p>
+
+<pre><code class="language-`">[source.crates-io]
+registry = &quot;https://github.com/rust-lang/crates.io-index&quot;
+replace-with = &#8217;ustc&#8217;
+[source.ustc]
+registry = &quot;git://mirrors.ustc.edu.cn/crates.io-index&quot;</code></pre>
+
+<h2 id='ink!_环境配置'>Ink! 环境配置</h2>
+
+<p>在配置了基本的 Rust 环境后，我们可以配置 Ink! 所需的开发环境了。</p>
+
+<pre><code class="language-`bash"># for substrate
+rustup component add rust-src --toolchain nightly
+rustup target add wasm32-unknown-unknown --toolchain stable
+# for canvas node 
+cargo install canvas-node --git https://github.com/paritytech/canvas-node.git --tag v0.1.4 --force --locked
+# for ink!CLI
+cargo install cargo-contract --vers 0.10.0 --force --locked</code></pre>
+
+<p>我们还要安装/升级<code>binaryen</code>，Binaryen 是 WebAssembly 的编译器。</p>
+
+<p>Mac 上安装：</p>
+
+<pre><code class="language-`bash"># for mac
+brew upgrade binaryen # 如果没安装用 brew install</code></pre>
+
+<p>Linux 上安装：</p>
+
+<h2 id='创建一个_ink!_项目'>创建一个 ink! 项目</h2>
+
+<p>执行如下命令：</p>
+
+<pre><code class="language-`">cargo contract new flipper</code></pre>
+
+<p>创建完成后进入文件夹：</p>
+
+<pre><code class="language-`">cd flipper/</code></pre>
+
+<p>合约项目目录结构：</p>
+
+<pre><code class="language-`">flipper
+|
++-- lib.rs                &lt;-- Contract Source Code
+|
++-- Cargo.toml            &lt;-- Rust Dependencies and ink! Configuration
+|
++-- .gitignore</code></pre>
+
+<h2 id='合约测试'>合约测试</h2>
+
+<pre><code class="language-`">cargo +nightly test</code></pre>
+
+<p>一切顺利的话会输出如下结果：</p>
+
+<pre><code class="language-`">$ cargo +nightly test
+    running 2 tests
+    test flipper::tests::it_works ... ok
+    test flipper::tests::default_works ... ok
+
+    test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out</code></pre>
+
+<h2 id='合约编译'>合约编译</h2>
+
+<pre><code class="language-`">cargo +nightly contract build</code></pre>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq16ioatj30mu0n6wj1.jpg' alt='image-20210323213148674' /></p>
+
+<p>如果顺利的话，目录下会生成<code>target/ink</code>文件夹，里面包含如下文件：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq12tx3jj30si04caan.jpg' alt='image-20210323205600627' /></p>
+
+<p>其中，<code>flipper.contract</code> 是部署时要用的合约文件，可以视为<code>solidity</code>合约中的<code>bin</code>文件。</p>
+
+<p><code>metadata.json</code>是元数据，可以视为<code>solidity</code>合约中的<code>abi</code>文件。</p>
+
+<h2 id='合约部署'>合约部署</h2>
+
+<p>通过<code>canvas</code>启动一个本地运行的开发节点！</p>
+
+<pre><code class="language-`">canvas --dev --tmp</code></pre>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq15c98vj30si04caan.jpg' alt='An image of the terminal starting a Substrate node' /></p>
+
+<p>打开如下网址，会这个页面会自动连接本地启动的开发节点：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq17aigpj30wq0ln7cz.jpg' alt='image-20210323210306845' /></p>
+
+<p>上传<code>flipper.contract</code>这个文件：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq19w3y0j30z80iqq48.jpg' alt='Contracts code page for deploying Flipper' /></p>
+
+<p>一路点击进行部署：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq1avddtj31c10u0q6a.jpg' alt='image-20210323210730452' /></p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq17hukij31200qmacj.jpg' alt='image-20210323210747989' /></p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq18snwhj30u00xb40w.jpg' alt='image-20210323210811846' /></p>
+
+<h2 id='合约调用'>合约调用</h2>
+
+<p>点击<code>Execute</code>：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq1bnzbuj30xw0i6jss.jpg' alt='image-20210323210928445' /></p>
+
+<p>选择<code>get():bool</code>函数，点击「调用」：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq18ec75j31ck0u0q6r.jpg' alt='image-20210323211004303' /></p>
+
+<p>返回调用结果：</p>
+
+<p><img src='https://tva1.sinaimg.cn/large/008eGmZEgy1goxq1929ldj30wg0codgq.jpg' alt='image-20210323211027286' /></p>
+
+<h2 id='flipper_源码解读'>Flipper 源码解读</h2>
+
+<pre><code class="language-`rust">// Copyright 2018-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = &quot;std&quot;), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract]
+pub mod flipper {
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        /// Creates a new flipper smart contract initialized with the given value.
+        #[ink(constructor)]
+        pub fn new(init_value: bool) -&gt; Self {
+            Self { value: init_value }
+        }
+
+        /// Creates a new flipper smart contract initialized to `false`.
+        #[ink(constructor)]
+        pub fn default() -&gt; Self {
+            Self::new(Default::default())
+        }
+
+        /// Flips the current value of the Flipper&#8217;s bool.
+        #[ink(message)]
+        pub fn flip(&amp;mut self) {
+            self.value = !self.value;
+        }
+
+        /// Returns the current value of the Flipper&#8217;s bool.
+        #[ink(message)]
+        pub fn get(&amp;self) -&gt; bool {
+            self.value
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn default_works() {
+            let flipper = Flipper::default();
+            assert_eq!(flipper.get(), false);
+        }
+
+        #[test]
+        fn it_works() {
+            let mut flipper = Flipper::new(false);
+            assert_eq!(flipper.get(), false);
+            flipper.flip();
+            assert_eq!(flipper.get(), true);
+        }
+    }
+}</code></pre>
+
+<h3 id='1._cfg_和_cfg_attr_的使用'>1.  <code>cfg</code>和<code>cfg_attr</code>的使用</h3>
+
+<p><code>cfg</code>是 Rust 中的特殊属性， 它允许我们编译基于标志的代码并传递给编译器。</p>
+
+<p>在本合约中，我们可以看到：</p>
+
+<pre><code class="language-`">#[cfg(test)]</code></pre>
+
+<p>这个标识意味着下面的代码是单元测试。</p>
+
+<h3 id='2._impl_关键字'>2. impl 关键字</h3>
+
+<p>&gt; &gt; Implement some functionality for a type. &gt; &gt; 为一种类型做函数实现。</p>
+
+<p>标准的模板是：</p>
+
+<pre><code class="language-`">struct Example {
+    number: i32,
+    # 许多变量……
+}
+
+impl Example {
+    fn boo() {
+        println!(&quot;boo! Example::boo() was called!&quot;);
+    }
+
+    fn answer(&amp;mut self) {
+        self.number += 42;
+    }
+		# 许多函数……
+}</code></pre>
+
+<p>套用到本合约中，首先我们定义本合约的<code>struct</code>：</p>
+
+<pre><code class="language-`">pub struct Flipper {
+	value: bool, # 其中包含一个变量 value
+}</code></pre>
+
+<p>然后对<code>struct</code>进行补充实现：</p>
+
+<pre><code class="language-`">impl Flipper {
+	……
+}</code></pre>
+
+<h3 id='3._#[ink(constructor)]_与_#[ink(message)]'>3.  <code> #[ink(constructor)]</code>与<code>#[ink(message)]</code></h3>
+
+<p><code> #[ink(constructor)]</code>表示这行语句函数是合约的构造函数，相当于<code>solidity</code>合约中的<code>constructor</code>。</p>
+
+<p>&gt; &gt; https://docs.soliditylang.org/en/v0.7.2/contracts.html#constructor</p>
+
+<p><code>#[ink(message)]</code>表示这行语句下面的函数是合约的普通函数，如例子中的<code>get</code>函数：</p>
+
+<pre><code class="language-`">/// Returns the current value of the Flipper&#8217;s bool.
+#[ink(message)]
+pub fn get(&amp;self) -&gt; bool {
+	self.value
+}</code></pre>
+
+<hr><p>作者简介：</p>
+
+<p>李大狗（李骜华），上海对外经贸大学区块链技术与应用研究中心副主任、柏链教育 CTO、FISCO BCOS（微众银行区块链框架）区块链认证讲师、5 年区块链工程师、北京大学硕士。 研究领域包括：区块链系统、共识机制、智能合约、区块链应用、数字身份等。</p>
+]]></content:encoded></item><item><title>「算法」蓄水池算法改进 - 面向抽奖场景保证等概率性</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/reservoir.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='蓄水池算法改进_-_面向抽奖场景保证等概率性'>蓄水池算法改进 - 面向抽奖场景保证等概率性</h1>
+
+<p>作者：huangjj / 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 免责声明：禁止任何个人或团体使用本文研究成果用于实施任何违反中华人民共和国法律法规的活动 &gt; 如有违反，均与本文作者无关</p>
+
+<h2 id=''></h2>
+
+<h2 id='正文'>正文</h2>
+
+<p>在我们通常遇到的抽奖场景，于年会时将所有人的编号都放到箱子里面抽奖，然后每次抽出中奖者 决定奖项。而在这过程中，因为先抽中者已经确定了奖项，然后不能够参与后续的奖项的抽奖；而后 续参与抽奖的人员则其实会以越来越低的概率参与抽奖:</p>
+
+<p>&gt; &gt; 例：在上述场景中共有 \\( n \\) 人参与抽取 \\( m ( \lt n) \\) 个奖项， &gt; &gt; 抽取第一个奖项概率为： \\( { m \over n } \\) &gt; &gt; 那么因为抽了第一个奖项，剩下 \\( n - 1 \\) 人参与 \\( m - 1 \\) 个奖项，被抽中的概率 &gt; 为 \\( m - 1 \over n - 1 \\)。 &gt; 那么 \\( m \lt n \Rightarrow -m \gt -n \Rightarrow mn - m \gt nm - n \Rightarrow m(n-1) \gt n(m - 1) \Rightarrow { m \over n } \gt { m - 1 \over n - 1 }\\)， &gt; 即如果前面的奖项没有抽到，后面抽到奖项的概率会更低。</p>
+
+<p>因此，在人数 \\( n \\) 大于奖项数 \\( m \\) 的时候，我们通过以越来越低的概率干涉前面 已经取得取得奖项的结果，来保证先参与抽奖的人中奖的概率随着人数的增多中奖的概率也变低， 最后中奖的概率为 \\( m \over n \\)。但是在实际场景中，\\( m \\) 个奖项可能不仅相同 （如划分了一二三等奖），因此对于蓄水池算法的改进提出了新的要求：</p>
+
+<ul>
+<li>不论人数多少（当还是要保证有人来参与抽奖 \\( n \gt 1\\) )所有人获得特定奖项的概率相同</li>
+
+<li>每当新来一人参与抽奖时，如果他没有中奖，可以即场告知未中</li>
+</ul>
+
+<h2 id='算法描述与等概率性证明'>算法描述与等概率性证明</h2>
+
+<p>我们分两种情况讨论：</p>
+
+<ul>
+<li>一种是当人数不足以覆盖所有的奖项的场景（ \\(n \lt m \\) )，</li>
+
+<li>另外一种是当抽奖人数远大于所有奖项加起来的数目。（ \\( n \gt m \\)）。</li>
+</ul>
+
+<p>然后我们再回来看看能不能找到一种很方便的方法桥接两种情况。</p>
+
+<p>同时，我们假设 \\( m \\) 个奖项两两互不相同。</p>
+
+<h3 id='抽奖人数不足时（_\\(n_\lt_m_\\)_)'>抽奖人数不足时（ \\(n \lt m \\) )</h3>
+
+<p>因为当人数不足时，所有参与者都能抽奖，因此我们要保证每个人获得特定奖项的概率为 \\( 1 \over m \\)。 算法描述：</p>
+
+<p>&gt; &gt; 记 \\( Choosen \\) 为容量为 \\( m \\) 的数组， &gt; \\( Choosen\[k] (1 \le k \le m) \\) 表示第 k 个奖项的当前占有情况， &gt; 初始值为 \\( None \\), &gt; &gt; \\( Players \\) 为参与参与抽奖的人的序列 &gt; &gt; 1. 令 \\( i := 1 \\)，当 \\( i \le n \\) 时，做如下操作： &gt;    * 产生随机数 \\( r<em>1 (1 \le r</em>1 \le i) \\) &gt;    * 如果 \\( r<em>1 \lt i \\)，\\( Choosen\[i] := Choosen\[r</em>1] \\) &gt;    * \\( Choosen\[r_1] := Players\[i] \\) &gt;    * \\( i := i + 1 \\) &gt; 1. 当 \\( i \le m \\) 时，做如下操作： &gt;    * 产生随机数 \\( r<em>2 (1 \le r</em>2 \le i) \\) &gt;    * 如果 \\( r_2 \lt i \\): &gt;      * \\( Choosen\[i] := Choosen\[r_2] \\) &gt;      * \\( Choosen\[r_2] := None \\) &gt;    * \\( i := i + 1 \\)</p>
+
+<h4 id='等概率性证明'>等概率性证明</h4>
+
+<p>我们先证明，在填入中奖者的第 \\( k (1 \le k \le m) \\) 轮过程中，能够保证对于前 \\( k \\) 个奖项中的每一个奖项，每一位中奖者抽中其中第 \\( i (1 \le i \le k) \\) 个奖项的概率为 \\(1 \over k \\)，证明如下：</p>
+
+<p>我们采用数学归纳法来证明：</p>
+
+<ol type="1">
+<li><strong>奠基</strong>：当 \\( k = 1 \\) 时，易知该中奖者一定会抽中第一个奖项，前一个奖项中只有第一个 选项，所以此时每一位中奖者抽中第 \\( k = 1 \\) 的概率为 \\( 1 = { 1 \over 1 } = { 1 \over k } \\);</li>
+
+<li>
+<p><strong>归纳</strong>:</p>
+
+<ul>
+<li>假设当 \\(k = j (1 \le j \lt m) \\)时，每一位抽奖者抽中第 \\( i (1 \le i \le j) \\)的概率为 \\( 1 \over j \\)</li>
+
+<li>当 \\( k = j + 1 \\), 有：</li>
+
+<li>第 \\( j + 1 \\) 位抽奖着抽中任意第 \\( i&#8217; (1 \le i&#8217; \le j + 1) \\) 个奖项的概率为 \\( 1 \over { j + 1 } \\) （假设产生的随机数 \\( r<em>1、r</em>2 \\) 足够的均匀）;</li>
+
+<li>对于前 \\( j \\) 位抽奖者，每一位都有 \\( 1 \over { j + 1 } \\)，的概率将自己的奖项更换位第 \\( j + 1 \\)个奖项；</li>
+
+<li>对于前 \\( j \\) 位抽奖者，每一位依然占有原有第 \\( i&#8217; \\) 个奖项的概率为：</li>
+</ul>
+</li>
+</ol>
+
+<p>\\\[ \begin{equation} \\begin{aligned} P\\{前 j 位抽奖者 j + 1 轮中仍然持有 i&#8217; \\} &amp; = P\\{前 j 位抽奖者j轮已经持有 i&#8217; \\} \cdot P\\{第 j + 1 位抽奖者没有抽中 i&#8217; \\} \\\\ &amp; = P\\{前 j 位抽奖者j轮已经持有 i&#8217; \\} \cdot (1 - P\\{第 j + 1 位抽奖者抽中 i&#8217; \\}) \\\\ &amp; = \frac{1}{j} \cdot (1 - \frac{1}{j+1}) \\\\ &amp; = \frac{1}{j} \cdot \frac{j}{j+1} \\\\ &amp; = \frac{1}{j + 1} \\\\ &amp; = \frac{1}{k} \\\\ \\end{aligned} \\label{1.1} \tag{1.1} \\end{equation} \\]</p>
+
+<p>由上，可知每一轮迭代之后，前 \\( k \\) 个奖项对于已经参与的 \\( k \\)中奖者来说抽中的概率均等，为 \\( 1 \over k \\)， 故到了第 \\( n \\) 轮操作后，我们可以通过不断填充 \\( None \\)值来稀释概率，最后达到 \\( 1 \over m \\) 的等概率性。</p>
+
+<p>特殊地，当 \\( n == m \\) 时，每个抽奖者抽到特定奖项的概率也为 \\(1 \over n \\)。</p>
+
+<h3 id='抽奖人数足够多时（_\\(n_\gt_m_\\)_)'>抽奖人数足够多时（ \\(n \gt m \\) )</h3>
+
+<p>类似地，当 \\(n \gt m \\)时，对于每一个抽奖序号 \\( k \gt m \\) 的抽奖者，我们生成随机数 \\( r<em>3(1 \le r</em>3 \le n) \\)，并且在 \\( r_3 \le m \\) 的时候，替换对应原本占有奖项的抽奖者；可以证明在这种情况下，能保证每个人抽到特定奖项的概率为 \\(1 \over n \\)[^1]。</p>
+
+<h3 id='整合后的算法'>整合后的算法</h3>
+
+<p>&gt; &gt; 记 \\( Choosen \\) 为容量为 \\( m \\) 的数组， &gt; \\( Choosen\[k] (1 \le k \le m) \\) 表示第 \\( k \\) 个奖项的当前占有情况， &gt; 初始值为 \\( None \\), &gt; &gt; \\( replaced \\) 为原本已经中奖，但是被人替换的抽奖者 &gt; &gt; \\( Players \\) 为参与参与抽奖的人的序列，每次只能获取一个 \\( player \\) &gt; &gt; 记 \\( n := 0 \\)为当前参与抽奖的人数 &gt; &gt; 1. 在抽奖结束前，每次遇到一个新的 \\( player \\) 执行以下操作： &gt;    * \\( placed := None \\) &gt;    * \\( n := n + 1 \\) &gt;    * 产生随机数 \\( r (1 \le r \le n) \\) &gt;    * 如果 \\( r \le m \\)： &gt;      * \\( replaced := Choosen\[r] \\) &gt;      * \\( Choosen\[r] := player \\) &gt;    * 如果 \\( r \lt n \\) 并且 \\( n \le m \\)： &gt;      * \\( Choosen\[n] := replaced \\) &gt; 1. 在抽奖结束时，如果 \\( n \lt m \\), 执行以下操作： &gt;    * \\( i := n \\) &gt;    * 当 \\( i \lt m \\)时，重复执行以下操作： &gt;      * \\( i := i + 1 \\) &gt;      * 产生随机数 \\( r<em>2 (1 \le r</em>2 \le i) \\) &gt;      * 如果 \\( r_2 \lt i \\): &gt;        * \\( Choosen\[i] := Choosen\[r_2] \\) &gt;        * \\( Choosen\[r_2] := None \\)</p>
+
+<h2 id='程序实现'>程序实现</h2>
+
+<h3 id='rust'>Rust</h3>
+
+<p>作者偏好 <a href='https://kaisery.gitbooks.io/trpl-zh-cn/'>Rust 编程语言</a>，故使用 Rust 实现。</p>
+
+<h4 id='特质（trait）'>特质（trait）</h4>
+
+<p>Rust 中的<a href='https://kaisery.gitbooks.io/trpl-zh-cn/ch10-02-traits.html'>特质（trait）</a> 是其用于复用行为抽象的特性，尽管比起 Java 或 C# 的接口 （Interface）更加强大，但在此文中， 熟悉 Java/C# 的读者把特质视作接口就可以了。</p>
+
+<h3 id='建模与实现'>建模与实现</h3>
+
+<p>本文使用面向对象（Object-Oriented）编程范式[^2]来进行抽象，如下所示：</p>
+
+<pre><code class="language-`rs">extern crate rand;
+use rand::random;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+trait ReservoirSampler {
+    // 每种抽样器只会在一种总体中抽样，而总体中所有个体都属于相同类型
+    type Item;
+
+    // 流式采样器无法知道总体数据有多少个样本，因此只逐个处理，并返回是否将样本纳入
+    // 样本池的结果，以及可能被替换出来的样本
+    fn sample(&amp;mut self, it: Self::Item) -&gt; (bool, Option&lt;Self::Item&gt;);
+
+    // 任意时候应当知道当前蓄水池的状态
+    fn samples(&amp;self) -&gt; &amp;[Option&lt;Self::Item&gt;];
+}
+
+struct Lottery&lt;P&gt; {
+    // 记录当前参与的总人数
+    total: usize,
+
+    // 奖品的名称与人数
+    prices: Vec&lt;Price&gt;,
+
+    // 当前的幸运儿
+    lucky: Vec&lt;Option&lt;P&gt;&gt;,
+}
+
+#[derive(Clone, Debug)]
+struct Price {
+    name: String,
+    cap: usize,
+}
+
+impl&lt;P&gt; ReservoirSampler for Lottery&lt;P&gt; {
+    type Item = P;
+
+    fn sample(&amp;mut self, it: Self::Item) -&gt; (bool, Option&lt;Self::Item&gt;) {
+        let lucky_cap = self.lucky.capacity();
+
+        self.total += 1;
+
+        // 概率渐小的随机替换
+        let r = random::&lt;usize&gt;() % self.total + 1;
+        let mut replaced = None;
+        if r &lt;= lucky_cap {
+            replaced = self.lucky[r - 1].take();
+            self.lucky[r - 1] = Some(it);
+        }
+
+        if self.total &lt;= lucky_cap &amp;&amp; r &lt; self.total {
+            self.lucky[self.total - 1] = replaced.take();
+        }
+
+        (r &lt;= lucky_cap, replaced)
+    }
+
+    fn samples(&amp;self) -&gt; &amp;[Option&lt;Self::Item&gt;] {
+        &amp;self.lucky[..]
+    }
+}
+
+impl&lt;P: Debug&gt; Lottery&lt;P&gt; {
+    fn release(self) -&gt; Result&lt;Vec&lt;(String, Vec&lt;P&gt;)&gt;, &amp;&#8217;static str&gt; {
+        let lucky_cap = self.lucky.capacity();
+
+        if self.lucky.len() == 0 {
+            return Err(&quot;No one attended to the lottery!&quot;);
+        }
+
+        let mut final_lucky = self.lucky.into_iter().collect::&lt;Vec&lt;Option&lt;P&gt;&gt;&gt;();
+        let mut i = self.total;
+        while i &lt; lucky_cap {
+            i += 1;
+
+            // 概率渐小的随机替换
+            let r = random::&lt;usize&gt;() % i + 1;
+            if r &lt;= lucky_cap {
+                final_lucky[i - 1] = final_lucky[r - 1].take();
+            }
+        }
+        println!(&quot;{:?}&quot;, final_lucky);
+
+        let mut result = Vec::with_capacity(self.prices.len());
+        let mut counted = 0;
+        for p in self.prices {
+            let mut luck = Vec::with_capacity(p.cap);
+
+            for i in 0 .. p.cap {
+                if let Some(it) = final_lucky[counted + i].take() {
+                    luck.push(it);
+                }
+            }
+
+            result.push((p.name, luck));
+            counted += p.cap;
+        }
+
+        Ok(result)
+    }
+}
+
+// 构建者模式（Builder Pattern），将所有可能的初始化行为提取到单独的构建者结构中，以保证初始化
+// 后的对象(Target)的数据可靠性。此处用以保证所有奖品都确定后才能开始抽奖
+struct LotteryBuilder {
+    prices: Vec&lt;Price&gt;,
+}
+
+impl LotteryBuilder {
+    fn new() -&gt; Self {
+        LotteryBuilder {
+            prices: Vec::new(),
+        }
+    }
+
+    fn add_price(&amp;mut self, name: &amp;str, cap: usize) -&gt; &amp;mut Self {
+        self.prices.push(Price { name: name.into(), cap });
+        self
+    }
+
+    fn build&lt;P: Clone&gt;(&amp;self) -&gt; Lottery&lt;P&gt; {
+        let lucky_cap = self.prices.iter()
+            .map(|p| p.cap)
+            .sum::&lt;usize&gt;();
+
+        Lottery {
+            total: 0,
+            prices: self.prices.clone(),
+            lucky: std::vec::from_elem(Option::&lt;P&gt;::None, lucky_cap),
+        }
+    }
+}
+
+fn main() {
+    let v = vec![8, 1, 1, 9, 2];
+    let mut lottery = LotteryBuilder::new()
+        .add_price(&quot;一等奖&quot;, 1)
+        .add_price(&quot;二等奖&quot;, 1)
+        .add_price(&quot;三等奖&quot;, 5)
+        .build::&lt;usize&gt;();
+
+
+    for it in v {
+        lottery.sample(it);
+        println!(&quot;{:?}&quot;, lottery.samples());
+    }
+
+    println!(&quot;{:?}&quot;, lottery.release().unwrap());
+}</code></pre>
+
+<h2 id='优点'>优点</h2>
+
+<ul>
+<li>流式处理，可以适应任意规模的参与人群</li>
+
+<li>在保证每一位抽奖者都有相同的概率获得特定奖项的同时，还能保证每一个抽奖者的获得的奖项均不相同</li>
+</ul>
+
+<h2 id='缺点'>缺点</h2>
+
+<ul>
+<li>所有参与抽奖的人都必须<strong>依次</strong>经过服务器处理，因为需要获知准确的总人数来保证等概率性。 一个改进的方法是，在人数足够多的时候，将总人数用总人数的特定数量级替代（给后续参加者的 一点点小福利——但是因为总人数足够多，所以总体中奖概率还是很低），在客户端完成中奖的选定</li>
+
+<li><strong>等概率性完全依赖随机数 <code>r</code> 生成</strong>。 因为奖品初始化时不需要考虑打乱顺序，因此如果在 随机这一步被技术破解，使得抽奖者可以选择自己能获取的奖项，则会破坏公平性。改进方案是， 在 <code>release</code> 的时候再一次对奖品顺序进行随机的打乱。</li>
+
+<li>这种抽奖方式还限定了每人只能抽取一次奖品，否则会出现一个人占有多个奖项的情况。</li>
+</ul>
+
+<p><a href='https://huangjj27.gitlab.io/reservoirsampling/#%E5%85%AC%E5%B9%B3%E6%80%A7%E7%AD%89%E6%A6%82%E7%8E%87--frackn--%E6%8A%BD%E5%8F%96-%E8%AF%81%E6%98%8E'>^1]: 可以参考[博主以前的博客</a></p>
+
+<p>[^2]: 作者理解的面向对象 = 对象是交互的最基本单元 + 对象通过相互发送消息进行交互。而特质/接口以及 对象其他公开的方法定义了对象可以向外发送/从外接收的消息。</p>
+
+<h2 id='下一步可能展开的工作'>下一步可能展开的工作</h2>
+
+<p>目前所有抽奖者都按照相等的概率抽奖，而在一些场景下可能按照一些规则给与某些抽奖者优惠 （例如绩效越高的员工中奖概率越大），因此下一步可能考虑如何按照权重赋予每位抽奖者各自的 中奖概率。</p>
+
+<h2 id='致谢'>致谢</h2>
+
+<p>感谢茶壶君（<a href='https://github.com/ksqsf'>@ksqsf</a>）一语惊醒梦中人，清楚明确地表达了需求； 感谢张汉东老师 (<a href='https://github.com/ZhangHanDong'>@ZhangHanDong</a>)老师提点了之后可以开展研究的方向； 感谢在这次讨论中提供意见的其他 Rust 社区的朋友，谢谢你们！</p>
+
+<h2 id='作者介绍'>作者介绍</h2>
+
+<p>huangjj，Rust 爱好者，公众号：坏姐姐日常入门 Rust。</p>
+]]></content:encoded></item><item><title>Rust中使用MySQL</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust-mysql.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「rust入门系列」rust_中使用_mysql'>「Rust入门系列」Rust 中使用 Mysql</h1>
+
+<p>作者：张军军 / 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 这个系列的文章，我计划给大家讲解如何在Rust中使用Mysql作为存储，先从简单的开始，然后在后面展示如何在开发<code>Web api</code>中使用。</p>
+
+<h3 id='数据表'>数据表</h3>
+
+<p>本次我会使用一张订单表<code>order</code>。订单表的具体<code>schema</code>如下。</p>
+
+<pre><code class="language-`sql">CREATE TABLE `student` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(128) NOT NULL,
+  `age` int(11) NOT NULL,
+  `id_card` varchar(128) NOT NULL,
+  `last_update` date NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 插入测试数据
+insert into student (name, age, id_card, last_update) values (&#8217;张三&#8217;, 23, &#8217;123456789X&#8217;, CURRENT_DATE());
+insert into student (name, age, id_card, last_update) values (&#8217;李四&#8217;, 24, &#8217;8382353902&#8217;, CURRENT_DATE())</code></pre>
+
+<h3 id='创建应用程序'>创建应用程序</h3>
+
+<pre><code class="language-`rust">cargo new mysql-test-01</code></pre>
+
+<p>由于要使用<code>Mysql</code>的驱动，所以添加依赖到<code>Cargo.toml</code></p>
+
+<pre><code class="language-`rust">[dependencies]
+mysql = &quot;*&quot; // 通配符*表示可以使用任何版本，通常会拉取最新版本
+chrono = &quot;0.4&quot;</code></pre>
+
+<p>在这里，我使用<code>chrono</code>来处理日期和时间列。具体 可以参考<a href='https://docs.rs/chrono/0.4.19/chrono/'> `https://docs.rs/chrono/0.4.19/chrono/`</a></p>
+
+<h3 id='开始'>开始</h3>
+
+<p>在main.rs中导入命名空间</p>
+
+<pre><code class="language-`rust">use mysql::*;
+use mysql::prelude::*;
+use chrono::prelude::*; // 用来处理日期</code></pre>
+
+<p>获取<code>Mysql</code>连接</p>
+
+<pre><code class="language-`rust">fn main() {
+    let url = &quot;mysql://root:password@localhost:3306/MYDB&quot;;
+    let pool = Pool::new(url).unwrap(); // 获取连接池
+    let mut conn = pool.get_conn().unwrap();// 获取链接
+}</code></pre>
+
+<p>先跑一下，确保可以打开一个连接</p>
+
+<pre><code class="language-`rust">cargo run</code></pre>
+
+<p>第一次下载和编译所有依赖，可能需要一点点时间，看到命令行编译过去了，表示和数据库已经打通了。</p>
+
+<h3 id='流式查询'>流式查询</h3>
+
+<p>流式查询，其实结果数据是逐行读取的。 好处就是，整个数据永远不会存储在内存中，如果要读取大量数据，使用<code>query_iter</code>很好。</p>
+
+<pre><code class="language-`rust"> conn.query_iter(&quot;select * from student&quot;)
+        .unwrap()
+        .for_each(|row| {
+            let r: (i32, String, i32, String, NaiveDate) = from_row(row.unwrap());
+            println!(&quot;{}, {},{},{}, {:?}&quot;, r.0, r.1, r.2, r.3, r.4);
+        });</code></pre>
+
+<p>上面代码中的<code>row</code>的类型是<code>mysql_common::row::Row</code>，这种类型把数据以字节的形式存储。所以这里需要把低级的字节转换成我们想要的类型比如<code>i32,String</code>等，这里我使用了<code>from_row</code>。注意，转换后的数据以元组的形式返回，其中每一项和选择列的顺序相同。</p>
+
+<h3 id='聚合查询结果'>聚合查询结果</h3>
+
+<p>其实， 可以将查询结果收集到Vec中。 Vec中的每个元素都是一个元组。</p>
+
+<pre><code class="language-`rust">// 输出到Vec
+let res: Vec&lt;(i32, String, i32, String, NaiveDate)&gt; =
+	conn.query(&quot;select * from student&quot;).unwrap();
+for r in res {
+    println!(&quot;{}, {},{},{}, {:?}&quot;, r.0, r.1, r.2, r.3, r.4);
+}</code></pre>
+
+<p><code>query</code>函数已经将字节转换为选择的数据类型，因此不需要再转换了。 需要注意的就是，这里必须明确元组的数据类型。 否则，编译器没办法做转换。</p>
+
+<h3 id='结果到结构体'>结果到结构体</h3>
+
+<p>使用元组也可以。 但是我们实际写代码时，数据表列数多，最普遍的做法就是定义一个结构体。比如这里叫<code>Student</code>, 然后，可以使用<code>query_map</code>将查询结果映射到<code>Student</code>对象。这里 不需要置顶元组的数据类型，编译器会自动推导字段类型根据Student类型</p>
+
+<pre><code class="language-`rust">struct Student {
+    id: u64,
+    name: String,
+    age: u16,
+    id_card: String,
+    last_changed_on: NaiveDate,
+}
+
+let res = conn.query_map(
+    &quot;select * from student&quot;,
+    |(id, name, age, id_card, update)| Student {
+        id: id,
+        name: name,
+        age: age,
+        id_card: id_card,
+        last_changed_on: update,
+    },
+).expect(&quot;Query failed.&quot;);
+
+for i in res {
+    println!(
+        &quot;{}, {},{},{}, {:?}&quot;,
+        i.id, i.name, i.age, i.id_card, i.last_changed_on
+    )
+}</code></pre>
+
+<h3 id='单条数据查询'>单条数据查询</h3>
+
+<p>查询特定数据行，可能会出现下面几种情况</p>
+
+<ul>
+<li>找到，返回实际数据</li>
+
+<li>没有找到行</li>
+
+<li>发生错误</li>
+</ul>
+
+<p>所以，使用query_first函数返回的是Option的结果。 需要将其解包两次才可以获取实际的行数据。</p>
+
+<pre><code class="language-`rust"> // 条件查询，查询单个数据
+let res = conn.query_first(&quot;select * from student where name = &#8217;张三&#8217;&quot;)
+.map(
+    // Unpack Result
+    |row| {
+        row.map(|(id, name, age, id_card, update)| Student {
+            id: id,
+            name: name,
+            age: age,
+            id_card: id_card,
+            last_changed_on: update,
+        })
+    },
+);
+
+match res.unwrap() {
+    Some(student) =&gt; println!(
+        &quot;{}, {},{},{}, {:?}&quot;,
+        student.id, student.name, student.age, student.id_card, student.last_changed_on
+    ),
+    None =&gt; println!(&quot;Sorry no student found.&quot;),
+}</code></pre>
+
+<h3 id='命名参数的使用'>命名参数的使用</h3>
+
+<pre><code class="language-`rust"> let res = conn
+        .exec_first(
+            &quot;select * from student where name = :name&quot;,
+            params! {
+                &quot;name&quot; =&gt; &quot;李四&quot;
+            },
+        )
+        .map(
+            // Unpack Result
+            |row| {
+                row.map(|(id, name, age, id_card, update)| Student {
+                    id: id,
+                    name: name,
+                    age: age,
+                    id_card: id_card,
+                    last_changed_on: update,
+                })
+            },
+        );</code></pre>
+
+<p>总结</p>
+
+<ul>
+<li>经常使用的时间处理库：<code>chrono</code></li>
+
+<li>流式查询使用： <code>query_iter</code></li>
+
+<li>输出到Vec使用：<code>query</code></li>
+
+<li>映射到结构体使用： <code>query_map</code></li>
+
+<li>获取单条数据使用：<code>query_first</code></li>
+
+<li>命名参数查询使用：<code>exec_first</code></li>
+</ul>
+]]></content:encoded></item><item><title>「系列」Rust设计模式 ｜ 工厂模式</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust-design-pattern-factory.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「系列」设计模式之工厂模式'>「系列」设计模式之工厂模式</h1>
+
+<p>作者：苏胤榕（DaviRain） / 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<h1 id='创建型设计模式_之_工厂模式'>创建型设计模式 之 工厂模式</h1>
+
+<p>&gt; &gt; 工厂方法模式 (虚拟构造函数，Virtual Constructor, Factory Method）</p>
+
+<h2 id='意图'>意图</h2>
+
+<p>工厂方法模式是一种创建型设计模式，其在父类中提供一个创建对象的方法，允许子类决定实例化对象的类型。在Rust中的实现就是提供一个抽象的trait，结构体实现该trait。</p>
+
+<h2 id='问题'>问题</h2>
+
+<p>假如你正在开发一款应用，最初的版本只能处理的业务逻辑只有单一的一个，比如开始只有简单的邮寄个人信的业务。而后面随着业务的扩大，需要增加邮寄公司订单业务。</p>
+
+<p>如果代码其余部分与现有的类已经存在耦合关系，那么向程序中添加新类其实没有那么容易。</p>
+
+<p>如果以后需要在程序支持另一种新的业务类型，很可能需要再次对这些代码进行大幅修改。</p>
+
+<p>最后，你将不得不编写纷繁复杂的代码，根据不同的业务类，在应用中进行不同的处理。</p>
+
+<h2 id='解决方案'>解决方案</h2>
+
+<p>工厂方法模式建议使用特殊的工厂方法代替对象构造函数的直接调用。对象的创建仍然通过new运算符，只是该运算符改在工厂中调用。工厂方法返回的对象通常被称作“产品”。</p>
+
+<p>虽然看似很简单，我们只是改变了程序中调用构造函数的位置。但是我们可以在子类中重写工厂方法，从而改变其创建产品的类型。（这里的话在Rust中是有新的结构体实现抽象的triat）仅当这些产品具有共同的基类或者接口时，子类才能返回不同类型的产品，同时基类中的工厂方法还应该将其返回类型声明为这一共有接口。</p>
+
+<h2 id='工厂方法模式结构'>工厂方法模式结构</h2>
+
+<ul>
+<li>产品将会对接口进行声明。对于所有由创建者及其子类构建的对象，这些接口都是通用的。</li>
+
+<li>具体产品是产品接口的不同实现。</li>
+
+<li>创建者类声明返回产品对象的工厂方法。该方法的返回对象必须与产品接口相匹配。你可以将工厂方法声明为抽象方法，强制要求每个子类以不同的方式实现该方法。或者，也可以在基础工厂方法中返回默认产品类型。注意。尽管它的名字是创建者，但他最主要的职责并不是创建产品。一般来说，创建者类包含一些与产品相关的核心业务逻辑。工厂方法将这些逻辑处理从具体产品类中分离出来。</li>
+</ul>
+
+<h2 id='示例结构图'>示例结构图</h2>
+
+<p><img src='../image/rust-design-pattern-factory.png' alt='' /></p>
+
+<h2 id='代码'>代码</h2>
+
+<pre><code class="language-`rust">enum ProductType {
+    Product1,
+    Product2,
+}
+
+// 定义接口
+trait Product {
+    fn show(&amp;self);
+}
+
+// 工厂模式
+trait Factory {
+    fn make_product(&amp;self, product_type : ProductType) -&gt; Box&lt;dyn Product&gt;;
+}
+
+struct ConcreteProduct1(String);
+struct ConcreteProduct2(String);
+
+impl Product for ConcreteProduct1 {
+    fn show(&amp;self) {
+        println!(&quot;red color, {}&quot;, self.0);
+    }
+}
+
+impl Product for ConcreteProduct2  {
+    fn show(&amp;self) {
+        println!(&quot;blue color, {}&quot;, self.0);
+    }
+}
+
+struct SimpleFactory;
+
+impl SimpleFactory {
+    fn new() -&gt; Self {
+        Self
+    }
+}
+
+impl Factory for SimpleFactory {
+    fn make_product(&amp;self, color_type : ProductType) -&gt; Box&lt;dyn Product&gt; {
+        match color_type {
+            ProductType::Product1 =&gt; Box::new(ConcreteProduct1(&quot;blue&quot;.to_string())),
+            ProductType::Product2 =&gt; Box::new(ConcreteProduct2(&quot;red&quot;.to_string())),
+        }
+    }
+}
+
+fn main() {
+    let factory =  SimpleFactory::new();
+    let product = factory.make_product(ProductType::Product1);
+    product.show();
+    let product = factory.make_product(ProductType::Product2);
+    product.show();
+}</code></pre>
+
+<h2 id='工厂方法模式适合应用的场景'>工厂方法模式适合应用的场景</h2>
+
+<ul>
+<li>
+<p>当你在编写代码的过程中，如果无法预知对象确切类别及其依赖关系时，可使用工厂方法</p>
+
+<ul>
+<li>工厂方法将创建产品的代码和实际使用产品的代码分离，从而能在不影响其他代码的情况下扩展产品创建部分代码</li>
+</ul>
+</li>
+
+<li>
+<p>如果你希望用户能扩展你软件库或架构的内部组件，可使用工厂方法</p>
+
+<ul>
+<li>通过将需要实现的共同特性的接口特性抽象为trait， 当有新的结构体时，将该结构体实现拥有共同特性的trait。从而实现新组件的假如，而不会破坏别的代码结构。</li>
+</ul>
+</li>
+
+<li>如果你希望复用现有对象对象来节省系统资源，而不是每次都重新创建对象，可使用工厂方法。</li>
+</ul>
+
+<h2 id='实现方法'>实现方法</h2>
+
+<ul>
+<li>让所有的产品都遵循统一triat接口，该接口必须声明对所有产品都有意义的方法</li>
+
+<li>在工厂trait中添加一个工厂方法，该方法的返回类型都必须遵循通用的产品接口（返回的是由Box包裹起来的trait对象）</li>
+
+<li>在创建者代码中找到对于产品构造函数的所有引用，将它们依次替换为对于工厂方法的调用。，同时将创建产品的代码移入工厂方法。</li>
+
+<li>为工厂方法中的每种产品编写一个结构体，然后将该结构体实现抽象出来的统一triat，并将基本方法中的相关创建代码移动到工厂方法中。</li>
+
+<li>如果代码经过上述移动之后，基础工厂方法中已经没有任何代码，你可以将其转变为抽象trait方法。如果基础工厂方法中还有其他语句，你可以将其设置为该方法的默认行为。</li>
+</ul>
+
+<h2 id='工厂方法模式优缺点'>工厂方法模式优缺点</h2>
+
+<ul>
+<li>
+<p>优点</p>
+
+<ul>
+<li>你可以避免创建者和具体产品之间的紧密耦合</li>
+
+<li>单一职责原则，你可以将产品创建代码放在程序的单一位置，从而使得代码更容易维护</li>
+
+<li>开闭原则，无需更改现有客户端代码你就可以在程序中引入新的产品类型。</li>
+</ul>
+</li>
+
+<li>
+<p>缺点</p>
+
+<ul>
+<li>应用工厂方法模式需要引入许多新的子类，代码可能会因此变得更复杂。最好的情况是将该模式引入创建者类的现有层次结构中。</li>
+</ul>
+</li>
+</ul>
+]]></content:encoded></item><item><title>「译」数据操作：Rust vs Pandas</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust_vs_pandas.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」数据操作：rust_vs_pandas'>「译」数据操作：Rust vs Pandas</h1>
+
+<p>译者：<a href='https://github.com/pi-pi-miao'>pi-pi-miao</a> / 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 原文：<a href='https://able.bio/haixuanTao/data-manipulation-pandas-vs-rust--1d70e7fc'>Data Manipulation: Pandas vs Rust</a></p>
+
+<h2 id=''></h2>
+
+<p>&gt; &gt; Rust requires a lot more work compared to Pandas, but, Rust is way more flexible and performant.</p>
+
+<p>与 pandas 相比，rust 需要做更多的工作，但是 rust 使用起来更灵活，更出色</p>
+
+<h2 id='介绍'>介绍</h2>
+
+<p>pandas 是 python 的主要数据分析包，但是由于很多原因，如果没有使用 numpty 等工具的话，原生 python 在数据分析等方面性非常差，pandas 是由 Wes McKinney 开发的，并且将这些操作封装到漂亮的 api 中，方便 python 开发者使用其进行数据分析</p>
+
+<p>rust 因为具有出色的数据性能，这也是为什么 rust 不需要像 pandas 那样进行 api 的包装</p>
+
+<p>我相信在 rust 进行数据操作的方法是构建一堆数据结构，但是我可能理解错了，如果是这样的话，请告诉我</p>
+
+<p>下面是我的经验和推理用来比较 rust 和 pandas</p>
+
+<h2 id='数据'>数据</h2>
+
+<p>性能基准是在这个非常随机的数据集上完成的：<a href='https://www.kaggle.com/START-UMD/gtd'>这里</a>，它提供了大约160,000行/ 130列，总大小为 150Mb 的数据，这个数据集的大小对应于我经常遇到的数据集类型，这就是我选择这个数据集的原因，他并不是世界上最大的数据集，更多的学习应该在更大的数据集上进行</p>
+
+<p>已经合并将使用另一个随机数据集已经完成 <a href='https://datacatalog.worldbank.org/dataset/world-development-indicators'>这里</a>, the<code>WDICountry.csv</code></p>
+
+<h2 id='1、读取和即时数据'>1、读取和即时数据</h2>
+
+<h3 id='\[pandas]'>\[pandas]</h3>
+
+<p>在 pandas 读取和即时数据非常简单，默认情况会处理很多数据质量问题</p>
+
+<pre><code class="language-`python">import pandas as pd
+
+path = &quot;/home/peter/Documents/TEST/RUST/terrorism/src/globalterrorismdb_0718dist.csv&quot;
+df = pd.read_csv(path)</code></pre>
+
+<p>\[rust] 读取 CSV 文件</p>
+
+<p>对于 rust 来说，管理质量差的数据是非常乏味的，在有些数据集中，有些字段是空的，有些行格式不好，有些没有使用 utf-8 编码</p>
+
+<p>要打开 csv，我使用了 csv crate ，它不但能解决上面所有的问题，所以读取可以使用 csv</p>
+
+<pre><code class="language-`rust">let path = &quot;/home/peter/Documents/TEST/RUST/terrorism/src/foo.csv&quot;
+let mut rdr = csv::Reader::from_path(path).unwrap();</code></pre>
+
+<p>由于格式化质量差，我的使用如下</p>
+
+<pre><code class="language-`rust">use std::fs::File;    
+use encoding_rs::WINDOWS_1252;
+use encoding_rs_io::DecodeReaderBytesBuilder;
+
+// ...
+
+    let file = File::open(path)?;
+    let transcoded = DecodeReaderBytesBuilder::new()
+        .encoding(Some(WINDOWS_1252))
+        .build(file);
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(b&#8217;,&#8217;)
+        .from_reader(transcoded);</code></pre>
+
+<p>\<a href='https://stackoverflow.com/questions/53826986/how-to-read-a-non-utf8-encoded-csv-file'>参考][https://stackoverflow.com/questions/53826986/how-to-read-a-non-utf8-encoded-csv-file\*</a></p>
+
+<h3 id='\[rust]即时数据'>\[rust]即时数据</h3>
+
+<p>为了实现数据的即时化，我使用<a href='https://serde.rs/'>Serde</a> 将我的数据序列化和反序列化</p>
+
+<p>要使用 Serde，需要对数据进行 struct 化，使用 struct 是我的代码遵循基于模型的编程范式，每个字段都有一个定义好的类型，它还能让我能在 struct 之上实现 trait 和方法</p>
+
+<p>然而，我想要的数据有130列...而且它看起来没有办法自动生成 struct的 定义，为了避免手动定义，我必须构建自己的结构生成器</p>
+
+<pre><code class="language-`rust">fn inspect(path: &amp;str) {
+    let mut record: Record = HashMap::new();
+
+    let mut rdr = csv::Reader::from_path(path).unwrap();
+
+    for result in rdr.deserialize() {
+        match result {
+            Ok(rec) =&gt; {
+                record = rec;
+                break;
+            }
+            Err(e) =&gt; (),
+        };
+    }
+    // Print Struct
+    println!(&quot;#[skip_serializing_none]&quot;);
+    println!(&quot;#[derive(Debug, Deserialize, Serialize)]&quot;);
+    println!(&quot;struct DataFrame {{&quot;);
+    for (key, value) in &amp;record {
+        println!(&quot;    #[serialize_always]&quot;);
+
+        match value.parse::&lt;i64&gt;() {
+            Ok(n) =&gt; {
+                println!(&quot;    {}: Option&lt;i64&gt;,&quot;, key);
+                continue;
+            }
+            Err(e) =&gt; (),
+        }
+        match value.parse::&lt;f64&gt;() {
+            Ok(n) =&gt; {
+                println!(&quot;    {}: Option&lt;f64&gt;,&quot;, key);
+                continue;
+            }
+            Err(e) =&gt; (),
+        }
+        println!(&quot;    {}: Option&lt;String&gt;,&quot;, key);
+    }
+    println!(&quot;}}&quot;);
+}</code></pre>
+
+<p>生成的 struct 如下</p>
+
+<pre><code class="language-`rust">use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct DataFrame {
+    #[serialize_always]
+    individual: Option&lt;f64&gt;,
+    #[serialize_always]
+    natlty3_txt: Option&lt;String&gt;,
+    #[serialize_always]
+    ransom: Option&lt;f64&gt;,
+    #[serialize_always]
+    related: Option&lt;String&gt;,
+    #[serialize_always]
+    gsubname: Option&lt;String&gt;,
+    #[serialize_always]
+    claim2: Option&lt;String&gt;,
+    #[serialize_always]
+
+    // ...</code></pre>
+
+<p>skip<em>serializing</em>none : 避免在 csv 中出现空字段的错误</p>
+
+<p>serialize_always : 固定写入 csv 的时候的字段的数量</p>
+
+<p>现在我有了自己的结构体，我使用 serde 序列化来填充结构体的向量</p>
+
+<pre><code class="language-`rust"> let mut records: Vec&lt;DataFrame&gt; = Vec::new();
+
+    for result in rdr.deserialize() {
+        match result {
+            Ok(rec) =&gt; {
+                records.push(rec);
+            }
+            Err(e) =&gt; println!(&quot;{}&quot;, e),
+        };
+    }</code></pre>
+
+<p>这生成了我的向量结构体，赞</p>
+
+<p>一般来说，在使用rust的时候，你不应该期望像使用 python 那样流畅的工作</p>
+
+<p>结论</p>
+
+<pre><code class="language-`">在读取/实例化数据的时候，pandas轻而易举的赢得了rust的csv</code></pre>
+
+<h2 id='2、过滤'>2、过滤</h2>
+
+<p>\[pandas]</p>
+
+<p>pandas 的过滤方法有很多种，对我来说最常见的方法是</p>
+
+<pre><code class="language-`rust">df = df[df.country_txt == &quot;United States&quot;]
+df.to_csv(&quot;python_output.csv&quot;)</code></pre>
+
+<p>\[rust]</p>
+
+<p>要在 rust 中使用过滤，可以参考 rust 的<a href='https://doc.rust-lang.org/std/vec/struct.Vec.html'>向量文档</a></p>
+
+<p>有一大堆向量的过滤方法，有狠多还是 nightly 的特性，这些特性在发布的时候非常适合数据操作，对于这个用例我使用了 retain 方法，因为它完全符合我的需求</p>
+
+<pre><code class="language-`rust">  records.retain(|x| &amp;x.country_txt.unwrap() == &quot;United States&quot;);
+    let mut wtr =
+        csv::Writer::from_path(&quot;output_rust_filter.csv&quot;)?;
+
+    for record in &amp;records {
+        wtr.serialize(record)?;
+    }</code></pre>
+
+<p>pandas 和 rust 的最大区别是 rust 过滤使用了闭包（比如 python 中的 lambda 函数）而 pandas 过滤式基于列的 pandas API，这意味着 rust 可以制造更复杂的过滤器，在我看来这也增加了可读性</p>
+
+<h3 id='性能'>性能</h3>
+
+<p>||时间|内存（Gb）| |:-|:-----|:-------------| |pandas|3.0s|2.5 Gb| |rust|1.6s 🔥 -50%|1.7 Gb 🔥 -32%|</p>
+
+<p>即使我们使用 pandas 的 api 来过滤，我们也可以使用 rust 获得更好的性能</p>
+
+<h3 id='结论'>结论</h3>
+
+<p>在过滤这方面，rust 更快，并且性能更好</p>
+
+<h2 id='3、分组'>3、分组</h2>
+
+<h3 id='\[pandas]'>\[pandas]</h3>
+
+<p>分组式 python 中使用 pipline 的重要组成部分，如下：</p>
+
+<pre><code class="language-`python">df = df.groupby(by=&quot;country_txt&quot;, as_index=False).agg(
+    {&quot;nkill&quot;: &quot;sum&quot;, &quot;individual&quot;: &quot;mean&quot;, &quot;eventid&quot;: &quot;count&quot;}
+)
+df.to_csv(&quot;python_output_groupby.csv&quot;)</code></pre>
+
+<p>\[rust]</p>
+
+<p>对于分组 感谢： <a href='https://able.bio/insideoutclub'>David Sanders</a> 分组恶意使用下面</p>
+
+<pre><code class="language-`rust">use itertools::Itertools;
+
+
+// ...
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GroupBy {
+    country: String,
+    total_nkill: f64,
+    average_individual: f64,
+    count: f64,
+}
+
+// ... 
+
+    let groups = records
+        .into_iter()
+        // .sorted_unstable_by(|a, b| Ord::cmp(&amp;a.country_txt, &amp;b.country_txt))
+        .group_by(|record| record.country_txt.clone())
+        .into_iter()
+        .map(|(country, group)| {
+            let (total_nkill, count, average_individual) = group.into_iter().fold(
+                (0., 0., 0.),
+                |(total_nkill, count, average_individual), record| {
+                    (
+                        total_nkill + record.nkill.unwrap_or(0.),
+                        count + 1.,
+                        average_individual + record.individual.unwrap_or(0.),
+                    )
+                },
+            );
+            lib::GroupBy {
+                country: country.unwrap(),
+                total_nkill,
+                average_individual: average_individual / count,
+                count,
+            }
+        })
+        .collect::&lt;Vec&lt;_&gt;&gt;();
+    let mut wtr =
+        csv::Writer::from_path(&quot;output_rust_groupby.csv&quot;)
+            .unwrap();
+
+    for group in &amp;groups {
+        wtr.serialize(group)?;
+    }</code></pre>
+
+<p>虽然这个解决方案不像 pandas 那样优雅，但是为这种场景提供了更好的灵活性</p>
+
+<p>我认为除了 sum and fold 之外，更多的 reduction 方法将会大大提高 rust 中 map-reduce 式操作的开发体验。</p>
+
+<h3 id='性能'>性能</h3>
+
+<p>||时间|内存（Gb）| |:-|:-----|:-------------| |pandas|2.78s|2.5 Gb| |rust|2.0s🔥 -35%|1.7Gb🔥 -32%|</p>
+
+<h3 id='结论：'>结论：</h3>
+
+<p>虽然性能更好的是 rust，我建议在 map-reduce 方法使用 pandas，因为它似乎更合适。</p>
+
+<h2 id='4、mutation'>4、Mutation</h2>
+
+<h3 id='\[pandas]'>\[pandas]</h3>
+
+<p>在 pandas 身上做 mutation 的方法有很多，我通常为了性能和功能风格做下面的方式</p>
+
+<pre><code class="language-`python">df[&quot;computed&quot;] = df[&quot;nkill&quot;].map(lambda x: (x - 10) / 2 + x ** 2 / 3)
+df.to_csv(&quot;python_output_map.csv&quot;)</code></pre>
+
+<h3 id='\[rust]'>\[rust]</h3>
+
+<p>rust 在 mutation 可以使用 iter</p>
+
+<pre><code class="language-`rust">   records.iter_mut().for_each(|x: &amp;mut DataFrame| {
+        let nkill = match &amp;x.nkill {
+            Some(nkill) =&gt; nkill,
+            None =&gt; &amp;0.,
+        };
+
+        x.computed = Some((nkill - 10.) / 2. + nkill * nkill / 3.);
+    });
+
+    let mut wtr = csv::Writer::from_path(
+        &quot;output_rust_map.csv&quot;,
+    )?;
+    for record in &amp;records {
+        wtr.serialize(record)?;
+    }</code></pre>
+
+<h3 id='性能'>性能</h3>
+
+<p>||时间|内存（Gb）| |:-|:-----|:-------------| |pandas|12.82s|4.7Gb| |rust|1.58s🔥 -87%|1.7Gb🔥 -64%|</p>
+
+<p>在我看来 mutation 就是 pandas 和 rust 的区别所在，pandas 在这方面表现非常糟糕</p>
+
+<h3 id='结论'>结论</h3>
+
+<p>rust 天生适合 mutation 操作</p>
+
+<h2 id='5._merge'>5. Merge</h2>
+
+<h3 id='\[python]'>\[python]</h3>
+
+<p>一般来说 merge 操作在 python 中式非常高效的</p>
+
+<pre><code class="language-`rust">df_country = pd.read_csv(
+    &quot;/home/peter/Documents/TEST/RUST/terrorism/src/WDICountry.csv&quot;
+)
+
+df_merge = pd.merge(
+    df, df_country, left_on=&quot;country_txt&quot;, right_on=&quot;Short_Name&quot;
+)
+df_merge.to_csv(&quot;python_output_merge.csv&quot;)</code></pre>
+
+<h3 id='\[rust]'>\[rust]</h3>
+
+<p>对于 rust 的 struct 来说这是一个棘手的部分，对我来说解决合并的办法式添加一个嵌套字段，这里包含我们要合并的另一个结构体，我首先为新数据创建一个新的结构体和新的堆</p>
+
+<pre><code class="language-`rust">#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct DataFrameCountry {
+    #[serialize_always]
+    SNA_price_valuation: Option&lt;String&gt;,
+    #[serialize_always]
+    IMF_data_dissemination_standard: Option&lt;String&gt;,
+    #[serialize_always]
+    Latest_industrial_data: Option&lt;String&gt;,
+    #[serialize_always]
+    System_of_National_Accounts: Option&lt;String&gt;,
+    //...
+
+// ...
+
+    let mut records_country: Vec&lt;DataFrameCountry&gt; = Vec::new();
+    let file = File::open(path_country)?;
+    let transcoded = DecodeReaderBytesBuilder::new()
+        .encoding(Some(WINDOWS_1252))
+        .build(file);
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(b&#8217;,&#8217;)
+        .from_reader(transcoded); 
+
+    for result in rdr.deserialize() {
+        match result {
+            Ok(rec) =&gt; {
+                records_country.push(rec);
+            }
+            Err(e) =&gt; println!(&quot;{}&quot;, e),
+        };
+    }</code></pre>
+
+<p>然后，我将这个新结构与前面的结构克隆到一个惟一的特定字段上。</p>
+
+<pre><code class="language-`rust">impl DataFrame {
+    fn add_country_ext(&amp;mut self, country: Option&lt;DataFrameCountry&gt;) {
+        self.country_merge = Some(country)
+    }
+}
+
+//...
+
+    for country in records_country {
+        records
+            .iter_mut()
+            .filter(|record| record.country_txt == country.Short_Name)
+            .for_each(|x| {
+                x.add_country_ext(Some(country.clone()));
+            });
+    }
+    let mut wtr =
+        csv::Writer::from_path(&quot;output_rust_join.csv&quot;)
+            .unwrap();
+    for record in &amp;records {
+        wtr.serialize(record)?;
+    }</code></pre>
+
+<p>为了方便和更好的可比性，我复制了数据，但是如果您能够管理它，可以传递引用。</p>
+
+<p>好了!🚀</p>
+
+<p>除此之外，嵌套结构在 CSV 中还不能序列化  对于 rust <a href='https://github.com/BurntSushi/rust-csv/pull/197'>这里</a></p>
+
+<p>所以我必须把它改写成:</p>
+
+<pre><code class="language-`rust">impl DataFrame {
+    fn add_country_ext(&amp;mut self, country: Option&lt;DataFrameCountry&gt;) {
+        self.country_ext = Some(format!(&quot;{:?}&quot;, country))
+    }
+}</code></pre>
+
+<p>最后我们归并</p>
+
+<h3 id='性能'>性能</h3>
+
+<p>||时间|内存（Gb）| |:-|:-----|:-------------| |pandas|22.47s|11.8Gb| |rust|5.48s🔥 -75%|2.6 Gb🔥 -78%|</p>
+
+<h3 id='结论'>结论</h3>
+
+<p>Rust 可以通过嵌套结构体的方式来实现和 pandans 一样的 merge 功能这并不是真正的一对一比较，在这种情况下，这将取决于您的用例。</p>
+
+<h2 id='最后的结论'>最后的结论</h2>
+
+<p>这次比较之后，我的收获如下</p>
+
+<p>​        使用 pandas 的时候，可以 使用小的 csv（\&lt;1M行），进行简单的操作数据清理</p>
+
+<p>​        使用 rust 的时候，你可以进行复杂的操作，内存大或者耗时的 piplines，可以自定义构建函数，扩展软件</p>
+
+<p>rust 和 pandas 相比，rust 提供了非常好的灵活性，以及 rust 比 pandas 可以使用多线程的能力，可以并行操作，我相信 rust 可以解决 pandas 不能解决的问题</p>
+
+<p>此外在任何平台上（ web，安卓或者嵌入式 ）上运行 rust 也是 pandas 无法做到的，并且 rust 也可以为尚未解决的挑战提供了新的解决方案</p>
+
+<h2 id='性能'>性能</h2>
+
+<p>性能表也给了我们更加深入了解 rust 的期望，我相信对于大数据处理方面，rust 会提高2-50倍的性能提升，随着时间的推移，rust 比着 python 内存使用量会大大的减少</p>
+
+<h2 id='免责声明'>免责声明</h2>
+
+<p>在很多方面，pandas 可以被优化，但是优化式有代价的，无论使硬件(例如集群 Cluster  #Dask, GPU #Cudf)，还是依赖于这些优化包的可靠性和维护。</p>
+
+<p>我非常喜欢使用原生 rust 的原因是，rust 不需要额外的硬件，也不需要额外的软件包，此解决方案不需要额外的抽象层，这使得 rust 在很多方面更加直观</p>
+
+<h2 id='代码库'>代码库</h2>
+
+<h3 id='git_repository'>Git repository</h3>
+
+<p><a href='https://github.com/haixuanTao/Data-Manipulation-Rust-Pandas'>点击这里</a></p>
+]]></content:encoded></item><item><title>「译」Unsafe Rust 的取舍</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/Unsafe_Rust_How_and_when_not_to_use_it.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」unsafe_rust_的取舍'>「译」Unsafe Rust 的取舍</h1>
+
+<p>译者： （ <a href='https://github.com/MATRIXKOO'>MATRIXKOO</a> 和 <a href='https://github.com/NiZerin'>NiZerin</a> ） / 后期编辑： 张汉东</p>
+
+<p>&gt; &gt; 原文：<a href='https://blog.logrocket.com/unsafe-rust-how-and-when-not-to-use-it/'>Unsafe Rust: How and when (not) to use it</a></p>
+
+<h2 id=''></h2>
+
+<h2 id='在本中，我将说明您需要了解的有关_unsafe_rust_的所有信息。我将专注于以下几个方面来讲解。'>在本中，我将说明您需要了解的有关<code>unsafe Rust</code>的所有信息。我将专注于以下几个方面来讲解。</h2>
+
+<ul>
+<li>有关于<code>unsafe Rust</code>代码的误解</li>
+
+<li>什么时候不使用<code>unsafe</code>代码</li>
+
+<li>处理未初始化的内存</li>
+
+<li>不可处理的异常</li>
+
+<li>内在机制</li>
+
+<li>内联汇编</li>
+
+<li>接口外部功能</li>
+
+<li>编写<code>unsafe Rust</code>代码的工具</li>
+</ul>
+
+<h2 id='关于_unsafe_rust_代码的几个误解'>关于<code>unsafe Rust</code>代码的几个误解</h2>
+
+<p>在解释如何以及何时使用<code>unsafe Rust</code>（或不使用）之前，我想先说明一些关于 Rust 中不安全代码的常见误解。</p>
+
+<p>\###误解1：所有 Rust 代码都不安全 不是的。 区别是微妙的，但是安全的 Rust 代码不能违反安全保证，只要编译器和它所构建的不安全代码都没有任何允许这种情况发生的bug。 因此，与其他低级语言不同，在其他低级语言中，代码的安全性取决于每一行代码和编译器实现，您可以显著减少需要审核错误的攻击面。</p>
+
+<p><a href='https://plv.mpi-sws.org/rustbelt/'>RustBelt</a> 项目从数学上证明，如果你有一部分安全代码和一部分不安全代码来保护它的不变量，那么只要不安全代码不允许，安全代码就不能破坏保证。</p>
+
+<p>顺便说一句，不变量是一种条件，它不会被某一类型的所有方法或模块的所有函数改变。</p>
+
+<p>从统计上讲，在 Crates.io 上发现的 Rust 代码中，只有不到1%是不安全的代码-这可能不到现有代码的50%，但仍然应该是一个足够有代表性的样本-而且许多项目里没有任何不安全的代码行。</p>
+
+<h3 id='误解2：它依赖于标准库代码，其中包含许多不安全因素'>误解2：它依赖于标准库代码，其中包含许多不安全因素</h3>
+
+<p>是的，标准库有比普通项目更多的不安全代码，这是意料之中的，因为它提供的许多抽象不能在<code>Safe Rust</code>中有效地实现，或者根本不能实现。 此外，我们可以放心，标准库已经收到了更多的审查，因此比您的项目更值得信赖。</p>
+
+<p>这并不是说它是完美的-毕竟，过去也发现了很多错误。 尽管如此，在验证和模糊标准库的大部分方面还是做了很好的工作，这使得所有的 Rust 代码都更加安全。</p>
+
+<h3 id='误解3：一旦我们编写了_unsafe_代码，就感觉打开了地狱之门'>误解3：一旦我们编写了 <code>unsafe</code> 代码，就感觉打开了地狱之门</h3>
+
+<p>不是的。 <a href='https://doc.rust-lang.org/nomicon/what-unsafe-does.html'>Rustonomicon</a> 仔细地列出了不安全代码授予您的额外权限，以换取您保证维护该部分代码中的安全常量。 例如，您可以：</p>
+
+<ul>
+<li>取消引用原始指针</li>
+
+<li>调用<code>unsafe</code>函数(包括C函数、编译器内部函数和原始分配器)</li>
+
+<li>实现<code>unsafe</code>traits</li>
+
+<li>改变静态变量</li>
+
+<li>访问联合体内的成员</li>
+</ul>
+
+<p>然而，即使是那些看起来可能是安全的代码，也可能会产生你应该注意的后果：</p>
+
+<ul>
+<li>原始指针不能保证指向它们声称要指向的数据的有效实例，因此取消对它们的引用可能会导致空域(很可能是分段错误)，或者更糟糕的是，会导致类型混乱，在这种情况下，您破坏了数据，破坏了程序的状态，可能会造成不利的影响。</li>
+
+<li>调用<code>unsafe</code>函数有使用不符合其安全要求的参数调用它们的风险，这可能会造成可利用的漏洞。</li>
+
+<li>为未能维护其不变式的类型实现<code>unsafe</code> traits 还可能导致调用方无意中导致其安全要求失败，并可能造成不利的影响。</li>
+
+<li>在另一个线程中观察静态变量时对其进行改变可能会导致数据竞争和读取异常，这意味着读取的值不再需要与旧值或新值相关。 根据读取的类型和使用方式的不同，这也可能导致未定义的行为，可能会造成不利的影响。</li>
+
+<li>访问联合体的字段可能会让您将数据解释为它们不表示有效实例的类型，或者观察未初始化的数据(如果类型的长度不同，一个字段可以包括另一个字段的填充)，这两种情况都会导致未定义的行为和可能被利用的漏洞。</li>
+</ul>
+
+<p>因此，尽管不安全代码并不像某些人所说的那样可怕，但需要小心安全地处理它。 然后，您可以在不安全代码的基础上编写安全代码。</p>
+
+<h3 id='误解4：只要不会有人意外地使用参数调用我的安全代码，从而导致下面的不安全代码失败，我就没问题'>误解4：只要不会有人意外地使用参数调用我的安全代码，从而导致下面的不安全代码失败，我就没问题</h3>
+
+<p>不是的。 一旦您在不安全的代码之上提供了一个安全接口，您的代码要么无论如何都会维护安全常量，要么您的代码是不健全的。</p>
+
+<p>有些人对不健全的感觉非常强烈，没有理由大发雷霆。 这仍然是一个错误，你应该公开和冷静地解决它。 如果错误可以通过更仔细的设计来解决，那就去做吧。 同时，您可以公开声明您的代码不健全，用户需要格外小心，以免违反安全常量。 如果你想出了一个合理的设计，就把所有发布的不完善的版本都撤回，并报告漏洞。</p>
+
+<h3 id='误解5：我试过运行它，它运行得很好'>误解5：我试过运行它，它运行得很好</h3>
+
+<p>未定义行为的问题不在于它会直接失败。 事实上，它可能永远不会失败。 在您将代码投入生产之前，它也可能一直正常工作，在这一点上，它可能会灾难性地失败。 或者，它可能会起作用，直到黑客尝试它，并手工制作正确的输入，以破解您的不健全的代码。 现在，您的所有用户都在其PC上安装了密码勒索特洛伊木马程序。</p>
+
+<p>即使多次运行它，也不能保证下一次就能正常工作。 正如哥伦比亚号航天飞机灾难所显示的那样，仅仅因为它成功了135次并不意味着它在第136次尝试中就不会失败。</p>
+
+<p>\###但如果这只发生在内存泄漏时呢？ 内存泄漏无法可靠地避免，并且本身不会对内存安全构成任何危险-尽管操作系统可能会停止您的程序，或者在您耗尽可用内存时简单地崩溃，但这在最坏的情况下会导致拒绝服务。 因此，它被认为超出了内存安全保障的范围，<code>mem：：forget</code>成为一个安全函数。 如果您的代码依赖于一些不泄漏的值来保证安全性，那么在某些时候，泄漏可能就会发生，安全保证的损失将由您承担。</p>
+
+<p>请注意，这个误解是如此常见，直到Rust1.0之后，它才最终允许安全代码泄漏。 这种不安全来源的解决方案通常是泄漏放大-在尝试不安全操作之前，泄漏所有可能由泄漏导致的可观察到的损坏状态，然后将所有东西重新组合在一起。 这样，泄漏会变得更大，有时甚至更大，但至少不会破坏内存安全。</p>
+
+<h3 id='好的，我明白了。_一旦我的项目中有一行不安全的代码，所有其他代码都必须小心，以免违反安全规则'>好的，我明白了。 一旦我的项目中有一行不安全的代码，所有其他代码都必须小心，以免违反安全规则</h3>
+
+<p>因此，通常的做法是在模块中创建不安全的代码。 这通常不打算从外部使用，但有时它可以是公开的，因为如果人们想要承担随后的责任以换取性能(或其他东西)，他们可能会在代码中使用不安全的方法。</p>
+
+<p>下一步是编写另一个模块，该模块将使用前面提到的不安全代码提供安全接口。 这个模块应该是允许所有其他用例的最低抽象，如果您愿意的话，它是核心功能。 省略所有可以通过构建此安全代码来实现的内容。 这是需要仔细审核的部分。</p>
+
+<p>最后，在您的安全API之上编写您想让人们使用的实际接口。 因为您处于安全的 Rust 区域，所以这段代码不需要太多关注。 如果您在核心接口实现上做得很好，编译器将维护其所有保证。</p>
+
+<p>既然我们已经消除了与<code>unsafe</code> Rust 代码相关的误解，在进入实际代码之前，我们只有一件事要讨论。</p>
+
+<h2 id='什么时候不该用_unsafe'>什么时候不该用 <code>unsafe</code></h2>
+
+<p>通常, <code>unsafe</code> 实际上是在追求性能的过程中使用的。但是，正如我在 <a href='https://blog.logrocket.com/how-to-write-crap-rust-code'>How to write CRaP Rust code</a> 中所写的那样，即使只是作为要测试的快照和作为基准进行基准测试，也应该始终运行较慢但是安全的版本。</p>
+
+<p>只是因为使用 <code>unsafe</code> 的代码有时可以更快，并不意味着一定要这样做。合理的评估情况, 在保持原有速度或者更快的时候, 就应该继续使用 <code>safe</code> 版本的代码。</p>
+
+<p>例如，在尝试加快 <a href='https://benchmarksgame-team.pages.debian.net/benchmarksgame/'>Benchmark Game</a> 条目之一作为练习时，我想通过使用数组而不是 <code>Vec</code> 来减少内存分配，这需要一些不安全的代码来处理未初始化的数据。但是，事实证明改用数组的版本要比基于 <code>Vec</code> 的版本慢，因为这个我就没继续下去了。克里夫·比佛尔（ Cliff L. Biffle ）在 <a href='https://benchmarksgame-team.pages.debian.net/benchmarksgame/'>Benchmark Game</a> 一书中也谈到了类似的经历。 使用 <code>unsafe</code> 不仅会让编译器减少对代码的安全性的保证，也减少了要做的检查,因此实际上可能会禁用某些优化以避免破坏代码。因此，在切换到 <code>unsafe</code> 之前，请务必先进行评估，进尽量保持  <code>safe</code> 的代码。</p>
+
+<p>好的，让我们开始吧！</p>
+
+<h3 id='处理未初始化的内存'>处理未初始化的内存</h3>
+
+<p>当 Rust 版本更新到1.0.0时，标准库有一个 <code>unsafe</code> 函数来获取未初始化的内存: <code>std::mem::uninitialized</code> (还有 <code>std::mem::zeroed</code>（），但是两者之间的唯一区别是 后者将返回的内存区域用0初始化)。</p>
+
+<p>人们普遍认为这是个坏主意，现在该函数已经处于废弃 (<code>deprecated</code>) 状态，建议使用<code>std::mem::MaybeUnit</code> 类型代替。 未初始化的麻烦的原因是，该值可能会在恐慌 (<code>panic</code>)或在之前返回时隐式删除。 例如：</p>
+
+<pre><code class="language-`rust">let x = std::mem::uninitialized();
+this_function_may_panic();
+mem::forget(x);</code></pre>
+
+<p>如果 <code>this_function_may_panic</code> 函数实际上 <code>panic </code> 了，则x会在我们调用 <code>forget</code> 之前就被 <code>drop</code> 。但是，删除未初始化的值是未定义的行为，并且由于删除通常是隐式的，因此很难避免这种情况。因此， <code>MaybeUninit</code> 被设计为能够处理潜在的未初始化数据。该类型永远不会自动 <code>drop</code> （如 <code>std::mem::ManuallyDrop</code> ），编译器知道该类型可能未初始化，并且具有许多函数来正确处理未初始化的数据。</p>
+
+<p>让我们回顾一下。我们可能不会调用 <code>std::ptr::read</code> 去读未初始化内存。我们甚至不能引用它（ <code>&amp;</code> 或者 <code>&amp;mut</code> ），因为引用规则要求引用的值必须是引用类型的有效实例，而未初始化的数据不是这种情况(除了使用 <code>MaybeUninit&lt;_&gt;</code> ，因为这显然不需要初始化）。</p>
+
+<p>因此，我们也不应该 <code>drop</code>，因为这会创建一个可变的引用（注意，<code>fn drop(&amp;mut self))</code> 。我们可以将其转换为其他允许储存未初始化数据的类型( 创建一个未初始化的数组还是最简洁的方法)或用 <code>std :: ptr :: write</code>  到从  <code>as_mut_ptr()</code> 方法获得的指针，又或者使用 <code>MaybeUninit</code> 等等。请注意，即使类型未初始化，我们也可以分配给 <code>MaybeUninit</code> ，因为类型不会 <code>drop</code> 。</p>
+
+<p>举例来说，假设我们要使用一个函数创建一个值数组。数组的没有实现 <code>Copy</code> 或没有const 的 <code>initializer</code> ，或者 <a href='https://en.wikipedia.org/wiki/LLVM'>LLVM</a>  由于某种原因无法优化 <code>double</code> 。这种时候就用 <code>unsafe</code> ：</p>
+
+<pre><code class="language-`rust">use std::mem::{MaybeUninit, transmute};
+
+unsafe {
+    // first part: initialize the array. This is one of the rare cases where
+    // directly calling `assume_init` is OK, because an array of
+    // `MaybeUninit` may contain uninitialized data.
+    
+    // 第一部分: 初始化这个数组。这种就是几种特殊情况之一，直接
+    // 调用 `assume_init` 是可行的,因为 `MaybeUninit` 可以放未初		// 始化数组
+    let mut array: [MaybeUninit&lt;MyType&gt;; 256] =
+        MaybeUninit::uninit().assume_init();
+
+    // second part: initialize the data. This is safe because we assign
+    // to a `MaybeUninit`, which is exempt from `drop`.
+    
+    //  第二部分: 初始化数据。因为 `Maybeuninit` 避免了 `drop`
+    for (i, elem) in array.iter_mut().enumerate() {
+        *elem = MaybeUninit::new(calculate_elem(i));
+    }
+
+    // third part: transmute to the initialized array. This works because
+    // `MaybeUninit&lt;T&gt;` is guaranteed to have the same Layout as `T`.
+    
+   // 第三部分: 转换成初始化过的数组。这是可行的，因为 `MaybeUninit&lt;T&gt;` 保证了数据填充是和 `T` 一致的
+    transmute::&lt;_, [MyType; 256]&gt;(array)
+}</code></pre>
+
+<p>如果任何 <code>calculate_elem(_)</code> 调用失败，则将删除整个 <code>MaybeUninits</code> 数组。 因为 <code>MaybeUninit</code> 不会 <code>drop</code> ，所以现在所有的数据都将泄漏。</p>
+
+<p>为了避免这种情况，我们应该加入额外的移动语义的部分:</p>
+
+<pre><code class="language-`rust">use std::mem::{forget, MaybeUninit, transmute};
+
+// first extra part: We need a &quot;guard&quot; that drops all *initialized* elements
+// on drop
+
+// 加入的第一个额外部分: 我们需要一个 &quot;guard&quot;(守护) 来销毁所有初始化过的元素
+
+struct Guard&lt;&#8217;a&gt; {
+    // a mutable ref to access the array from
+    array: &amp;&#8217;a mut [MaybeUninit&lt;MyType&gt;; 256],
+    // the index until which all elements are initialized
+    index: usize,
+    // 一个可变引用允许用索引访问,使得所有元素都被初始化
+}
+
+impl Drop for Guard&lt;&#8217;_&gt; {
+    // drop all elements that are initialized
+    // 销毁所有被初始化的元素
+    fn drop(&amp;mut self) {
+        for i in 0..self.index {
+            unsafe {
+                std::ptr::drop_in_place(self.array[i].as_mut_ptr());
+            }
+        }
+    }
+}
+
+unsafe {
+    let mut array: [MaybeUninit&lt;MyType&gt;; 256] =
+        MaybeUninit::uninit().assume_init();
+
+    // second extra part: here we initialize the guard. From here on, it
+    // borrows our array mutably. All access will be done through the guard
+    // (because the borrow checker won&#8217;t let us access `array` directly
+    // while it&#8217;s mutably borrowed).
+    
+    // 加入的第二个额外部分: 这里我们用 `&amp;mut array` 初始化了 `guard`。
+    // (当使用可变借用时，借用检查器并不让我们直接访问数组)
+    let mut guard = Guard { array: &amp;mut array, index: 0 };
+    for i in 0..256 {
+        guard.array[guard.index] = MaybeUninit::new(calculate_elem(i));
+        // update the index so `drop` will include the newly created element.
+        // 更新索引，使得包含新创建的元素
+        guard.index += 1;
+    }
+    // third extra part: forget the guard to avoid dropping the initialized
+    // elements and also end the borrow.
+    
+    // 加入的第三部分: 调用 `forget` ,销毁 `guard`，防止内存泄漏
+    forget(guard);
+
+    transmute::&lt;_, [MyType; 256]&gt;(array)
+}</code></pre>
+
+<p>如果你认为只是为了初始化数组居然就需要这么多步骤，你是对的。同样，在这一点上，一定要衡量对性能的影响。当然不是和 <code>Vec &lt;MyType&gt;</code> 比。</p>
+
+<p>无论如何，这显示了处理未初始化数据的规范方法：标志一个不变量(“在<code>index</code> 之前的都应该不可变 ”)，对其进行维护(“写入一个元素后索引增加”)，你可以从中受益——在这种情况下，<code>panic</code> 时也不会发生泄漏。</p>
+
+<p>这种方法也适用于其他数据结构，但那里通常使用不同的不变量。例如，<code>Vec</code> 在 <code>resize</code> 操作前, 将内存拷贝一份放在后备内存里，并将长度设置为零，并在操作完成后将其恢复(发生泄漏时,泄漏的内存其实是比 <code>vec</code> 长度要大的)。这确保了 <code>drop</code> 不会用在未初始化或已经释放的内存上。</p>
+
+<p>取决于不同的数据机构，这个不变量将变的晦涩难懂。例如，可以使用一个 <code>bit set</code> 对初始化的元素进行编码，因此需要比普通数组多八分之一的内存，但允许随机访问任意元素。在这种情况下，将是“初始化和 <code>bit set</code> 一一对应”。 Rust的<code> HashMaps</code> 基本上是这样做的。</p>
+
+<p>&gt; &gt; 译者注:  bit set 其实就是位示图法</p>
+
+<h3 id='不可变的转换'>不可变的转换</h3>
+
+<p>Rust关于引用的规则非常严格——在每个给定的时间点可以读取或写入多少变量。 但是有时候我们确实需要稍微改变规则。</p>
+
+<p>为此，Rust为内部可变性提供了一种(显然得用 <code>unsafe</code>)类型，它可以使用 <code>get(＆self)</code>方法从不可变的借项中获得一个可变的指针(当然不是引用)。 还有一个<code>get_mut(&amp;mut self)</code> 的方法，该方法向内容返回可变的借用。</p>
+
+<p>这意味着编译器将假定所有 <code>UnsafeCell</code> 中的内容都被引用了。 标准库在顶层提供了许多安全抽象，特别是 <code>Cell</code>，<code>RefCell</code> ，<code>RwLock</code> ，<code>Mutex</code> 和各种<code>Atomic*</code>类型。</p>
+
+<p>&gt; &gt; 译者注: Atomic\* 的意思是以Atomic开头的类型 , 这是<a href='https://zh.wikipedia.org/wiki/%E6%AD%A3%E5%88%99%E8%A1%A8%E8%BE%BE%E5%BC%8F'>正则表达式</a>的一种</p>
+
+<p>例如，<a href='https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html'>AtomicBool</a> 的定义如下(为简洁起见删除了注释)：</p>
+
+<pre><code class="language-`rust">pub struct AtomicBool {
+    v: UnsafeCell&lt;u8&gt;,
+}</code></pre>
+
+<p>当然，该实现必须确保避免数据竞争(是指在非线程安全的情况下，多线程对同一个地址空间进行写操作)，通过 LLVM 内部函数使用实际的原子操作来完成的。 我还没有检查即将到来的  <a href='https://github.com/bytecodealliance/cranelift'>Cranelift</a> 后端的功能，但它似乎也有某种类似的实现。 同样，在直接使用 <code>UnsafeCell</code> 之前，请检查是否有任何 <code>safe</code> 的替代品可用，虽然确定 <code>unsafe</code> 是否会给你带来足够的性能提升(或其他好处)。</p>
+
+<h3 id='使用cpu的特有指令集'>使用CPU的特有指令集</h3>
+
+<p>Rust的标准库在<code>std:: arch</code> 模块中有按CPU类型分类的固有函数。它们都被定义为 <code>unsafe</code> 的，主要是因为它们可能未在你的CPU上实现。 幸运的是，有一种规范的方法可以确保你在编译时或运行时拥有相应的CPU。</p>
+
+<p>假设你以&quot;标准&quot;的方式编写了算法，看了生成的汇编，觉得编译器生成的代码不够好。是时候掏出&quot;屠龙刀&quot;了。 但基本上就是在 Rust 里编写汇编了(因为 <code>arch</code> 内部函数是和不同架构一一对应的)。 如上所述，你需要确保用户的平台和你的一致。 以下代码显示了在编译时和运行时检查 CPU是否支持的方法：</p>
+
+<pre><code class="language-`rust">// compile time check 编译时检查
+#[cfg(any(target_arch = &quot;x86&quot;, target_arch = &quot;x86_64&quot;))]
+mod simd {
+    fn calculate() -&gt; .. {
+        // this is a std library macro that allows us to safely access CPU
+        // features by doing runtime detection
+        // 这里是标准库的一个宏，通过它我们可用进行CPU的编译器检查
+        
+        if is_x86_feature_detected!(&quot;avx2&quot;) {
+            // code using avx2 intrinsics here
+        } else if is_x86_feature_detected!(&quot;sse2&quot;)
+            // code using sse2 intrinsics here
+        } else {
+            // code using no special features, using e.g. avx2 intrinsics
+            // would be UB!
+        }
+    }
+}
+
+#[cfg(not(any(target_arch = &quot;x86&quot;, target_arch = &quot;x86_64&quot;)))]
+mod simd {
+    // fallback code here
+}</code></pre>
+
+<p>此示例仅具有针对x86和x86_64架构的专用代码，以及各种运行时检测到的CPU功能。 如果你希望程序在其他平台(例如ARM-NEON)上使用SIMD内部函数，则需要添加另一个 <code>#[cfg]</code> 声明。不用多说，最后你就得写上不少代码。</p>
+
+<p>除了可用性之外，一些指令还要考虑内存对齐。 为了简化 <code>bit</code> ，内存对齐告诉我们有些地址的最后几位必须为零。 例如，一个32位值的对齐方式可能为 <code>4</code> ，这意味着其地址的最后两位应为零。 请参阅库文档以获取详细信息，并参考 <a href=''>上一章</a> 以获取适当的帮助。</p>
+
+<h3 id='内联汇编'>内联汇编</h3>
+
+<p>假设你正在编写内核，并且需要使用堆栈指针来处理一些&quot;奇怪&quot;的事情，或者其他不得不需要用汇编的地方。 Rust有两个 <code>FFI</code> 接口：一个是C语言，另一个是汇编。 不幸的是，这既不稳定又不安全，所以你就得使用<code>nightly</code> 版本来编译<code>#[feature(asm)]</code> 和 <code>unsafe</code> 的块。 显然，Rust无法检查你在汇编中所做的事情。 使用内联汇编的细节不在本文讨论范围之内。 请查看 <a href='https://doc.rust-lang.org/1.8.0/book/inline-assembly.html'>Rust Book chapter</a>  或者 <a href='https://rust-lang.github.io/rfcs/2873-inline-asm.html'>RFC text</a>。 就本文而言，不需要你熟悉 <code>FFI</code> 。</p>
+
+<h3 id='与其他语言交互'>与其他语言交互</h3>
+
+<p>假如你有非常庞大的 C 代码库，并希望将其移至 Rust，不用多说，这是一项艰巨的任务。你可以先使用外部函数接口来重写代码库的一小部分，然后逐个模块进行重写，直到整个程序都用 Rust 编写，然后你就可以扔掉C了(😀)(顺带一说 <a href='https://people.gnome.org/~federico/blog/a-rust-api-for-librsvg.html'>librsvg</a> 就是这样做的)。或者在 C ++ 中使用 Rust。</p>
+
+<p>无论如何，你都得在安全的，充满温暖的 Rust 世界与艰难而又无情的世界之间架起一座桥梁。既然外面的世界很危险，显然你得用 <code>unsafe</code> 与之交互。 首先，请确保你拥有正确的接口，以免你在调试时踩坑。 <a href='https://github.com/rust-lang/rust-bindgen'>bindgen</a>（用于从 Rust 访问 C ）和<a href='https://github.com/eqrion/cbindgen/'>cbindgen</a>（用于从 C 访问 Rust）的工具箱就显得非常有用。 如果你从 C ( 使用C接口的C++ ) 访问 Rust，请注意对象的生命周期，并将Rust对象的生存期保留在Rust代码中-也就是说，让Rust删除它们; 而对于 C 的指针，就让 C 处理它们。众所周知，Rust 有非常特殊的管理生命周期的方法，记住你的需求。</p>
+
+<p>另一方面，如果将 C（(或是C++ 使用了 <code>extern</code> ) 包装在Rust中，则会发现 C 库通常还需要考虑数据的生命周期。一旦有了绑定，就尝试考虑类型的生命周期的问题。 unofficial patterns book 有这样一章 <a href='https://rust-unofficial.github.io/patterns/patterns/ffi-intro.html'>instructive chapter</a>  。</p>
+
+<p>如果与 C++ 交互，需要使用 <a href='https://docs.rs/cxx'>cxx</a> 。但是，请注意，与通常的 <code>bindings generators</code> 不同，<code>cxx</code> 不会用 <code>unsafe</code> 标记你的函数 ！我在这里的看法是，绑定机制部分是在 Rust 中构建的，一部分是在 C++ 中构建的，它是否是 <code>safe</code> 的，这取决于你审查 C++ 的代码。你可能仍然希望将结果接口包装在一个友好的接口中，并且不会以不安全的方式被滥用。</p>
+
+<h2 id='编写_unsafe_rust_的工具'>编写 <code>unsafe rust</code> 的工具</h2>
+
+<p>正如我们所见，编写 <code>unsafe</code> Rust比 <code>safe</code> 的 Rust 需要多做许多工作，因为这样将不再依靠编译器检查。 因此，要踏上这条道路，最好先&quot;带上&quot;下面的这些工具：</p>
+
+<h3 id='miri'>Miri</h3>
+
+<p><a href='https://github.com/rust-lang/miri'>Miri </a>是 <code>Rustc</code> 的 MIR (中级中间语言)，这是 Rust 在移交给 <code>LLVM</code> 或者<code>Cranelift</code>之前用来优化程序的中间表示，是一种解释器。 你可以用 <code>rustup</code> 运行 <code>rustup component add miri</code> 安装它。 它跑在  <code>cargo miri</code> 上-例如，<code> cargo miri test</code> 将在解释器中运行测试。 Miri 采用了很多可以检测未定义行为的技术，例如访问未初始化的数据，并会指出问题所在。 但是，它只会在被执行的代码上检测未定义行为，因此不能完整的覆盖代码。</p>
+
+<h3 id='clippy_and_rust_lints'>Clippy and Rust lints</h3>
+
+<p>Rust的官方 lints (静态分析工具) 中有很多对编写 <code>unsafe</code>  有帮助的 lint。 至少，missing<em>safety</em>docs棉绒将帮助您将所有不安全方法的要求记录在案。 另外，Rust编译器默认情况下不会激活所有棉绒； 致电rustc -W help将显示最新列表。</p>
+
+<h3 id='prusti'>Prusti</h3>
+
+<p><a href='https://github.com/viperproject/prusti-dev'>Prusti</a>  仍在开发中（目前在更新到最新的稳定Rust时存在一些问题，因此最新的稳定版本针对某些2018 Rust编译器），但是这个工具非常有前景，可让你在数学上验证给定特定条件的代码的安全性。</p>
+
+<p>基本上，你可以用数学证明代码中某些不变量是 &quot;真的&quot; 保持不变的，这对于必须支持不安全代码的不变量的安全抽象是理想的。 有关更多信息，请参见<a href='https://viperproject.github.io/prusti-dev/user-guide/'>用户指南</a>。</p>
+
+<h3 id='fuzzers'>Fuzzers</h3>
+
+<p><a href='https://rust-fuzz.github.io/book/'>Rust Fuzz Book</a> 列出了许多可与Rust一起使用的 <code>Fuzzer</code> (模糊测试器)。目前，可使用的<code>Fuzzer</code> 有 <a href='https://github.com/rust-fuzz/cargo-fuzz'>cargo-fuzz/libfuzzer</a> 和 <a href='http://lcamtuf.coredump.cx/afl/'>American Fuzzy Lop / afl.rs</a>的。两者都将为的代码创建大量的测试输入，并运行它以查找触发崩溃的某种组合。</p>
+
+<p>&gt; &gt; 译者注: 这个地方的 Fuzzer 是安全测试里面常用的模糊测试工具, 常见的就是上文提到的AFL 。而这种随机生成的测试样例被用于保证代码覆盖率, 每当遇到 crash (崩溃的样例) 并会记录下, 提示此处可能有漏洞。</p>
+
+<p>为了检测未初始化内存的使用，<a href='https://github.com/Shnatsel/libdiffuzz'>libdiffuzz</a>是一个侵入式内存分配器，它将使用不同的值来初始化每个内存分配。通过运行两次代码并比较结果，可以确定未初始化内存的哪一部分是造成了问题。更不错的是，<code>memory sanitizer</code>  是每天更新的（<a href='https://github.com/rust-lang/rust/issues/39699'>tracking lssue</a>列出了各种<code>memory sanitizer</code>及其在各个平台上的支持），会监测每一次对未初始化内存的读取，哪怕没有造成任何问题。</p>
+
+<p>尽管从统计学上讲， <code>Fuzzer</code> 比普通的属性测试更有可能找到代码路径，但不能保证他们会在任何时间后找到特定的代码路径。比如说我曾经遇到的标记化函数的 <code>bug</code>，就是由我在互联网上的一个随机文档中发现的一个 <code>unicode</code> 宽的空格触发的，当在运行了数十亿个测试案例的模糊测试一周后也并未发现。Rust fuzz 在 <a href='https://github.com/rust-fuzz/trophy-case'>trophy case</a> 上展示了不少没被 Fuzzing 到的 <code>bug</code>。如果你找到一个同样的 <code>bug</code> ，请添加它。</p>
+
+<p>&gt; &gt; 译者注: Fuzzer 不保证100%的代码覆盖率, 因为种子是随机的</p>
+
+<p><a href='https://github.com/jakubadamw/rutenspitz'>rutenspitz</a> 是一个过程宏，非常适合对状态代码（例如数据结构）进行模型测试。模型测试意味着您拥有一个 “模型” ，即一个简单但缓慢的版本，可以对要确保的行为进行建模，然后使用它来测试不安全的实现。然后它将生成一系列操作，以测试相等关系是否成立。如果你遵循了我的上述建议，则应该已经有一个安全的实施方案可以进行测试。</p>
+
+<h2 id='logrocket_:_full_visibility_into_production_rust_apps'><a href='https://logrocket.com/signup'>LogRocket</a>: Full visibility into production Rust apps</h2>
+
+<p>(广告时间到) 调试 Rust 应用程序是艰辛的，当我们遇到难以重现的问题时更是如此。 如果希望监视和跟踪 Rust 应用程序的性能，自动显示错误以及跟踪缓慢的网络请求和加载时间，请尝试 <a href='https://logrocket.com/signup'>LogRocket</a>。</p>
+
+<p><img src='../image/unsafe_rust.png' alt='' /></p>
+
+<p><code>LogRocket</code> 就像Web应用程序中的 <code>DVR</code> ，实际上记录了 Rust 应用程序中发生的所有事情。 它可以汇总并报告问题发生时应用程序所处的状态，而不用猜测为什么会发生问题。 <code>LogRocket</code> 还会监视应用程序的性能，报告诸如客户端CPU负载，客户端内存使用情况等指标。</p>
+
+<p>走一条 rust debug 现代化之路吧!  <a href='https://logrocket.com/signup'>点击即用</a>.</p>
+]]></content:encoded></item><item><title>「译」基于 Rust 用 Bevy 实现节奏大师游戏</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/Rhythm-game-in-Rust-using-bevy.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」基于_rust_用_bevy_实现节奏大师游戏'>「译」基于 Rust 用 Bevy 实现节奏大师游戏</h1>
+
+<p>译者：<a href='https://github.com/suhanyujie'>suhanyujie</a>/ 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 原文链接：https://caballerocoll.com/blog/bevy-rhythm-game/</p>
+
+<p>本文相关：</p>
+
+<p>&gt; &gt; Rust中文社群线上学习室 | 使用 Bevy 实现节奏大师游戏 &gt; ⁣&gt; &gt; &gt; * 01 <a href='https://rust-lang.feishu.cn/minutes/obcnw4jtr2832779jmg373wz'>录屏</a> &gt; * 02 <a href='https://rust-lang.feishu.cn/minutes/obcnxrrm878zw3q7c9z7bx6p'>录屏⁣</a> &gt; &gt; Rust 中文社群 飞书群 邀请你加入： &gt; &gt; * 对话群： https://applink.feishu.cn/TeLAcbDR &gt; * 话题群：https://applink.feishu.cn/TeLD868w</p>
+
+<h2 id=''></h2>
+
+<h2 id='正文'>正文</h2>
+
+<p>在这个教程中，我们基于 Rust 使用 Bevy 引擎实现一个节奏大师游戏。目的是展现如何用 Bevy 实现一些东西，特别是一些更高级的功能，如着色器，状态，和音频。</p>
+
+<p>如果你想在进入学习之前看看最终的代码，你可以在<a href='https://github.com/guimcaballero/bevy_rhythm'>这里</a>找到仓库，并且下面是一个游戏视频：</p>
+
+<p><a href='https://caballerocoll.com/images/rhythm/rhythm_working_menu_and_game.mp4'>视频资源</a></p>
+
+<p>这款游戏很简单：箭头飞过屏幕，玩家必须在正确的时间内按下正确的方向键才能让箭头消失。如果玩家成功地做到了这一点，他们将获得积分。否则，箭头会旋转着掉下来。箭头会有不同的速度，每个箭头颜色不同。游戏还有一个选择歌曲的菜单，以及一个简单的地图制作器来帮助创建歌曲地图。</p>
+
+<h2 id='bevy'>Bevy</h2>
+
+<p><a href='https://bevyengine.org/'>Bevy</a> 是一个数据驱动的游戏引擎。它使用起来非常简单，令人愉悦。它使用 <a href='https://en.wikipedia.org/wiki/Entity_component_system'>ECS</a> 来管理游戏实体及其行为。</p>
+
+<p>Bevy 有一个很受欢迎的社区，所以如果你对本教程有任何疑问，可以查阅 <a href='https://bevyengine.org/learn/book/introduction/'>Bevy book</a>，浏览\<a href='https://github.com/bevyengine/bevy/tree/master/examples'>示例]</a>，或者加入<a href='https://discord.gg/gMUk5Ph'>官方的 Discord</a> 进行提问。</p>
+
+<p>如果你发现教程中存在错误，请在这里开一个 <a href='https://github.com/guimcaballero/bevy_rhythm/issues'>Issue</a>，我会修正它。</p>
+
+<h2 id='前期准备'>前期准备</h2>
+
+<p>在本教程中，你需要熟悉 Rust。你不必成为专家，我们不会使用任何的黑魔法。虽然不是必须的，但强烈建议你去了解一下 ECS 的工作原理。</p>
+
+<p>如果你想阅读一些更简单的教程，我建议你阅读<a href='https://mbuffett.com/posts/bevy-snake-tutorial/'>基于 Rust，使用 Bevy 实现贪吃蛇</a>，或者<a href='https://caballerocoll.com/blog/bevy-chess-tutorial/'> Bevy 实现国际象棋</a>教程，可以详细了解基础知识。</p>
+
+<p>此外，我们将在本教程中使用着色器和 <a href='https://en.wikipedia.org/wiki/OpenGL_Shading_Language'>GLSL</a>。这两种知识不是必须的，因为我会提供要使用的代码，但了解 GLSL 会使你可以修改更多的东西，并让游戏真正属于你自己的。</p>
+
+<p>如果你之前从未使用过着色器，可以参考下面这些推荐链接开始学习：</p>
+
+<ul>
+<li><a href='https://www.youtube.com/watch?v=u5HAYVHsasc'>Shadertoy 入门</a>：介绍并使用 <a href='https://www.shadertoy.com/'>Shadertoy</a>。</li>
+
+<li>Unity 着色器编码入门 —— <a href='https://www.youtube.com/watch?v=9WW5-0N1DsI'>一款即兴的在线课程</a>：介绍在 Unity 中使用着色器。非 Unity 官方指定的大部分资料都在这儿。</li>
+
+<li><a href='https://www.youtube.com/watch?v=C0uJ4sZelio'>Unity 教程：着色器的实用介绍 —— 第一部分</a>：与上面类似。</li>
+</ul>
+
+<h2 id='创建一个项目'>创建一个项目</h2>
+
+<p>和往常一样，我们使用 <code>cargo new bevy_rhythm &amp;&amp; cd bevy_rhythm</code> 创建一个空 Rust 项目。你现在可以打开该 crate 项目。并用你喜欢的编辑器打开 <code>Cargo.toml</code>，把 <code>bevy</code> 加入到依赖项中：</p>
+
+<pre><code class="language-`rust">[package]
+name = &quot;bevy_rhythm&quot;
+version = &quot;0.1.0&quot;
+authors = [&quot;You &lt;your@emailhere.com&gt;&quot;]
+edition = &quot;2018&quot;
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bevy = &quot;0.4&quot;</code></pre>
+
+<h2 id='快速编译'>快速编译</h2>
+
+<p>我建议你启用快速编译，以确保开发过程不会太烦躁。以下是我们需要准备的：</p>
+
+<ul>
+<li>
+<p>1.LLD 链接器：普通链接器会有点慢，所以我们把其换成 LLD 链接器进行加速：</p>
+
+<ul>
+<li>Ubuntu: <code>sudo apt-get install lld</code></li>
+
+<li>Arch: <code>sudo pacman -S lld</code></li>
+
+<li>Windows: <code>cargo install -f cargo-binutils and rustup component add llvm-tools-preview</code></li>
+
+<li>MacOS: <code>brew install michaeleisel/zld/zld</code></li>
+</ul>
+</li>
+
+<li>2.为该项目启用 Rust 的 nightly 版本：rustup 工具链安装 nightly 版，并且在项目目录中设置 rustup 为 nightly 进行启用。</li>
+
+<li>3.把<a href='https://github.com/bevyengine/bevy/blob/master/.cargo/config_fast_builds'>这个文件</a>的内容拷贝到 <code>bevy_rhythm/.cargo/config</code> 中。</li>
+</ul>
+
+<p>以上就是所有要准备的事情了，现在运行游戏来编译所有的库。编译完成后，你应该在命令行中看到 <code>Hello, world!</code>。</p>
+
+<p>注意：如果你看到游戏性能很差，或者看到<a href='https://github.com/guimcaballero/bevy_rhythm/issues/1'>加载资源很慢</a>，你可以用 <code>cargo run --release</code> 的编译模式下运行。编译时间可能会稍长一些，但游戏运行会更加流畅！</p>
+
+<h2 id='开始'>开始</h2>
+
+<p>任何 Bevy 游戏的第一步都是增加小段示例代码来启动应用的。打开 <code>main.rs</code>，并将已有的 <code>main</code> 函数替换为下面的内容：</p>
+
+<pre><code class="language-`rust">use bevy::{input::system::exit_on_esc_system, prelude::*};
+
+fn main() {
+    App::build()
+        // 抗锯齿设置 samples 为 4
+        .add_resource(Msaa { samples: 4 })
+        // 设置 WindowDescriptor 资源修改标题和窗口大小
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_plugins(DefaultPlugins)
+        .add_system(exit_on_esc_system.system())
+        .run();
+}</code></pre>
+
+<p>如果你使用 <code>cargo run</code> 运行程序，你会看到一个空白窗口：</p>
+
+<p><img src='https://caballerocoll.com/images/bevy_empty_window.png' alt='' /></p>
+
+<p>这一步设置 Bevy <code>App</code>，添加默认插件。这将包括转换、输入、窗口等游戏运行所需的元素。如果你不需要这些功能， Bevy 是模块化的，你可以选择只开启你需要的功能。我们要新增这些插件，所以需要使用 <code>add_plugins</code> 和 <code>DefaultPlugins</code>。</p>
+
+<p>我们还添加了两个资源：<code>Msaa</code> 和 <code>WindowDescriptor</code>，分别用于配置 anti-aliasing，以及窗口大小和标题。最后，我们添加了 Bevy 的 <code>exit_on_esc_system</code>，它的作用是按下 esc 键时关闭游戏。</p>
+
+<h2 id='bevy_中的_ecs'>Bevy 中的 ECS</h2>
+
+<p>下面是 ECS 如何在 Bevy 中工作的介绍。如果你已经知道它是如何工作的，可以<a href='https://caballerocoll.com/blog/bevy-rhythm-game/#adding-a-setup-system'>跳过本节</a>。这和我们的游戏无关，我将使用 <a href='https://bevyengine.org/learn/book/getting-started/ecs/'>Bevy book</a> 中的例子来说明它是如何运作的。你不需要复制这里的代码，只需读懂它即可。</p>
+
+<p>Bevy 的 ECS 是 <a href='https://github.com/Ralith/hecs'>hecs</a> 的一个分支版本。它使用 Rust 结构体作为组件，不需要添加宏或其他复杂的东西。例如：</p>
+
+<pre><code class="language-`rust">// 有两个字段的结构体组件
+struct Position { 
+    x: f32,
+    y: f32
+}
+
+// 元组组件
+struct Name(String);
+
+// 我们甚至可以使用标记组件
+struct Person;</code></pre>
+
+<p>Systems are just normal Rust functions, that have access to <code>Querys</code>: \&gt;这个“系统”中可以使用正常的 Rust 函数，访问 <code>Querys</code>：</p>
+
+<pre><code class="language-`rust">fn set_names(mut query: Query&lt;(&amp;Position, &amp;mut Name), With&lt;Person&gt;&gt;) {
+    for (pos, mut name) in query.iter_mut() {
+        name.0 = format!(&quot;position: ({}, {})&quot;, pos.x, pos.y);
+    }
+}</code></pre>
+
+<p>一次查询可以访问组件中所有实体。在前面的示例中，<code>query</code> 参数允许我们迭代包括 <code>Person</code> 组件在内以及 <code>Position</code> 和 <code>Name</code> 等组件实体。因为我们用 <code>&amp;mut Name</code> 替代 <code>&amp;Name</code>，所以可以对实体进行修改。如果对 <code>&amp;Name</code> 类型的该值进行修改，Rust 会报错。</p>
+
+<p>有时候我们想要只在游戏开始时运行一次的机制。我们可以通过“启动系统”来做到这一点。“启动系统”和“普通系统”完全一样，唯一的区别是我们将如何把它加到游戏中，这会在后面进行详细讲解。下面是一个使用 <code>Commands</code> 生成一些实体的“启动系统”：</p>
+
+<pre><code class="language-`rust">fn setup(commands: &amp;mut Commands) {
+    commands
+        .spawn((Position { x: 1., y: 2. }, Name(&quot;Entity 1&quot;.to_string())))
+        .spawn((Position { x: 3., y: 9. }, Name(&quot;Entity 2&quot;.to_string())));
+}</code></pre>
+
+<p>Bevy 也有资源的概念，它可以保存全局数据。例如，内置的 <code>Time</code> 资源给我们提供游戏中的当前时间。为了在“系统”中使用这类资源，我们需要用到 <code>Res</code>：</p>
+
+<pre><code class="language-`rust">fn change_position(mut query: Query&lt;&amp;mut Position&gt;, time: Res&lt;Time&gt;) {
+    for mut pos in query.iter_mut() {
+        pos.x = time.seconds_since_startup() as f32;
+    }
+}</code></pre>
+
+<p>我们自定义资源也很简单：</p>
+
+<pre><code class="language-`rust">// 一个简单的资源
+struct Scoreboard {
+    score: usize,
+}
+
+// 另一个资源，它实现了 Default trait
+#[derive(Default)]
+struct OtherScore(f32);</code></pre>
+
+<p>我们有两种方法初始化资源：第一种是使用 <code>.add_resource</code> 并提供我们需要的结构体，另一种是实现了 <code>Default</code> 和 <code>FromResources</code> 的 <code>.init_resource</code>。</p>
+
+<p>下面我们如何把它们加到游戏中：</p>
+
+<pre><code class="language-`rust">fn main() {
+    App::build()
+        // 新增资源的第一种方法
+        .add_resource(Scoreboard { score: 7 })
+        // 第二种方法，通过 Default 的初始化加载资源
+        .init_resource::&lt;OtherScore&gt;()
+
+        // 增加“启动系统”，游戏启动时只会运行一次
+        .add_startup_system(setup.system())
+        // 增加一个“普通系统”，每一帧都会运行一次
+        .add_system(set_names.system())
+        .add_system(change_position.system())
+        .run();
+}</code></pre>
+
+<p>Another cool thing Bevy has are Plugins, which we&#8217;ve already seen when we used <code>DefaultPlugins</code> in the previous section. Plugins allow us to wrap features that belong together, which then let&#8217;s us enable and disable them together easily. Plugins also provide organization, which is the main purpose we&#8217;ll be creating our own in this tutorial. \&gt;Bevy 还有一个很酷的东西是插件，我们在上一节使用 <code>DefaultPlugins</code> 时看到了。插件可以让我们将一些特性包装在一起，这可以让我们很容易地启用和禁用它，插件也提供了组织功能，这也是我们在这篇教程中自定义插件地主要功能点。</p>
+
+<p>如果有些东西不清楚，不用担心，我们会在后面更详细地解释所有内容。</p>
+
+<h2 id='增加系统设置'>增加系统设置</h2>
+
+<p>每个游戏都需要一个相机来渲染对象，所以我们将从如何添加一个生成相机的“启动系统”开始。因为这是一款 2D 游戏，所以我们要使用 <code>Camera2dBundle</code>。</p>
+
+<pre><code class="language-`rust">use bevy::{input::system::exit_on_esc_system, prelude::*};
+
+fn main() {
+    App::build()
+        // 设定[抗锯齿](https://cn.bing.com/search?q=%E7%BB%98%E5%88%B6+%E6%8A%97%E9%94%AF%E9%BD%BF&amp;qs=n&amp;form=QBRE&amp;sp=-1&amp;pq=%E7%BB%98%E5%88%B6+%E6%8A%97%E9%94%AF%E9%BD%BF)，samples 参数值为 4
+        .add_resource(Msaa { samples: 4 })
+        // 设定 WindowDescriptor 资源，定义我们需要的标题和窗口大小
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_startup_system(setup.system()) // &lt;--- New
+        .add_plugins(DefaultPlugins)
+        .add_system(exit_on_esc_system.system())
+        .run();
+}
+
+fn setup(commands: &amp;mut Commands) {
+    commands.spawn(Camera2dBundle::default());
+}</code></pre>
+
+<p>bundle 是组件的集合。在本例中，<code>Camera2dBundle</code> 将创建一个包含 <code>Camera</code>，<code>OrthographicProjection</code>，<code>VisibleEntities</code>，<code>Transform</code> 和 <code>GlobalTransform</code> 的 实体。其中大部分是我们玩游戏时不需要用到的，所以我们使用抽象的 <code>Camera2dBundle</code> 添加组件。</p>
+
+<p>注意：我们还可以使用一个元组代替 bundle 来添加所有组件：</p>
+
+<pre><code class="language-`rust">fn setup(commands: &amp;mut Commands) {
+    commands.spawn((Camera::default(), OrthographicProjection::default(), VisibleEntities::default(), Transform::default(), GlobalTransform::default()));
+}</code></pre>
+
+<p>这段代码实际上还不能运行，因为我们还需要在 camera 和投影组件中设置一些字段，但我觉得它明确地体现了使用 bundle 和元组来添加结构是很相似的。</p>
+
+<h2 id='加载精灵'>加载精灵</h2>
+
+<p>在这部分中，我们会添加一些“精灵”，让它们四处移动。为此，我们需要创建一个 <code>assets</code> 目录，我们将存储一些<a href='https://github.com/guimcaballero/bevy_rhythm/tree/main/assets/images'>图像</a>和<a href='https://github.com/guimcaballero/bevy_rhythm/tree/main/assets/fonts'>字体文件</a>。目录中有两个子文件夹，图像和字体。你可以点击前面提到的链接，从 GitHub 仓库下载。</p>
+
+<p>你的资源目录应该如下所示：</p>
+
+<pre><code class="language-`">assets
+├── fonts
+│   └── FiraSans-Bold.ttf
+└── images
+    ├── arrow_blue.png
+    ├── arrow_border.png
+    ├── arrow_green.png
+    └── arrow_red.png</code></pre>
+
+<p>我们将使用带颜色的箭头来表示不同速度的箭头，并使用带边框的箭头来标记目标区域。</p>
+
+<p>有了这些静态资源，我们就可以开始编写一些游戏动画了。我们将创建一个 <code>arrows.rs</code> 文件，它将包含生成，移动，清除箭头等相关操作。首先要做的是为“箭头精灵”保留资源，这样我们就不必在每次创建箭头时重新加载它们：</p>
+
+<pre><code class="language-`rust">use bevy::prelude::*;
+
+/// 为箭头保留材料和资源
+struct ArrowMaterialResource {
+    red_texture: Handle&lt;ColorMaterial&gt;,
+    blue_texture: Handle&lt;ColorMaterial&gt;,
+    green_texture: Handle&lt;ColorMaterial&gt;,
+    border_texture: Handle&lt;ColorMaterial&gt;,
+}
+impl FromResources for ArrowMaterialResource {
+    fn from_resources(resources: &amp;Resources) -&gt; Self {
+        let mut materials = resources.get_mut::&lt;Assets&lt;ColorMaterial&gt;&gt;().unwrap();
+        let asset_server = resources.get::&lt;AssetServer&gt;().unwrap();
+
+        let red_handle = asset_server.load(&quot;images/arrow_red.png&quot;);
+        let blue_handle = asset_server.load(&quot;images/arrow_blue.png&quot;);
+        let green_handle = asset_server.load(&quot;images/arrow_green.png&quot;);
+        let border_handle = asset_server.load(&quot;images/arrow_border.png&quot;);
+        ArrowMaterialResource {
+            red_texture: materials.add(red_handle.into()),
+            blue_texture: materials.add(blue_handle.into()),
+            green_texture: materials.add(green_handle.into()),
+            border_texture: materials.add(border_handle.into()),
+        }
+    }
+}</code></pre>
+
+<p>通过实现 <code>FromResources</code> trait，在我们调用 <code>.init_resource::&lt;ArrowMaterialResource&gt;()</code> 时，Bevy 会管理并初始化资源，在进程中加载图片。</p>
+
+<p>如你所看到的，实际的资源加载是 <code>Handle&lt;ColorMaterial&gt;</code> 而不是 <code>ColorMaterials</code>。这样，当我们创建箭头实例时，我们可以使用对应的 handle，并且它们将复用已存在的资源，而不是每个都各自独有一份。</p>
+
+<h2 id='生成并移动箭头'>生成并移动箭头</h2>
+
+<p>我们接下来要做的是生成箭头并在屏幕上移动它们。我们从实现每秒生成一个箭头的“系统”开始。箭头会包含一个名为 <code>Arrow</code> 的空（结构体）组件：</p>
+
+<pre><code class="language-`rust">/// 箭头组件
+struct Arrow;
+
+/// 跟踪何时生成新箭头
+struct SpawnTimer(Timer);
+
+/// 生成箭头
+fn spawn_arrows(
+    commands: &amp;mut Commands,
+    materials: Res&lt;ArrowMaterialResource&gt;,
+    time: Res&lt;Time&gt;,
+    mut timer: ResMut&lt;SpawnTimer&gt;,
+) {
+    if !timer.0.tick(time.delta_seconds()).just_finished() {
+        return;
+    }
+
+    let transform = Transform::from_translation(Vec3::new(-400., 0., 1.));
+    commands
+        .spawn(SpriteBundle {
+            material: materials.red_texture.clone(),
+            sprite: Sprite::new(Vec2::new(140., 140.)),
+            transform,
+            ..Default::default()
+        })
+        .with(Arrow);
+}</code></pre>
+
+<p>在这个系统中，我们使用了 <code>Timer</code>，这是 Bevy 中执行每隔 <code>x</code> 秒重复操作的最佳方式。我们使用 <a href='https://rust-unofficial.github.io/patterns/patterns/newtype.html'>newtype 模式</a>进行封装，这样我们能够把 <code>SpawnTimer</code> 与其他的定时器区分开。我们需要使用形如 <code>.add_resource(SpawnTimer(Timer::from_seconds(1.0, true)))</code> 的调用方式进行初始化，调用稍后会进行。将 <code>true</code> 作为参数值传递表示计时器结束时会再次重复执行。</p>
+
+<p>要使用计时器，我们必须手动调用它的 <code>tick</code> 方法，入参 time 是距离上次调用所间隔的时间差，然后我们可以使用 <code>just_finished</code> 来查看定时器是否完成。实际上我们所做的是提前检查定时器是否完成来确保 <code>spawn_arrows</code> 系统每秒只运行一次。</p>
+
+<p>系统的其余部分将创建一个 <code>Transform</code> 组件，我们将其添加到箭头组件中，它会返回 <code>SpriteBundle</code> 从而生成箭头，并给箭头实体一个来自 <code>ArrowMaterialResource</code> 的红色纹理。我们使用 <code>Commands</code> 中的 <code>with</code> 方法添加了 <code>Arrow</code> 组件。这样，我们创建的实体将拥有所有的 <code>SpriteBundle</code> 和 <code>Arrow</code> 组件。</p>
+
+<p>注意：这个系统只是临时的，并且它会被在某个特定时间内生成箭头的东西所覆盖。</p>
+
+<p>现在，我们生成的那些箭头就在那了，我们需要用另一个系统让它们向右移动：</p>
+
+<pre><code class="language-`rust">/// 箭头前移
+fn move_arrows(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    for (mut transform, _arrow) in query.iter_mut() {
+        transform.translation.x += time.delta_seconds() * 200.;
+    }
+}</code></pre>
+
+<p><code>move_arrows</code> 使用 <code>Query</code> 来获取所有带有 <code>Transform</code> 和 <code>Arrow</code> 组件的实体，并通过增加 x 坐标值来将它们向右移动一点点。我们还使用了 <code>Time::delta_seconds()</code> 来根据当前帧到上一帧的时间来增加距离。</p>
+
+<p>我们把这些 <code>ArrowMaterialResource</code> 和 <code>SpawnTimer</code> 等系统连接到一个插件中：</p>
+
+<pre><code class="language-`rust">pub struct ArrowsPlugin;
+impl Plugin for ArrowsPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app
+            // 初始化资源
+            .init_resource::&lt;ArrowMaterialResource&gt;()
+            .add_resource(SpawnTimer(Timer::from_seconds(1.0, true)))
+            // 增加 system
+            .add_system(spawn_arrows.system())
+            .add_system(move_arrows.system());
+    }
+}</code></pre>
+
+<p>我们现在可以将 <code>main.rs</code> 改为如下内容：</p>
+
+<pre><code class="language-`rust">use bevy::{input::system::exit_on_esc_system, prelude::*};
+
+mod arrows;
+use arrows::ArrowsPlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin) // &lt;--- New
+        .run();
+}
+
+fn setup(commands: &amp;mut Commands) {
+    commands.spawn(Camera2dBundle::default());
+}</code></pre>
+
+<p>我们需要做的只是增加 <code>.add_plugin(ArrowsPlugin)</code>，这样所有的系统和资源就被正确地集成在 <code>arrows.rs</code> 中。</p>
+
+<p>如果你运行程序，你会看到箭头在屏幕上飞舞：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_red_arrows_moving.mp4'>视频资源</a></p>
+
+<h2 id='类型和常量'>类型和常量</h2>
+
+<p>我们在上一节中对一些值硬编码了。因此我们需要重新使用它们，我们要新建一个小模块来保存我们的常量。创建一个名为 <code>consts.rs</code> 的文件，并添加以下内容：</p>
+
+<pre><code class="language-`rust">/// 箭头移动的速度
+pub const BASE_SPEED: f32 = 200.;
+
+/// 箭头生成时的 X 坐标值，应该在屏幕之外
+pub const SPAWN_POSITION: f32 = -400.;
+
+/// 箭头应该被正确点击时的 X 坐标值
+pub const TARGET_POSITION: f32 = 200.;
+
+/// 点击箭头时的容错间隔
+pub const THRESHOLD: f32 = 20.;
+
+/// 箭头从刷出到目标区域的总距离
+pub const DISTANCE: f32 = TARGET_POSITION - SPAWN_POSITION;</code></pre>
+
+<p>其中一些常数稍后才会用到。在 <code>main.rs</code> 中增加 <code>mod consts</code>，以导入模块使其可用。我们可以在 <code>arrows.rs</code> 中的 <code>spawn_arrows</code> 和 <code>move_arrows</code> 替换掉对应硬编码的值。</p>
+
+<pre><code class="language-`rust">use crate::consts::*;
+
+fn spawn_arrows(
+    commands: &amp;mut Commands,
+    materials: Res&lt;ArrowMaterialResource&gt;,
+    time: Res&lt;Time&gt;,
+    mut timer: ResMut&lt;SpawnTimer&gt;,
+) {
+    if !timer.0.tick(time.delta_seconds()).just_finished() {
+        return;
+    }
+
+    let transform = Transform::from_translation(Vec3::new(SPAWN_POSITION, 0., 1.));
+    commands
+        .spawn(SpriteBundle {
+            material: materials.red_texture.clone(),
+            sprite: Sprite::new(Vec2::new(140., 140.)),
+            transform,
+            ..Default::default()
+        })
+        .with(Arrow);
+}
+
+/// 箭头前移
+fn move_arrows(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    for (mut transform, _arrow) in query.iter_mut() {
+        transform.translation.x += time.delta_seconds() * BASE_SPEED;
+    }
+}</code></pre>
+
+<p>现在我们的箭头在屏幕上移动，但他们都面向相同的方向、相同的速度移动，且颜色相同。为了能够区分它们，我们将创建两个不同的枚举，一个用于表示方向（上、下、左、右），一个表示速度（慢、中、快）。</p>
+
+<p>注意：我们把它叫做 <code>Directions</code> 而非 <code>Direction</code>，因为后者是一个<a href='https://docs.rs/bevy/0.4.0/bevy/prelude/enum.Direction.html'> Bevy 枚举</a>。通过给它取一个稍微不一样的名字，防止混淆带来的麻烦。</p>
+
+<p>让我们创建一个 <code>types.rs</code> 文件，并把上面提到的枚举值放于其中：</p>
+
+<pre><code class="language-`rust">use crate::consts::*;
+use bevy::input::{keyboard::KeyCode, Input};
+use core::f32::consts::PI;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Directions {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+impl Directions {
+    /// 检查相应的方向键是否被按下
+    pub fn key_just_pressed(&amp;self, input: &amp;Input&lt;KeyCode&gt;) -&gt; bool {
+        let keys = match self {
+            Directions::Up =&gt; [KeyCode::Up, KeyCode::D],
+            Directions::Down =&gt; [KeyCode::Down, KeyCode::F],
+            Directions::Left =&gt; [KeyCode::Left, KeyCode::J],
+            Directions::Right =&gt; [KeyCode::Right, KeyCode::K],
+        };
+
+        keys.iter().any(|code| input.just_pressed(*code))
+    }
+
+    /// 返回此方向的箭头的旋转角度
+    pub fn rotation(&amp;self) -&gt; f32 {
+        match self {
+            Directions::Up =&gt; PI * 0.5,
+            Directions::Down =&gt; -PI * 0.5,
+            Directions::Left =&gt; PI,
+            Directions::Right =&gt; 0.,
+        }
+    }
+
+    /// 返回此方向的箭头的 y 坐标值
+    pub fn y(&amp;self) -&gt; f32 {
+        match self {
+            Directions::Up =&gt; 150.,
+            Directions::Down =&gt; 50.,
+            Directions::Left =&gt; -50.,
+            Directions::Right =&gt; -150.,
+        }
+    }
+}</code></pre>
+
+<p>首先，我们添加 <code>Directions</code> 枚举。并且已经实现了三种不同的方法。</p>
+
+<p><code>key_just_pressed</code>，用于检查被按下的方向键。我已经决定增加 <code>D, F, J, K</code> 作为可能的键，因为我键盘上的方向键比较小。如果你是 FPS 玩家，你可以使用 <code>W, S, A, D</code>，或者 VIM 世界的 <code>K, J, H, L</code> 来替代它们。</p>
+
+<p>注意：如果你不太习惯使用迭代器，下面是用传统的方法实现 <code>key_just_pressed</code>：</p>
+
+<pre><code class="language-`rust">/// 检查与方向对应的按键是否被按下
+pub fn key_just_pressed(&amp;self, input: &amp;Input&lt;KeyCode&gt;) -&gt; bool {
+    match self {
+        Up =&gt; input.just_pressed(KeyCode::Up) || input.just_pressed(KeyCode::D),
+        Down =&gt; input.just_pressed(KeyCode::Down) || input.just_pressed(KeyCode::F),
+        Left =&gt; input.just_pressed(KeyCode::Left) || input.just_pressed(KeyCode::J),
+        Right =&gt; input.just_pressed(KeyCode::Right) || input.just_pressed(KeyCode::K),
+    }
+}</code></pre>
+
+<p><code>rotation</code> 表示我们需要将“箭头精灵”旋转多少度以将其指向正确的方向。<code>y</code> 表示箭头的 <code>y</code> 坐标值。我决定把箭头的顺序调整为 <code>Up, Down, Left, Right</code>，但如果你喜欢其他顺序，你可以自己修改。</p>
+
+<pre><code class="language-`rust">#[derive(Copy, Clone, Debug)]
+pub enum Speed {
+    Slow,
+    Medium,
+    Fast,
+}
+impl Speed {
+    /// 返回箭头移动的实际速度
+    pub fn value(&amp;self) -&gt; f32 {
+        BASE_SPEED * self.multiplier()
+    }
+    /// Speed 乘数
+    pub fn multiplier(&amp;self) -&gt; f32 {
+        match self {
+            Speed::Slow =&gt; 1.,
+            Speed::Medium =&gt; 1.2,
+            Speed::Fast =&gt; 1.5,
+        }
+    }
+}</code></pre>
+
+<p>接下来，我们添加了 <code>Speed</code> 枚举。我们实现了两个方法：一个是乘法，它表示箭头应该相对于 <code>BASE_SPEED</code> 所移动的距离；另一个是 <code>value</code>，它是执行乘法运算得到的值。</p>
+
+<p>这是一部分代码，我不希望特别复杂！接下来要添加的类型是 <code>ArrowTime</code> 和 <code>SongConfig</code>。前者记录何时生成一个箭头，以及它的方向和速度。第二个将保存所有箭头实体的列表：</p>
+
+<pre><code class="language-`rust">#[derive(Clone, Copy, Debug)]
+/// 跟踪记录箭头应该在什么时候生成，以及箭头的速度和方向。
+pub struct ArrowTime {
+    pub spawn_time: f64,
+    pub speed: Speed,
+    pub direction: Directions,
+}
+
+#[derive(Debug)]
+pub struct SongConfig {
+    pub arrows: Vec&lt;ArrowTime&gt;,
+}</code></pre>
+
+<p>我们的 <code>ArrowTime</code> 有个问题。在内部，我们需要知道箭头什么时候生成，但在生成它时，我们希望指定应该在什么时候点击它。因为每个箭头都有不同的速度，所以仅仅减去几秒是不够的。为了解决这个问题，我们要创建一个 <code>new</code> 函数，包含 <code>click_time</code>，<code>speed</code> 和 <code>direction</code>，并设置相应的 <code>spawn_time</code>：</p>
+
+<pre><code class="language-`rust">impl ArrowTime {
+    fn new(click_time: f64, speed: Speed, direction: Directions) -&gt; Self {
+        let speed_value = speed.value();
+        Self {
+            spawn_time: click_time - (DISTANCE / speed_value) as f64,
+            speed,
+            direction,
+        }
+    }
+}</code></pre>
+
+<p>为了进行测试，我们将创建一个函数，它返回硬编码的 <code>SongConfig</code>，其中包含了不同的速度和方向的箭头：</p>
+
+<pre><code class="language-`rust">pub fn load_config() -&gt; SongConfig {
+    SongConfig {
+        arrows: vec![
+            ArrowTime::new(1., Speed::Slow, Directions::Up),
+            ArrowTime::new(2., Speed::Slow, Directions::Down),
+            ArrowTime::new(3., Speed::Slow, Directions::Left),
+            ArrowTime::new(4., Speed::Medium, Directions::Up),
+            ArrowTime::new(5., Speed::Fast, Directions::Right),
+        ],
+    }
+}</code></pre>
+
+<p>最后，我们可以进入 <code>main.rs</code> 并将 <code>setup</code> 系统修改成下方所示：</p>
+
+<pre><code class="language-`rust">mod types;
+
+fn setup(commands: &amp;mut Commands) {
+    let config = types::load_config();
+
+    commands
+        .spawn(Camera2dBundle::default())
+        .insert_resource(config);
+}</code></pre>
+
+<p>注意：我们使用 <code>insert_resource</code> 替代 <code>add_resource</code> 或 <code>init_resource</code>，因为后者是 <code>AppBuilder</code>，前者是用在 <code>Commands</code> 中。</p>
+
+<p>如果我们现在运行游戏，没有任何变化，但仍然是能运行的，这很棒！我们进入 <code>arrows.rs</code> 文件，修改它使它能根据 <code>SongConfig</code> 中的列表生成箭头。</p>
+
+<h2 id='定时生成箭头'>定时生成箭头</h2>
+
+<p>现在我们有了一个要生成的箭头列表，我们可以删除所有定时器的内容，并修改 <code>spawn_arrows</code> 系统来检查每一帧刷出的箭头。</p>
+
+<p>我们可以想到的第一个实现是循环遍历 <code>SongConfig</code> 中的所有箭头，并检查哪些箭头应该在当前帧中生成。这是可行的，但我们会在每一帧都循环遍历一个可能会很大的数组。我们硬编码的只有 5 个箭头，这不成问题，但一整首歌的情况下，箭头可能会超过 1000 个，就算电脑很快，玩家也不希望游戏让它们的 CPU “热”起来。</p>
+
+<p>相反，我们将假设 <code>SongConfig</code> 中的箭头是有序的。我们需要在歌曲开始前将它们进行排序，这很简单。了解了这一点，我们只能先检查列表中的第一个箭头，如果它应该被生成出来，我们也会检查下一个箭头，一次类推，直到我们到达那个不需要再生成的箭头为止。由于箭头是有序的，如果一个箭头不需要生成，那么其后的箭头也无需生成。在这之后，我们需要移除列表中已经被生成的箭头。</p>
+
+<p>我们还需要给 <code>Arrow</code> 新增 <code>Speed</code> 和 <code>Directions</code> 字段：</p>
+
+<pre><code class="language-`rust">// 在顶部
+use crate::types::*;
+
+/// “精灵实体”上的组件
+struct Arrow {
+    speed: Speed,
+    direction: Directions,
+}
+
+/// 生成箭头
+fn spawn_arrows(
+    commands: &amp;mut Commands,
+    mut song_config: ResMut&lt;SongConfig&gt;,
+    materials: Res&lt;ArrowMaterialResource&gt;,
+    time: Res&lt;Time&gt;,
+) {
+    // 我们得到了从启动到当前的时间（secs）以及到最后一次迭代的时间（secs_last），这样我们就可以检查是否有箭头应该在这个窗口中生成。
+
+    // 歌曲在启动后 3 秒开始，所以减去 3 秒。
+    let secs = time.seconds_since_startup() - 3.;
+    let secs_last = secs - time.delta_seconds_f64();
+
+    // 计数器用于计算列表中产生和删除箭头数量
+    let mut remove_counter = 0;
+    for arrow in &amp;song_config.arrows {
+        // 列表是有序的，所以我们遍历检查直到第一个不满足条件为止
+        // 检查箭头是否应该在当前帧和下一帧之间的时间点生成
+        if secs_last &lt; arrow.spawn_time &amp;&amp; arrow.spawn_time &lt; secs {
+            remove_counter += 1;
+
+            // 根据速度得到与之匹配的箭头素材（纹理）
+            let material = match arrow.speed {
+                Speed::Slow =&gt; materials.red_texture.clone(),
+                Speed::Medium =&gt; materials.blue_texture.clone(),
+                Speed::Fast =&gt; materials.green_texture.clone(),
+            };
+
+            let mut transform =
+                Transform::from_translation(Vec3::new(SPAWN_POSITION, arrow.direction.y(), 1.));
+            // 按一定的方向旋转箭头
+            transform.rotate(Quat::from_rotation_z(arrow.direction.rotation()));
+            commands
+                .spawn(SpriteBundle {
+                    material,
+                    sprite: Sprite::new(Vec2::new(140., 140.)),
+                    transform,
+                    ..Default::default()
+                })
+                .with(Arrow {
+                    speed: arrow.speed,
+                    direction: arrow.direction,
+                });
+        } else {
+            break;
+        }
+    }
+
+    // 移除列表中生成的箭头
+    for _ in 0..remove_counter {
+        song_config.arrows.remove(0);
+    }
+}</code></pre>
+
+<p>上面这段代码，我们来分析一下它。</p>
+
+<p>在“系统”开始时，我们先获取游戏已经开始多久了，以及“系统”最后一次运行的时间点。我们使用 <a href='https://docs.rs/bevy/0.4.0/bevy/core/struct.Time.html#method.delta_seconds_f64'>delta_seconds_f64</a> 来获取，它返回自最后一次游戏更新以来的时间。有了这两个值，我们就能知道该生成哪个箭头。因为 Bevy 不会每纳秒都更新（不代表所有的游戏引擎），所以如果只是简单地检查 <code>spawn_time</code> 是否等于当前时间会导致我们跳过需要处理的箭头。例如，我们可能有一个箭头，它刷出的时间被设为 <code>3.0</code>。Bevy 可以在 <code>2.99</code> 时运行这个“系统”，然后 <code>3.01</code> 时运行一次。由于箭头被指定为在 <code>3.0</code> 时生成，它就与运行“系统”的时间不匹配，导致它永远不会生成。</p>
+
+<p>我们换个方法，在“系统”开始时检查当前时间和最后结束时的时间，对于上面的举例，在第二次运行该“系统”时，就会有 <code>secs = 3.01</code> 以及 <code>secs_last = 2.99</code>，因为我们的箭头产生的时间超过 <code>secs_last</code>，但小于下一帧的 <code>secs</code>，所以能够生成。大功告成！</p>
+
+<p>有了这个，我们可以对 <code>move_arrows</code> 做一下小修改，让它兼顾速度的影响，可以使用我们之前创建的 <code>Speed::value()</code> 方法：</p>
+
+<pre><code class="language-`rust">/// 把箭头向前移动
+fn move_arrows(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    for (mut transform, arrow) in query.iter_mut() {
+        transform.translation.x += time.delta_seconds() * arrow.speed.value();
+    }
+}</code></pre>
+
+<p>很酷，现在每个箭头都显示了正确的颜色，并以相应的速度移动：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_colored_arrows_moving_at_speed.mp4'>视频资源</a></p>
+
+<h2 id='增加目标区域箭头'>增加目标区域箭头</h2>
+
+<p>现在我们将使用 <code>border_texture</code> 去创造目标箭头，以便玩家能够知道何时应该按下按键。为此，我们将创建另一个“启动系统”，<code>setup_target_arrows</code> 以及一个标记组件，<code>TargetArrow</code>：</p>
+
+<pre><code class="language-`rust">struct TargetArrow;
+
+fn setup_target_arrows(commands: &amp;mut Commands, materials: Res&lt;ArrowMaterialResource&gt;) {
+    use Directions::*;
+    let directions = [Up, Down, Left, Right];
+
+    for direction in directions.iter() {
+        let mut transform =
+            Transform::from_translation(Vec3::new(TARGET_POSITION, direction.y(), 1.));
+        transform.rotate(Quat::from_rotation_z(direction.rotation()));
+        commands
+            .spawn(SpriteBundle {
+                material: materials.border_texture.clone(),
+                sprite: Sprite::new(Vec2::new(140., 140.)),
+                transform,
+                ..Default::default()
+            })
+            .with(TargetArrow);
+    }
+}</code></pre>
+
+<p>为了创建四个箭头，我们创建了一个有四个方向值的数组，然后循环调用 <code>border_texture</code> 和空的 <code>TargetArrow</code> 组件。</p>
+
+<p>不要忘记在 <code>ArrowsPlugin</code> 中添加 <code>setup_target_arrows</code> 作为“启动系统”：</p>
+
+<pre><code class="language-`rust">pub struct ArrowsPlugin;
+impl Plugin for ArrowsPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;ArrowMaterialResource&gt;()
+            .add_startup_system(setup_target_arrows.system())
+            .add_system(spawn_arrows.system())
+            .add_system(move_arrows.system());
+    }
+}</code></pre>
+
+<p>好了，我们现在把“目标区域箭头”准备好了。</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_target_arrows.mp4'>视频资源</a></p>
+
+<h2 id='按键按下时清除箭头'>按键按下时清除箭头</h2>
+
+<p>现在我们有了目标箭头，我们接下来要实现一个“系统”，它的作用是，当箭头刷出时，并且如果在特定的阈值内，用户点击了正确的操作键，箭头就会消失。我们将创建一个名为 <code>despawn_arrows</code> 的新“系统”：</p>
+
+<pre><code class="language-`rust">/// 用户在箭头到达尽头前按下正确的按键，箭头消失。
+fn despawn_arrows(
+    commands: &amp;mut Commands,
+    query: Query&lt;(Entity, &amp;Transform, &amp;Arrow)&gt;,
+    keyboard_input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+) {
+    for (entity, transform, arrow) in query.iter() {
+        let pos = transform.translation.x;
+
+        // 检查按下按键时，是否是在特定的阈值内
+        if (TARGET_POSITION - THRESHOLD..=TARGET_POSITION + THRESHOLD).contains(&amp;pos)
+            &amp;&amp; arrow.direction.key_just_pressed(&amp;keyboard_input)
+        {
+            commands.despawn(entity);
+        }
+
+        // 当箭头离开屏幕时，箭头消失
+        if pos &gt;= 2. * TARGET_POSITION {
+            commands.despawn(entity);
+        }
+    }
+}</code></pre>
+
+<p>我们使用 <code>Query</code> 来查询所有实现了 <code>Transform</code> 和 <code>Arrow</code> 的实体。我们在查询中添加了 <code>Entity</code>，这样可以访问实体的“id”，然后我们可以在 <code>Commands::despawn()</code> 中根据它来消除实体。然后我们循环所有箭头，并检查 x 坐标值是否在点击的阈值内，如果是，则消除箭头。还有第二个检查，当箭头被错过离开屏幕时，它在最后也会被消除。它是在 x 坐标值大于等于 <code>2. * TARGET_POSITION</code> 时消除。</p>
+
+<p>记得用 <code>.add_system(despawn_arrows.system())</code> 将“系统”添加到 <code>ArrowsPlugin</code> 中，这样，运行游戏时，当我们斜着看的时候，也可以将其视为一种游戏！</p>
+
+<h2 id='增加基础_ui'>增加基础 UI</h2>
+
+<p>在这一节中，我们将实现一些基本的 UI，目前只是显示了歌曲中的当前时间。我们会把它保存在 <code>ui.rs</code> 中：</p>
+
+<pre><code class="language-`rust">use bevy::prelude::*;
+
+fn setup_ui(
+    commands: &amp;mut Commands,
+    asset_server: ResMut&lt;AssetServer&gt;,
+    mut color_materials: ResMut&lt;Assets&lt;ColorMaterial&gt;&gt;,
+) {
+    let font = asset_server.load(&quot;fonts/FiraSans-Bold.ttf&quot;);
+    let material = color_materials.add(Color::NONE.into());
+
+    commands
+        // 时间文本节点
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    left: Val::Px(10.),
+                    top: Val::Px(10.),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            material: material.clone(),
+            ..Default::default()
+        })
+        .with_children(|parent| {
+            parent
+                .spawn(TextBundle {
+                    text: Text {
+                        value: &quot;Time: 0.0&quot;.to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 40.0,
+                            color: Color::rgb(0.9, 0.9, 0.9),
+                            ..Default::default()
+                        },
+                    },
+                    ..Default::default()
+                })
+                .with(TimeText);
+        });
+}
+
+struct TimeText;</code></pre>
+
+<p>在这个系统中，我们使用了父子关系模式（parenting），使得子实体可以相对于父实体进行转换。当我们把子实体加到父实体中后，给它一个合适的命名 <code>with_children</code>，它的参数是一个闭包，闭包接受一个类似于 <code>Commands</code> 的结构体类型 <code>ChildBuilder</code> 参数。在这个例子中，我创建了一个 <code>NodeBundle</code> 作为父实体，并将 <code>TextBundle</code> 作为子实体添加到其中。我们使用类似于 css 风格的 <code>Style</code> 组件让父节点坐落在屏幕的左上角。我们给文本实体增加了 <code>TimeText</code> 标记组件，这样我们就可以查询它，并且可以在任意帧中修改它。</p>
+
+<p>现在，我们可以添加一个“系统”，它可以在每一帧中更新文本：</p>
+
+<pre><code class="language-`rust">fn update_time_text(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Text, &amp;TimeText)&gt;) {
+    // 歌曲在实时启动 3 秒后开始
+    let secs = time.seconds_since_startup() - 3.;
+
+    // 在歌曲开始播放前不做任何处理
+    if secs &lt; 0. {
+        return;
+    }
+
+    for (mut text, _marker) in query.iter_mut() {
+        text.value = format!(&quot;Time: {:.2}&quot;, secs);
+    }
+}</code></pre>
+
+<p>该系统使用内置的 <code>Time</code> 资源，以及具有 <code>Text</code> 和 <code>TimeText</code> 的组件的实体查询。之后，我们只需要循环遍历它们并更新文本值。在实际情况中，应该只有一个实体能匹配上查询，所以我们可以只需获取第一个实体并完成此次操作，但无论如何我还是倾向于使用循环。这样，如果将来我们决定创建多个“系统”，我们就不必修改其中的代码了。</p>
+
+<p>我们通过创建一个插件来完成该代码文件的编写：</p>
+
+<pre><code class="language-`rust">pub struct UIPlugin;
+impl Plugin for UIPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_startup_system(setup_ui.system())
+            .add_system(update_time_text.system());
+    }
+}</code></pre>
+
+<p>现在，进入 <code>main.rs</code>，把 <code>CameraUiBundle</code> 加到 <code>setup</code> “系统”中，并导入插件：</p>
+
+<pre><code class="language-`rust">use bevy::{input::system::exit_on_esc_system, prelude::*};
+
+mod arrows;
+use arrows::ArrowsPlugin;
+mod consts;
+mod types;
+mod ui;
+use ui::UIPlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin) // &lt;--- 新代码
+        .run();
+}
+
+fn setup(commands: &amp;mut Commands) {
+    let config = types::load_config();
+
+    commands
+        .spawn(Camera2dBundle::default())
+        .spawn(CameraUiBundle::default()) // &lt;--- 新代码
+        .insert_resource(config);
+}</code></pre>
+
+<p><code>CameraUiBundle</code> 和 <code>Camera2dBundle</code> 很类似，但对于 UI 元素。如果不显式地添加它，文本就不会显示。因为我们之前已经添加了它，现在可以运行游戏，在屏幕上可以看到华丽地文字：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_time_text.mp4'>视频资源</a></p>
+
+<h2 id='增加得分'>增加得分</h2>
+
+<p>在本节中，我们将创建得分系统，以便于玩家能过够在每次玩耍后看到自己的表现。为此，我们打开另一个文件 <code>score.rs</code>。在其中，我们将创建一个新的资源来记录分数以及正确的箭头和失败的箭头数量：</p>
+
+<pre><code class="language-`rust">use crate::consts::*;
+
+#[derive(Default)]
+pub struct ScoreResource {
+    corrects: usize,
+    fails: usize,
+
+    score: usize,
+}
+
+impl ScoreResource {
+    /// 增加合适的次数值以及得分
+    pub fn increase_correct(&amp;mut self, distance: f32) -&gt; usize {
+        self.corrects += 1;
+
+        // 根据按下的按键的及时性获取一个 0 到 1 的值
+        let score_multiplier = (THRESHOLD - distance.abs()) / THRESHOLD;
+        // 最少增加 10 分，最多不超过 100 分。
+        let points = (score_multiplier * 100.).min(100.).max(10.) as usize;
+        self.score += points;
+
+        points
+    }
+
+    /// 统计失败的次数
+    pub fn increase_fails(&amp;mut self) {
+        self.fails += 1;
+    }
+
+    // Getters
+
+    pub fn score(&amp;self) -&gt; usize {
+        self.score
+    }
+    pub fn corrects(&amp;self) -&gt; usize {
+        self.corrects
+    }
+    pub fn fails(&amp;self) -&gt; usize {
+        self.fails
+    }
+}</code></pre>
+
+<p><code>ScoreResource</code> 是一个简单的结构体，它有三个 <code>usize</code> 类型的私有字段。我们没有将字段设计成公有，而是设计成成员属性的 getter 和 setter。通过这种方式，增加合适的箭头数量的唯一方法是通过 <code>increase_correct</code>，它也能增加积分，我们需要保证有了这个方法后不会又编写另一个类似功能的方法。在这款游戏中，我们不需要这样，因为我们只需在一个地方增加分数，但对于其他更大的项目而言，这种做法更让我们有信心维护，它不会造成意料之外的漏洞。</p>
+
+<p>我们把这个资源添加到 <code>main.rs</code>，并加上下面的引入代码：</p>
+
+<pre><code class="language-`rust">mod score;
+use score::ScoreResource;</code></pre>
+
+<p>使用下面的代码替换 <code>main</code> 函数：</p>
+
+<pre><code class="language-`rust">fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .init_resource::&lt;ScoreResource&gt;() // &lt;--- New
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .run();
+}</code></pre>
+
+<p>完成之后，我们就能使用“系统”上的资源了。也就是说，我们对 <code>arrows.rs</code> 文件中的 <code>despawn_arrows</code> 系统做一些调整，这样，当箭头消失时，就会触发调用增加积分方法：</p>
+
+<pre><code class="language-`rust">use crate::ScoreResource;
+
+/// 当它们到达终点时，正确点击了按钮，就会消除箭头
+fn despawn_arrows(
+    commands: &amp;mut Commands,
+    query: Query&lt;(Entity, &amp;Transform, &amp;Arrow)&gt;,
+    keyboard_input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+    
+    // 新代码
+    mut score: ResMut&lt;ScoreResource&gt;,
+) {
+    for (entity, transform, arrow) in query.iter() {
+        let pos = transform.translation.x;
+
+        // 检查箭头是否是在阈值内点击的
+        if (TARGET_POSITION - THRESHOLD..=TARGET_POSITION + THRESHOLD).contains(&amp;pos)
+            &amp;&amp; arrow.direction.key_just_pressed(&amp;keyboard_input)
+        {
+            commands.despawn(entity);
+
+            // 新代码
+            let _points = score.increase_correct(TARGET_POSITION - pos);
+        }
+
+        // 离开屏幕时，箭头消失
+        if pos &gt;= 2. * TARGET_POSITION {
+            commands.despawn(entity);
+
+            // 新代码
+            score.increase_fails();
+        }
+    }
+}</code></pre>
+
+<p>改动很简单，我们增加 <code>mut score: ResMut&lt;ScoreResource&gt;</code> 作为系统的参数，以便我们可以编辑得分，我们添加了一个 <code>increase_correct</code> 方法，它会帮助我们增加积分，并且还有一个 <code>increase_fails</code> 方法，用于表示箭头离开屏幕消失时，积分增加失败。</p>
+
+<p>现在，拥有一个得分系统很不错，但如果玩家无法看到自己的表现，那就没啥价值了！我们需要在 UI 模板中加一些东西，以显示分数：</p>
+
+<pre><code class="language-`rust">use crate::ScoreResource;
+
+// 新代码
+struct ScoreText;
+fn update_score_text(score: ChangedRes&lt;ScoreResource&gt;, mut query: Query&lt;(&amp;mut Text, &amp;ScoreText)&gt;) {
+    for (mut text, _marker) in query.iter_mut() {
+        text.value = format!(
+            &quot;Score: {}. Corrects: {}. Fails: {}&quot;,
+            score.score(),
+            score.corrects(),
+            score.fails()
+        );
+    }
+}
+
+pub struct UIPlugin;
+impl Plugin for UIPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_startup_system(setup_ui.system())
+            .add_system(update_time_text.system())
+            .add_system(update_score_text.system()); // &lt;--- 新代码
+    }
+}</code></pre>
+
+<p>在 <code>update_score_text</code> 中，我们使用 <code>ChangedRes</code>，而非普通的 <code>Res</code>。它们的区别在于后者会在每一帧都会运行一次，而 <code>ChangedRes</code> 只会在资源发生改变时才会运行。这很酷，因为分数不会再每一帧里都发生变化，所以这样可以节省一些开销，只需在需要时才更新文本。然后，它在具有 <code>ScoreText</code> 组件的实体上设置文本值（和 <code>TimeText</code> 一样，应该只有一个，但为什么要限制）。</p>
+
+<p>我们还要修改 <code>setup_ui</code> 中的一些东西，在第二次产生 <code>NodeBundle</code> 和 <code>TextBundle</code> 时，使用 <code>ScoreText</code> 组件：</p>
+
+<pre><code class="language-`rust">fn setup_ui(
+    commands: &amp;mut Commands,
+    asset_server: ResMut&lt;AssetServer&gt;,
+    mut color_materials: ResMut&lt;Assets&lt;ColorMaterial&gt;&gt;,
+) {
+    let font = asset_server.load(&quot;fonts/FiraSans-Bold.ttf&quot;);
+    let material = color_materials.add(Color::NONE.into());
+
+    commands
+        // Time 文本节点
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    left: Val::Px(10.),
+                    top: Val::Px(10.),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            material: material.clone(),
+            ..Default::default()
+        })
+        .with_children(|parent| {
+            parent
+                .spawn(TextBundle {
+                    text: Text {
+                        value: &quot;Time: 0.0&quot;.to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 40.0,
+                            color: Color::rgb(0.8, 0.8, 0.8),
+                            ..Default::default()
+                        },
+                    },
+                    ..Default::default()
+                })
+                .with(TimeText);
+        })
+        
+        // 新代码
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    left: Val::Px(10.),
+                    bottom: Val::Px(10.),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            material,
+            ..Default::default()
+        })
+        .with_children(|parent| {
+            parent
+                .spawn(TextBundle {
+                    text: Text {
+                        value: &quot;Score: 0. Corrects: 0. Fails: 0&quot;.to_string(),
+                        font,
+                        style: TextStyle {
+                            font_size: 40.0,
+                            color: Color::rgb(0.8, 0.8, 0.8),
+                            ..Default::default()
+                        },
+                    },
+                    ..Default::default()
+                })
+                .with(ScoreText);
+        });
+}</code></pre>
+
+<p>我已经打算把这个文本设置在屏幕的左下角，但如果你想练习，你可以尝试把它设置在左上角时间文本的下面。</p>
+
+<p>试试吧！运行游戏，看看我们的成果如何：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_score_text.mp4'>视频资源</a></p>
+
+<p>你可以随心所欲地为 UI 增减东西！我们在这里所做的是比较基础地展示文本。</p>
+
+<h2 id='从配置文件中加载数据'>从配置文件中加载数据</h2>
+
+<p>目前我们游戏中的箭头是硬编码的。目前这一切都还好，但我们希望玩家能创作自己的歌曲。我们不会通过制作自定义文件格式或任何花哨的东西使配置复杂化，所以我们将通过 <a href='https://en.wikipedia.org/wiki/TOML'>TOML</a> 和 <a href='https://github.com/serde-rs/serde'>serde</a> 库，来使用经过试用和测试的 <a href='https://en.wikipedia.org/wiki/TOML'>TOML</a> 格式。这两个 crate 将帮助我们非常容易地实现 <code>SongConfig</code> 结构的 TOML 序列化和反序列化。</p>
+
+<p>向 <code>Cargo.toml</code> 文件加入以下内容：</p>
+
+<pre><code class="language-`toml">toml = &quot;0.5.8&quot;
+serde = &quot;1.0.118&quot;
+serde_derive = &quot;1.0.118&quot;</code></pre>
+
+<p>我们现在可以编辑 <code>types.rs</code> 文件，并且导入准备好的类型和反序列化格式，向 <code>Directions</code> 和 <code>Speed</code> 类型中增加 <code>Deserialize</code> 和 <code>Serialize</code> trait 实现声明：</p>
+
+<pre><code class="language-`rust">use bevy::prelude::*;
+
+use serde_derive::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::prelude::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum Directions {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum Speed {
+    Slow,
+    Medium,
+    Fast,
+}</code></pre>
+
+<p>现在，我们有个小问题。我们的 <code>ArrowTime</code> 结构体有 <code>spawn_time</code> 字段，但是我们想在 TOML 文件中写入点击时间，所以我们不能直接在 Serde 中使用 <code>ArrowTime</code> 和 <code>SongConfig</code>。我们会通过创建两个新结构体来解决这个问题，<code>ArrowTimeToml</code> 和 <code>SongConfigToml</code>，它们对应的数据将会被包含在 TOML 文件中：</p>
+
+<pre><code class="language-`rust">#[derive(Deserialize, Debug)]
+struct SongConfigToml {
+    pub name: String,
+    pub filename: String,
+    pub arrows: Vec&lt;ArrowTimeToml&gt;,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ArrowTimeToml {
+    pub click_time: f64,
+    pub speed: Speed,
+    pub direction: Directions,
+}</code></pre>
+
+<p><code>name</code> 字段用于存储歌曲的名称，<code>filename</code> 是音频文件的路径，<code>arrows</code> 是 <code>ArrowTimeTomls</code> 列表。<code>ArrowTimeToml</code> 和 <code>ArrowTime</code> 的字段大部分一样，不同的是前者有 <code>click_time</code>，后者没有，取而代之的是 <code>spawn_time</code>。</p>
+
+<p>我们也会把 <code>ArrowTime::new</code> 的入参改为 <code>ArrowTimeToml</code> 类型：</p>
+
+<pre><code class="language-`rust">impl ArrowTime {
+    fn new(arrow: &amp;ArrowTimeToml) -&gt; Self {
+        let speed_value = arrow.speed.value();
+        Self {
+            spawn_time: arrow.click_time - (DISTANCE / speed_value) as f64,
+            speed: arrow.speed,
+            direction: arrow.direction,
+        }
+    }
+}</code></pre>
+
+<p>让我们在 <code>SongConfig</code> 加几个字段，用来保存名称和音频：</p>
+
+<pre><code class="language-`rust">pub struct SongConfig {
+    pub name: String,
+    pub song_audio: Handle&lt;AudioSource&gt;,
+    pub arrows: Vec&lt;ArrowTime&gt;,
+}</code></pre>
+
+<p>我们用 <code>Handle&lt;AudioSource&gt;</code> 保存音频，当我们把 <code>SongConfigToml</code> 转换为 <code>SongConfig</code> 时，我们会使用 <code>AssetServer</code> 加载它。</p>
+
+<p>最后，我们将修改 <code>load_config</code> 来从文件中加载 <code>SongConfig</code>：</p>
+
+<pre><code class="language-`rust">pub fn load_config(path: &amp;str, asset_server: &amp;AssetServer) -&gt; SongConfig {
+    // 打开文件并读取内容
+    let mut file = File::open(format!(&quot;assets/songs/{}&quot;, path)).expect(&quot;Couldn&#8217;t open file&quot;);
+    let mut contents = String::new();
+    file.read_to_string(&amp;mut contents)
+        .expect(&quot;Couldn&#8217;t read file into String&quot;);
+
+    // 使用 toml 和 Serde 进行解析
+    let parsed: SongConfigToml =
+        toml::from_str(&amp;contents).expect(&quot;Couldn&#8217;t parse into SongConfigToml&quot;);
+
+    // 处理箭头
+    let mut arrows = parsed
+        .arrows
+        .iter()
+        .map(|arr| ArrowTime::new(arr))
+        .collect::&lt;Vec&lt;ArrowTime&gt;&gt;();
+    // 根据 spawn_time 对箭头排序
+    arrows.sort_by(|a, b| a.spawn_time.partial_cmp(&amp;b.spawn_time).unwrap());
+
+    // 加载音频歌曲，并进行处理
+    let song_audio = asset_server.load(&amp;*format!(&quot;songs/{}&quot;, parsed.filename));
+
+    SongConfig {
+        name: parsed.name,
+        song_audio,
+        arrows,
+    }
+}</code></pre>
+
+<p>只有几行代码，但是很直接：先打开文件并读取文件的内容，使用 toml 库中的 <code>from_str</code> 方法解析文件内容，然后修改 <code>ArrowTimeTomls</code> 数组为 <code>ArrowTimes</code> 数组，我们使用 <code>AssetServer::load</code> 加载歌曲音频，然后返回新构建的 <code>SongConfig</code>。</p>
+
+<p>注意：<code>AssetServer::load</code> 将在 <code>assets</code> 文件夹中搜索文件。<code>File::open</code> 不会从根目录开始查找，所以我们需要手动地将 <code>assets</code> 加到路径前缀中。</p>
+
+<p>我们还需要修改 <code>main.rs</code> 中的 <code>setup</code> “系统”，修改 <code>load_config</code> 的调用方式，把 <code>AssetServer</code> 作为参数：</p>
+
+<pre><code class="language-`rust">fn setup(commands: &amp;mut Commands, asset_server: Res&lt;AssetServer&gt;) {
+    let config = types::load_config(&quot;test.toml&quot;, &amp;asset_server);
+
+    commands
+        .spawn(Camera2dBundle::default())
+        .spawn(CameraUiBundle::default())
+        .insert_resource(config);
+}</code></pre>
+
+<p>我们将在 <code>assets</code> 中创建一个 <code>songs</code> 文件夹，可以在其中保存所有的歌曲文件和对应的音频。现在，我们将创建一个名为 <code>test.toml</code> 的占位文件。你可以随意修改 arrows 以获得更详细的内容，现在只做一些简单测试：</p>
+
+<pre><code class="language-`">name = &quot;Test song&quot;
+filename = &quot;audio.mp3&quot;
+
+arrows = [
+    { click_time = 1.00, speed = &quot;Slow&quot;, direction = &quot;Up&quot; },
+    { click_time = 3.00, speed = &quot;Slow&quot;, direction = &quot;Down&quot; },
+    { click_time = 5.00, speed = &quot;Fast&quot;, direction = &quot;Left&quot; },
+    { click_time = 5.00, speed = &quot;Slow&quot;, direction = &quot;Right&quot; },
+    { click_time = 7.00, speed = &quot;Slow&quot;, direction = &quot;Up&quot; },
+    { click_time = 8.00, speed = &quot;Medium&quot;, direction = &quot;Up&quot; },
+    { click_time = 9.00, speed = &quot;Slow&quot;, direction = &quot;Left&quot; },
+    { click_time = 10.00, speed = &quot;Slow&quot;, direction = &quot;Right&quot; },
+    { click_time = 10.50, speed = &quot;Medium&quot;, direction = &quot;Right&quot; },
+    { click_time = 11.00, speed = &quot;Slow&quot;, direction = &quot;Up&quot; },
+    { click_time = 11.00, speed = &quot;Slow&quot;, direction = &quot;Down&quot; },
+]</code></pre>
+
+<p>现在，（合法地）下载你最喜欢的歌曲，将其放在 <code>assets/songs</code> 中，并将其命名为 <code>audio.mp3</code>。</p>
+
+<p>你的 assets 目录应该如下方所示：</p>
+
+<pre><code class="language-`">assets
+├── fonts
+│   └── FiraSans-Bold.ttf
+├── images
+│   ├── arrow_blue.png
+│   ├── arrow_border.png
+│   ├── arrow_green.png
+│   └── arrow_red.png
+└── songs
+    ├── audio.mp3
+    └── test.toml</code></pre>
+
+<p>现在运行游戏，应该和上一节没有太大不同，只是你得到的箭头是根据外部文件配置加载的！如果你问我的话，我觉得相当酷 :)。</p>
+
+<h2 id='播放音频'>播放音频</h2>
+
+<p>你可能注意到，在上一节中，我们做了一些加载歌曲的逻辑，但当我们玩游戏时，歌曲还是不能播放。现在，我们来实现播放！为此，我新建了一个文件，<code>audio.rs</code>，其中只含有一个“系统”：</p>
+
+<pre><code class="language-`rust">audio.rs
+use crate::types::SongConfig;
+use bevy::prelude::*;
+
+fn start_song(audio: Res&lt;Audio&gt;, time: Res&lt;Time&gt;, config: Res&lt;SongConfig&gt;) {
+    // 歌曲将在实时的 3 秒后开始播放
+    let secs = time.seconds_since_startup();
+    let secs_last = secs - time.delta_seconds_f64();
+
+    if secs_last &lt;= 3. &amp;&amp; 3. &lt;= secs {
+        audio.play(config.song_audio.clone());
+    }
+}
+
+pub struct AudioPlugin;
+impl Plugin for AudioPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_system(start_song.system());
+    }
+}</code></pre>
+
+<p><code>start_song</code> 使用 <code>Audio</code> 资源，在进入游戏 3 秒后开始播放歌曲。如你所看到的，我们使用了与“生成箭头”相同的方法。</p>
+
+<p>注意：我们本可以复用 <code>Timer</code>，但当我们制作一个菜单来选择歌曲时，会带来一定的复杂度。何况尝试使用定时器重写，是个很不错的练习方式！</p>
+
+<p>在 <code>main.rs</code> 中，我们添加以下内容：</p>
+
+<pre><code class="language-`rust">// main.rs
+mod audio;
+use audio::AudioPlugin;</code></pre>
+
+<p>在 <code>main</code> 函数中，在所有插件加载的最后，添加 <code>.add_plugin(AudioPlugin)</code>。现在运行游戏应该会让歌曲播放了，因为计时器在运行！</p>
+
+<p>至此，我们完成了游戏核心实现。你可以自由地在此基础上构建你自己地东西，但我建议你再往后看看，因为我们将致力于让游戏更加✨漂亮✨。</p>
+
+<h2 id='美化失败的箭头'>美化失败的箭头</h2>
+
+<p>首先，我们可以改进失败箭头的外观。目前，它们只是飞向远处。我们希望给玩家一些暗示，提醒他们那个箭头失败了。</p>
+
+<p>我们要做的是让箭头在穿过目标区域后，“脱离”那条线。为了实现这一点，我们在 <code>arrows.rs</code> 中的 <code>move_arrows</code> 函数中加点东西：</p>
+
+<pre><code class="language-`rust">/// 箭头前移
+fn move_arrows(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    for (mut transform, arrow) in query.iter_mut() {
+        transform.translation.x += time.delta_seconds() * arrow.speed.value();
+
+        // 新加代码
+        let distance_after_target = transform.translation.x - (TARGET_POSITION + THRESHOLD);
+        if distance_after_target &gt;= 0.02 {
+            transform.translation.y -= time.delta_seconds() * distance_after_target * 2.;
+        }
+    }
+}</code></pre>
+
+<p>我们所做的是获取目标到目标区域箭头符号的 <code>x</code> 坐标距离差，如果是正的，意味着它已经移动到目标区域外，我们就在它的 <code>y</code> 坐标减去一点，这样它就会下降。通过 <code>time.delta_seconds() * distance_after_target</code>，我们让每一帧的下降因子变大，这会让箭头以弧线的形式下降。<code>2.</code> 只是一个特定的常量，使弧线更好看（我觉得是），你可以根据你自己的意愿调整它！</p>
+
+<p>效果见下方链接的视频：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_arrows_falling.mp4'>视频资源</a></p>
+
+<p>很好，我们再给它加点效果。我们让箭头在下降时收缩并旋转：</p>
+
+<pre><code class="language-`rust">/// 箭头前移
+fn move_arrows(time: Res&lt;Time&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    for (mut transform, arrow) in query.iter_mut() {
+        transform.translation.x += time.delta_seconds() * arrow.speed.value();
+
+        let distance_after_target = transform.translation.x - (TARGET_POSITION + THRESHOLD);
+        if distance_after_target &gt;= 0.02 {
+            // 一旦箭头穿过目标区域，则开始下落
+            transform.translation.y -= time.delta_seconds() * distance_after_target * 2.;
+
+            // 根据箭头地距离改变下降因子（比例）
+            let scale = ((100. - distance_after_target / 3.) / 100.).max(0.2);
+            transform.scale = Vec3::splat(scale);
+
+            // 根据距离和速度旋转箭头
+            transform.rotate(Quat::from_rotation_z(
+                -distance_after_target * arrow.speed.multiplier() / 460.,
+            ));
+        }
+    }
+}</code></pre>
+
+<p>这是一串充满魔力的数字和公式，我在经过多次不同的尝试得出的结论。我建议你试试其它内容！</p>
+
+<p>我们将其分析一下：首先，我们使用一个随着箭头移动而减小的公式来获得一个比例。然后，使用 <code>max</code> 来确保比例至少为 <code>0.2</code>。之后，我们使用 <a href='https://docs.rs/bevy/0.4.0/bevy/prelude/struct.Transform.html#method.rotate'>Transform::rotate</a> 来旋转箭头。对于旋转，我们使用 <code>Speed::multiplier</code>，如果箭头的速度更快，就会旋转地更快。下面是所有这些效果组合在一起的样子：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_arrows_spinning.mp4'>视频资源</a></p>
+
+<p>太酷了！再次强调，你可以随时即兴发挥，添加其他逻辑，让它更加酷炫。游戏有一半的乐趣来自于制作你喜欢的花哨特效！</p>
+
+<h2 id='着色器背景'>着色器背景</h2>
+
+<p>接下来我们要做的是替换灰色背景。选择之一是使用 <code>ClearColor</code> 资源，以静态颜色作为背景。<a href='https://github.com/bevyengine/bevy/blob/v0.4.0/examples/window/clear_color.rs'>这里</a>是一个使用示例。这种方式很简单，我们只需要在 <code>main</code> 函数中加上 <code>.add_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))</code>，缺点是只能将背景改为一个平面颜色，我们希望看到更加生动的内容。着色器可以帮助我们！</p>
+
+<p>我们将在所有元素下面制作一个窗口大小的精灵，我们将添加着色器材料。这样我们会有一个背景，也就是设置一个着色器作为背景。</p>
+
+<p>当我们用着色器添加一些其他东西时，我们创建一个名为 <code>shaders</code> 的文件夹，用于存放相关文件。我们先打开 <code>shaders/mod.rs</code>：</p>
+
+<pre><code class="language-`rust">use bevy::{
+    prelude::*,
+    reflect::TypeUuid,
+    render::{
+        pipeline::{PipelineDescriptor, RenderPipeline},
+        render_graph::{base, RenderGraph},
+        renderer::RenderResources,
+        shader::{ShaderStage, ShaderStages},
+    },
+    window::WindowResized,
+};
+
+mod background;
+use background::*;</code></pre>
+
+<p>现在，我们只添加了一些导入，声明了 <code>background</code> 模块，接下来就创建这个模块：</p>
+
+<pre><code class="language-`rust">use super::*;
+
+pub struct Background;
+pub fn setup_background(
+    commands: &amp;mut Commands,
+    mut pipelines: ResMut&lt;Assets&lt;PipelineDescriptor&gt;&gt;,
+    mut shaders: ResMut&lt;Assets&lt;Shader&gt;&gt;,
+    window: Res&lt;WindowDescriptor&gt;,
+) {
+    // 创建一个新的着色器管道
+    let pipeline_handle = pipelines.add(PipelineDescriptor::default_config(ShaderStages {
+        vertex: shaders.add(Shader::from_glsl(
+            ShaderStage::Vertex,
+            include_str!(&quot;background.vert&quot;),
+        )),
+        fragment: Some(shaders.add(Shader::from_glsl(
+            ShaderStage::Fragment,
+            include_str!(&quot;background.frag&quot;),
+        ))),
+    }));
+
+    commands
+        .spawn(SpriteBundle {
+            render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                pipeline_handle,
+            )]),
+            transform: Transform::from_scale(Vec3::new(
+                window.width + 10.,
+                window.height + 10.,
+                1.,
+            )),
+            ..Default::default()
+        })
+        .with(Background);
+}</code></pre>
+
+<p>在这个文件中，我们添加了一个“启动系统”，它首先创建了 <code>PipelineDescriptor</code>，其中包含顶点和 fragment 着色器。这些都是用 <code>include_str</code> 宏从文件中添加进来的。然后我们会创建一个带有 <code>RenderPipelines</code> 组件的 <code>SpriteBundle</code>，并将我们创建的管道描述符传入。最后，我们添加了一个 <code>Background</code> 标记组件。</p>
+
+<p>我们正在使用 <code>WindowDescriptor</code> 资源来得到屏幕宽度和高度，这样就可以进行正确的转换。如果玩家将窗口变大，会出现一个小问题，因为我们的背景大小不变，导致后面的灰色背景被显示出来！为了解决这个问题，我们添加另一个“系统”：</p>
+
+<pre><code class="language-`rust">/// 当窗口大小变化时，背景大小跟着改变
+pub fn update_background_size(
+    mut event_reader: Local&lt;EventReader&lt;WindowResized&gt;&gt;,
+    events: Res&lt;Events&lt;WindowResized&gt;&gt;,
+    mut background: Query&lt;(&amp;mut Transform, &amp;Background)&gt;,
+) {
+    for event in event_reader.iter(&amp;events) {
+        for (mut transform, _) in background.iter_mut() {
+            transform.scale = Vec3::new(event.width, event.height, 1.);
+        }
+    }
+}</code></pre>
+
+<p>它监听 <a href='https://docs.rs/bevy/0.4.0/bevy/window/struct.WindowResized.html'>WindowResized</a> 事件，该事件在每次调整窗口大小时会提供新的窗口宽高。</p>
+
+<p>正如你注意到的，在 Bevy 中有一种易于使用且优雅的模式。事件也不例外。要使用一个事件，我们需要添加一个 <code>Event&lt;T&gt;</code> 资源和一个 <code>Local&lt;EventReader&lt;T&gt;&gt;</code> 作为参数。然后我们就可以通过事件资源来使用 <code>EventReader::iter</code>，该事件资源将给我们提供需要处理的事件。</p>
+
+<p>实际使用着色器时是使用 Rust 的 <code>include_str</code> 宏添加的，它将以字符串的形式添加文件内容。首先，我们创建 <code>background.vert</code>：</p>
+
+<pre><code class="language-`">#version 450
+
+layout(location = 0) in vec3 Vertex_Position;
+layout(location = 1) in vec3 Vertex_Normal;
+layout(location = 2) in vec2 Vertex_Uv;
+
+layout(location = 1) out vec2 v_Uv;
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 ViewProj;
+};
+layout(set = 1, binding = 0) uniform Transform {
+    mat4 Model;
+};
+
+void main() {
+    v_Uv = Vertex_Uv;
+    gl_Position = ViewProj * Model * vec4(Vertex_Position, 1.0);
+}</code></pre>
+
+<p>我们在这里只需做一件特殊的事是添加 <code>v_Uv</code>（纹理的 uv 坐标）作为输出，这样，我们就可以在 fragment 着色器中使用它，现在我们在 <code>background.frag</code> 中创建它：</p>
+
+<pre><code class="language-`">// shaders/background.frag
+#version 450
+
+layout(location = 0) in vec4 v_Position;
+layout(location = 1) in vec2 v_Uv;
+
+layout(location = 0) out vec4 o_Target;
+
+void main() {
+    o_Target = vec4(v_Uv, 0.1, 1.0);
+}</code></pre>
+
+<p>在这个着色器中，我们只返回基于背景的 uv 坐标的简单颜色。</p>
+
+<p>我们现在需要注册这些创建的“系统”。我们在 <code>shaders/mod.rs</code> 中添加 <code>ShaderPlugin</code>：</p>
+
+<pre><code class="language-`rust">// shaders/mod.rs
+pub struct ShadersPlugin;
+impl Plugin for ShadersPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_startup_system(setup_background.system())
+            .add_system(update_background_size.system());
+    }
+}</code></pre>
+
+<p>现在我们可以在 <code>main.rs</code> 中导入它：</p>
+
+<pre><code class="language-`rust">mod shaders;
+use shaders::ShadersPlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .init_resource::&lt;ScoreResource&gt;()
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .add_plugin(AudioPlugin)
+        .add_plugin(ShadersPlugin) // &lt;--- New
+        .run();
+}</code></pre>
+
+<p>运行游戏你可以看到下方链接视频中展示的效果：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_simple_background.mp4'>视频资源</a></p>
+
+<h2 id='使用时间着色器'>使用时间着色器</h2>
+
+<p>继续，我们会有一些奇特的场景，酷！理想情况下，我们希望游戏背景随着时间有一些变化。</p>
+
+<p>Bevy 没有（至少现在没有）添加时间和分辨率到着色器中作为输入，所以我们将不得不手动添加它们。希望这点能在 Bevy 中尽快得到改善。</p>
+
+<p>我们再次打开 <code>shaders/mod.rs</code>文件，并增加以下代码：</p>
+
+<pre><code class="language-`rust">#[derive(RenderResources, Default, TypeUuid)]
+#[uuid = &quot;0320b9b8-b3a3-4baa-8bfa-c94008177b17&quot;]
+/// 将资源传递给着色器
+pub struct ShaderInputs {
+    time: f32,
+    resolution: Vec2,
+}
+
+/// 在每一帧中，更新 ShaderInputs 中的时间
+fn update_time(time: Res&lt;Time&gt;, mut nodes: Query&lt;&amp;mut ShaderInputs&gt;) {
+    let time = time.seconds_since_startup();
+    for mut node in nodes.iter_mut() {
+        node.time = time as f32;
+    }
+}
+
+/// 如果窗口大小发生改变，更新 ShaderInputs 的分辨率
+fn update_resolution(
+    mut event_reader: Local&lt;EventReader&lt;WindowResized&gt;&gt;,
+    events: Res&lt;Events&lt;WindowResized&gt;&gt;,
+    mut background: Query&lt;&amp;mut ShaderInputs&gt;,
+) {
+    for event in event_reader.iter(&amp;events) {
+        for mut node in background.iter_mut() {
+            node.resolution = Vec2::new(event.width / event.height, 1.);
+        }
+    }
+}
+
+/// 在渲染图形时，添加 ShaderInputs 作为一个 edge
+fn setup_render_graph(mut render_graph: ResMut&lt;RenderGraph&gt;) {
+    render_graph.add_system_node(&quot;inputs&quot;, RenderResourcesNode::&lt;ShaderInputs&gt;::new(true));
+    render_graph
+        .add_node_edge(&quot;inputs&quot;, base::node::MAIN_PASS)
+        .unwrap();
+}</code></pre>
+
+<p>我们正在创建一个新的 <code>ShaderInputs</code> 结构体，将其作为渲染图形边添加到 <code>setup_render_graph</code> 中，并将其加到“启动系统”中。<code>update_time</code> 和 <code>update_resolution</code> 是两个负责更新 <code>ShaderInputs</code> 组件值的系统。注意在 <code>update_resolution</code> 中我们是通过监听 <code>WindowResized</code> 事件来实现，而非更新每一帧。</p>
+
+<p>现在，用以下代码替换 <code>ShaderPlugin</code> 中的实现，添加所有系统和资源：</p>
+
+<pre><code class="language-`rust">pub struct ShadersPlugin;
+impl Plugin for ShadersPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_asset::&lt;ShaderInputs&gt;() // &lt;--- 新代码
+            .add_startup_system(setup_render_graph.system()) // &lt;--- 新代码
+            .add_system(update_time.system()) // &lt;--- 新代码
+            .add_system(update_resolution.system()) // &lt;--- 新代码
+            .add_startup_system(setup_background.system())
+            .add_system(update_background_size.system());
+    }
+}</code></pre>
+
+<p>我们现在要向之前创建的背景实体添加 <code>ShaderInputs</code> 组件，提供初始值：</p>
+
+<pre><code class="language-`rust">// shaders/background.rs
+pub fn setup_background(
+    commands: &amp;mut Commands,
+    mut pipelines: ResMut&lt;Assets&lt;PipelineDescriptor&gt;&gt;,
+    mut shaders: ResMut&lt;Assets&lt;Shader&gt;&gt;,
+    window: Res&lt;WindowDescriptor&gt;,
+) {
+    // 创建新的着色器管道
+    let pipeline_handle = pipelines.add(PipelineDescriptor::default_config(ShaderStages {
+        vertex: shaders.add(Shader::from_glsl(
+            ShaderStage::Vertex,
+            include_str!(&quot;background.vert&quot;),
+        )),
+        fragment: Some(shaders.add(Shader::from_glsl(
+            ShaderStage::Fragment,
+            include_str!(&quot;background.frag&quot;),
+        ))),
+    }));
+
+    commands
+        .spawn(SpriteBundle {
+            render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                pipeline_handle,
+            )]),
+            transform: Transform::from_scale(Vec3::new(
+                window.width + 10.,
+                window.height + 10.,
+                1.,
+            )),
+            ..Default::default()
+        })
+        .with(Background)
+        // New
+        .with(ShaderInputs {
+            time: 0.,
+            resolution: Vec2::new(window.width / window.height, 1.),
+        });
+}</code></pre>
+
+<p>这些值在添加一些东西后，现在可以在着色器上使用了：</p>
+
+<pre><code class="language-`">// shaders/background.frag
+#version 450
+
+layout(location = 0) in vec4 v_Position;
+layout(location = 1) in vec2 v_Uv;
+
+layout(location = 0) out vec4 o_Target;
+
+// New
+layout(set = 2, binding = 0) uniform ShaderInputs_time {
+    float time;
+};
+// New
+layout(set = 2, binding = 1) uniform ShaderInputs_resolution {
+    vec2 resolution;
+};
+
+void main() {
+    o_Target = vec4(v_Uv, abs(sin(time)), 1.0);
+}</code></pre>
+
+<p>基本上，我们必须对 <code>ShaderInputs</code> 的每个字段增加 uniform，它包含 <code>binding</code> 对应增加的值，以及形如 <code>ShaderInputs_$name</code> 的名字，其中的 <code>$name</code> 是字段名。现在我们可以使用着色器内部的变量了！</p>
+
+<p>现在看起来应该如下方链接视频所示：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_background_with_time.mp4'>视频资源</a></p>
+
+<p>就个人而言，我选择了以下配置的着色器作为背景：</p>
+
+<pre><code class="language-`">#version 450
+
+#define TWO_PI 6.28318530718
+
+layout(location = 0) in vec4 v_Position;
+layout(location = 1) in vec2 v_Uv;
+layout(location = 0) out vec4 o_Target;
+
+layout(set = 2, binding = 0) uniform ShaderInputs_time {
+    float time;
+};
+layout(set = 2, binding = 1) uniform ShaderInputs_resolution {
+    vec2 resolution;
+};
+
+vec3 hsb2rgb(in vec3 c){
+    vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),
+                             6.0)-3.0)-1.0,
+                     0.0,
+                     1.0 );
+    rgb = rgb*rgb*(3.0-2.0*rgb);
+    return c.z * mix( vec3(1.0), rgb, c.y);
+}
+
+float wave_sin(in float x) {
+    float amplitude = 0.5;
+    float frequency = 1.0;
+    float y = sin(x * frequency);
+    float t = 0.01*(-time*50.0);
+    y += sin(x * frequency * 2.1 + t)*4.5;
+    y += sin(x * frequency * 1.72 + t*1.121)*4.0;
+    y += sin(x * frequency * 2.221 + t*0.437)*5.0;
+    y += sin(x * frequency * 3.1122+ t*4.269)*2.5;
+    y *= amplitude*0.06;
+    return y;
+}
+float wave_cos(in float x) {
+    float amplitude = 0.5;
+    float frequency = 2.0;
+    float y = cos(x * frequency);
+    float t = 0.01*(-time*30.0);
+    y += cos(x * frequency * 2.1 + t)*4.5;
+    y += cos(x * frequency * 1.72 + t*1.121)*4.0;
+    y += cos(x * frequency * 2.221 + t*0.437)*5.0;
+    y += cos(x * frequency * 3.1122+ t*4.269)*2.5;
+    y *= amplitude*0.06;
+    return y;
+}
+vec2 wave(in vec2 v) {
+    return vec2(wave_sin(v.x), wave_cos(v.y));
+}
+
+void main() {
+    vec2 uv = wave(v_Uv);
+    vec3 color = hsb2rgb(vec3(uv.x + sin(uv.y), 0.7, 1.0));
+
+    o_Target = vec4(color,1.0);
+}</code></pre>
+
+<p>它移动周围的颜色，产生好看的波浪，效果如下方链接视频所示：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_fancy_background.mp4'>视频资源</a></p>
+
+<p>现在轮到你玩它了，找到你喜欢的东西。如果你不太理解着色器，你可以尝试对上面的着色器做一些小修改，你也可以去 <a href='https://www.shadertoy.com/'>Shadertoy</a> 查找一些资料。例如，下面是一个 <a href='https://www.shadertoy.com/view/XsXXDn'>shader</a> 配置，它由 Danilo Guanabara 转换自 Shadertoy：</p>
+
+<pre><code class="language-`">// shaders/background.frag
+#version 450
+
+// Creation, by Silexars (Danilo Guanabara)
+// From https://www.shadertoy.com/view/XsXXDn
+
+layout(location = 0) in vec4 v_Position;
+layout(location = 1) in vec2 v_Uv;
+layout(location = 0) out vec4 o_Target;
+
+layout(set = 2, binding = 0) uniform ShaderInputs_time {
+    float time;
+};
+layout(set = 2, binding = 1) uniform ShaderInputs_resolution {
+    vec2 resolution;
+};
+
+void main() {
+    vec3 c;
+    vec2 r = resolution;
+    float l,z=time;
+    for(int i=0;i&lt;3;i++) {
+        vec2 uv,p = v_Uv; // / r;
+        uv = p;
+        p -= 0.5;
+        p.x *= r.x/r.y;
+        z += 0.07;
+        l = length(p);
+        uv += p/l*(sin(z)+1.)*abs(sin(l*9.0-z*2.0));
+        c[i] = (0.01)/length(abs(mod(uv,1.0)-0.5));
+    }
+    o_Target = vec4(c/l,time);
+}</code></pre>
+
+<p>效果如下方链接视频所示：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_creation_background.mp4'>视频资源</a></p>
+
+<h2 id='美化点击动画'>美化点击动画</h2>
+
+<p>我们之前已经为失败的箭头添加了有趣动画，但当成功命中箭头时，我们啥也没做。它就这样消失了，这有点让人失望。我们将这一点进行改进。</p>
+
+<p>我们将有四个不同的“精灵”，每个精灵在每个目标区域箭头下都有一个着色器。然后，每当正确命中箭头时，相应的精灵下的着色器就会启动动画，动画持续一段时间后，再消失。</p>
+
+<p>注意：这个如果用技术实现会比较复杂，但这样可以展示很多东西。实现这一点有个捷径是在每次正确点击箭头时创建一个精灵，然后几秒钟后删除掉。</p>
+
+<p>打开 <code>shaders/target_arrows.rs</code> 文件。我们为这些精灵添加一个组件（我把它叫做“普通目标箭头”），它只是指示目标箭头的方向和位置：</p>
+
+<pre><code class="language-`rust">pub struct TargetArrowSparkle {
+    direction: Directions,
+}</code></pre>
+
+<p>我们再添加另一条边到渲染图中，并将另一个结构体作为参数传递给着色器。这将保留最近一次正确命中箭头的时间，以及对应得分：</p>
+
+<pre><code class="language-`rust">// shaders/target_arrows.rs
+#[derive(RenderResources, TypeUuid)]
+#[uuid = &quot;c9400817-b3a3-4baa-8bfa-0320b9b87b17&quot;]
+pub struct TimeSinceLastCorrect {
+    last_time: f32,
+    points: f32,
+}</code></pre>
+
+<p>请注意，当我们向目标箭头添加 <code>TimeSinceLastCorrect</code> 组件时，每个组件都有自己的值，这些值是不共享的，所以我们需要单独设定它们。</p>
+
+<p>现在，我们添加一个“启动系统”用于创建精灵：</p>
+
+<pre><code class="language-`rust">// shaders/target_arrows.rs
+use super::*;
+use crate::consts::*;
+use crate::types::Directions::{self, *};
+
+pub fn setup_target_arrows(
+    commands: &amp;mut Commands,
+    mut pipelines: ResMut&lt;Assets&lt;PipelineDescriptor&gt;&gt;,
+    mut shaders: ResMut&lt;Assets&lt;Shader&gt;&gt;,
+    mut render_graph: ResMut&lt;RenderGraph&gt;,
+    window: Res&lt;WindowDescriptor&gt;,
+) {
+    // 创建一个新的着色器管道
+    let pipeline_handle = pipelines.add(PipelineDescriptor::default_config(ShaderStages {
+        vertex: shaders.add(Shader::from_glsl(
+            ShaderStage::Vertex,
+            include_str!(&quot;target_arrows.vert&quot;),
+        )),
+        fragment: Some(shaders.add(Shader::from_glsl(
+            ShaderStage::Fragment,
+            include_str!(&quot;target_arrows.frag&quot;),
+        ))),
+    }));
+
+    // 把 TimeSinceLastCorrect 加到渲染图中
+    render_graph.add_system_node(
+        &quot;last_time&quot;,
+        RenderResourcesNode::&lt;TimeSinceLastCorrect&gt;::new(true),
+    );
+    render_graph
+        .add_node_edge(&quot;last_time&quot;, base::node::MAIN_PASS)
+        .unwrap();
+
+    let directions = [Up, Down, Left, Right];
+    for direction in directions.iter() {
+        // z 值不同，所以它们不会重叠
+        let z = match direction {
+            Up =&gt; 0.3,
+            Down =&gt; 0.4,
+            Left =&gt; 0.5,
+            Right =&gt; 0.6,
+        };
+
+        let mut transform =
+            Transform::from_translation(Vec3::new(TARGET_POSITION, direction.y(), z));
+        transform.scale = Vec3::new(300., 300., 1.);
+        commands
+            .spawn(SpriteBundle {
+                render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                    pipeline_handle.clone(),
+                )]),
+                transform,
+                visible: Visible {
+                    is_transparent: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .with(TargetArrowSparkle {
+                direction: *direction,
+            })
+            .with(TimeSinceLastCorrect {
+                last_time: 3.,
+                points: 0.5,
+            })
+            .with(ShaderInputs {
+                time: 0.,
+                resolution: Vec2::new(window.width / window.height, 1.),
+            });
+    }
+}</code></pre>
+
+<p>这个系统就像是 <code>setup_target_arrows</code>，<code>setup_render_graph</code> 和 <code>setup_background</code> 的混合体。我们首先创建一个 <code>PipelineDescriptor</code>，然后添加 <code>TimeSinceLastCorrect</code> 作为渲染图的边，最后我们创建一个存放所有方向的数组，然后迭代它，创建 4 个精灵组，并添加 <code>TargetArrowSparkle</code>，<code>TimeSinceLastCorrect</code> 和 <code>ShaderInputs</code> 组件。</p>
+
+<p>我们把 <code>last_time</code> 设为 3 秒进行测试。这样，当时间达到三秒时，动画就开始了。当我们设置好所有内容后，我们会将其更改为负值，因为我们希望箭头在被正确点击时触发。</p>
+
+<p>我们还需要为这个着色器创建新文件：</p>
+
+<pre><code class="language-`">#version 450
+
+layout(location = 0) in vec3 Vertex_Position;
+layout(location = 1) in vec3 Vertex_Normal;
+layout(location = 2) in vec2 Vertex_Uv;
+
+layout(location = 1) out vec2 v_Uv;
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 ViewProj;
+};
+layout(set = 1, binding = 0) uniform Transform {
+    mat4 Model;
+};
+
+void main() {
+    v_Uv = Vertex_Uv;
+    gl_Position = ViewProj * Model * vec4(Vertex_Position, 1.0);
+}</code></pre>
+
+<p>vertex 着色器的实现基本上和 <code>shaders/background.vert</code> 一样。更有趣的是 <code>shaders/target_arrows.frag</code>：</p>
+
+<pre><code class="language-`"># shaders/target_arrows.frag
+#version 450
+
+#define TWO_PI 6.28318530718
+
+layout(location = 0) in vec4 v_Position;
+layout(location = 1) in vec2 v_Uv;
+layout(location = 0) out vec4 o_Target;
+
+layout(set = 2, binding = 0) uniform ShaderInputs_time {
+    float time;
+};
+layout(set = 2, binding = 1) uniform ShaderInputs_resolution {
+    vec2 resolution;
+};
+layout(set = 3, binding = 0) uniform TimeSinceLastCorrect_last_time {
+    float last_time;
+};
+layout(set = 3, binding = 1) uniform TimeSinceLastCorrect_points {
+    float points;
+};
+
+float interval(in float a, in float b, in float val) {
+    return step(a, val) * smoothstep(1.0 - b - 0.1, 1.0 - b, 1. - val);
+}
+
+float circle(in vec2 uv, in float _radius){
+    vec2 dist = uv - vec2(0.5);
+    return 1.0 - smoothstep(_radius - (_radius * 0.01),
+                            _radius + (_radius * 0.01),
+                            dot(dist, dist) * 4.0);
+}
+
+float smoothcircle(in vec2 _st, in float s){
+    vec2 dist = _st-vec2(0.5);
+    return 4. * dot(dist,dist) / (s);
+}
+
+void main() {
+    // 0. when the circle shouldn&#8217;t be shown
+    float alpha = interval(last_time, last_time + 0.6, time);
+
+    // Circle radius
+    float radius = time - last_time;
+    // 0. for not in circle, 1. for circle
+    // float circle = circle(v_Uv, radius) * (1. - circle(v_Uv, radius - 0.1));
+    float circle = smoothcircle(v_Uv, radius) * smoothcircle(v_Uv, radius) * circle(v_Uv, radius);
+
+    // rgb(92, 175, 29);
+    vec3 colorMin = vec3(0.36078431373,0.6862745098,0.1137254902);
+    // rgb(255, 255, 6);
+    vec3 colorMax = vec3(1.,1.,0.02352941176);
+
+    // Get color according to points
+    vec3 color = mix(colorMin, colorMax, points);
+
+    o_Target = vec4(color * circle, circle * alpha);
+}</code></pre>
+
+<p>这个着色器有点复杂，但简而言之，它的作用是创建一个半径随时间增加的圆。圆圈在 <code>last_time</code> 后存在 <code>0.6</code> 秒。我们把值设为 3 来添加 <code>TimeSinceLastCorrect</code>，并且和 <code>ShaderInputs</code> 一样，每个字段的绑定值都会增加。圆形的颜色根据点的不同而有所变化。</p>
+
+<p>我们还需要把 <code>setup_target_arrows</code> 加到 <code>ShaderPlugin</code> 中：</p>
+
+<pre><code class="language-`rust">// shaders/mod.rs
+mod target_arrows;
+use target_arrows::*;
+
+pub struct ShadersPlugin;
+impl Plugin for ShadersPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.add_asset::&lt;ShaderInputs&gt;()
+            .add_asset::&lt;TimeSinceLastCorrect&gt;()
+            .add_startup_system(setup_render_graph.system())
+            .add_system(update_time.system())
+            .add_system(update_resolution.system())
+            .add_startup_system(setup_background.system())
+            .add_system(update_background_size.system())
+            .add_startup_system(setup_target_arrows.system()); // &lt;--- New
+    }
+}</code></pre>
+
+<p>现在运行游戏，将看到如下面链接视频所展示的效果：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_half_done_fancy_clicking.mp4'>视频资源</a></p>
+
+<p>如你所看到的，就在歌曲开始后，第 3 秒时，所有的圆圈开始变大，约过半秒后它们就消失了。太好了，这意味这着色器和定时器都正常工作了！我们仍然缺少一些东西来更新一些值，所以我们添加一个“系统”，用于当箭头被正确的按下时，更新 <code>last_time</code> 值。在此之前，我们使其默认值为负的：</p>
+
+<pre><code class="language-`rust">// shaders/target_arrows.rs
+.with(TimeSinceLastCorrect {
+    last_time: -10.,
+    points: 0.,
+})</code></pre>
+
+<p>现在如果你运行这个游戏，圆圈就不会出现了。</p>
+
+<p>之前，我们已经看到了如何侦听事件，但我们仍然没有看到硬币的另一面。我们现在就准备探索一下。我们将创建一个正确点击箭头时发生的事件。我们在 <code>arrows.rs</code> 文件中的 <code>despawn_arrows</code> 中产生这个事件：</p>
+
+<pre><code class="language-`rust">// arrows.rs
+/// 事件结构体
+pub struct CorrectArrowEvent {
+    pub direction: Directions,
+    pub points: usize,
+}
+
+/// 当他们到达目标区域时，正确点击按钮，箭头就会消失
+fn despawn_arrows(
+    commands: &amp;mut Commands,
+    query: Query&lt;(Entity, &amp;Transform, &amp;Arrow)&gt;,
+    keyboard_input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+    mut score: ResMut&lt;ScoreResource&gt;,
+    mut correct_arrow_events: ResMut&lt;Events&lt;CorrectArrowEvent&gt;&gt;,
+) {
+    for (entity, transform, arrow) in query.iter() {
+        let pos = transform.translation.x;
+
+        // Check if arrow is inside clicking threshold
+        if (TARGET_POSITION - THRESHOLD..=TARGET_POSITION + THRESHOLD).contains(&amp;pos)
+            &amp;&amp; arrow.direction.key_just_pressed(&amp;keyboard_input)
+        {
+            commands.despawn(entity);
+
+            let points = score.increase_correct(TARGET_POSITION - pos);
+
+            // 新代码
+            
+            // 发送事件
+            correct_arrow_events.send(CorrectArrowEvent {
+                direction: arrow.direction,
+                points,
+            });
+        }
+
+        // 当箭头离开屏幕时消除它们
+        if pos &gt;= 2. * TARGET_POSITION {
+            commands.despawn(entity);
+            score.increase_fails();
+        }
+    }
+}</code></pre>
+
+<p>我们首先要做的是创建一个新的 <code>CorrectArrowEvent</code> 结构体，它用来表示我们的事件。对于 <code>despawn_arrows</code>，我们添加了 <code>ResMut&lt;Events&lt;CorrectArrowEvent&gt;&gt;</code> 参数，这样我们就能通过 <code>send</code> 方法发送事件。为了发送一个事件，我们需要传入一个 <code>CorrectArrowEvent</code> 结构体，它携带箭头的方向以及玩家的得分。</p>
+
+<p>现在我们需要把 <code>.init_resource::&lt;Events&lt;CorrectArrowEvent&gt;&gt;()</code> 添加到 <code>ArrowsPlugin</code>，我们已经准备好了。很简单，对吧？</p>
+
+<p>现在我们要在 <code>shaders/target_arrows.rs</code> 中添加一个“系统”，它负责更新“目标区域箭头”中的 <code>last_time</code>：</p>
+
+<pre><code class="language-`rust">// shaders/target_arrows.rs
+pub fn correct_arrow_event_listener(
+    time: Res&lt;Time&gt;,
+    mut correct_event_reader: Local&lt;EventReader&lt;CorrectArrowEvent&gt;&gt;,
+    correct_events: Res&lt;Events&lt;CorrectArrowEvent&gt;&gt;,
+    mut query: Query&lt;(&amp;TargetArrowSparkle, &amp;mut TimeSinceLastCorrect)&gt;,
+) {
+    for event in correct_event_reader.iter(&amp;correct_events) {
+        for (arrow, mut last_correct) in query.iter_mut() {
+            if arrow.direction == event.direction {
+                last_correct.last_time = time.seconds_since_startup() as f32;
+                last_correct.points = event.points as f32 / 100.;
+            }
+        }
+    }
+}</code></pre>
+
+<p>它通过监听事件，寻找与目标方向相关的箭头精灵，并更新其中的 <code>last_time</code> 和 <code>points</code> 值。</p>
+
+<p>把最后一个“系统”加到 <code>ShaderPlugin</code>，<code>.add_system(correct_arrow_event_listener.system())</code>。现在如果你运行游戏，当你正确点击箭头时，就会看到圆圈效果：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_target_arrow_circles.mp4'>视频资源</a></p>
+
+<p>这就是这个游戏中我们要做的所有着色工作。和以往一样，你可以随便修改代码，添加更多效果，进行实验！</p>
+
+<h2 id='增加状态'>增加状态</h2>
+
+<p>在下一节，我们将制作一个非常简单的歌曲选择菜单。为此，我们将在一些状态值上下手，这就需要修改一些地方。为了创建一个状态，我们需要新建一个新的枚举，并将其包装成 <a href='https://docs.rs/bevy/0.4.0/bevy/ecs/struct.State.html'>State</a> 的资源加到游戏代码中。然后，我们可以使用 <code>on_state_update</code>，<code>on_state_enter</code> 和 <code>on_state_exit</code> 等方法为每个系统分配特定的状态。</p>
+
+<p>我们开始吧。首先，打开 <code>consts.rs</code>，添加 state 枚举：</p>
+
+<pre><code class="language-`rust">/// Stage for our systems
+pub const APP_STATE_STAGE: &amp;str = &quot;app_state_stage&quot;;
+
+/// States
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum AppState {
+    Menu,
+    Game,
+    MakeMap,
+}</code></pre>
+
+<p><code>AppState</code> 将代表我们游戏的三个模式：歌曲选择菜单，游戏和（尚未实现的）地图制作模式。</p>
+
+<p>我们，还添加了一个字符串用于表示我们的系统的阶段。现在我们进入 <code>main.rs</code> 中，添加 <code>State</code> 以及更新后的新阶段两个资源：</p>
+
+<pre><code class="language-`rust">// main.rs
+use crate::consts::*;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_resource(State::new(AppState::Menu)) // &lt;--- 新代码
+        .add_stage_after( // &lt;--- 新代码
+            stage::UPDATE,
+            APP_STATE_STAGE,
+            StateStage::&lt;AppState&gt;::default(),
+        )
+        .init_resource::&lt;ScoreResource&gt;()
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .add_plugin(AudioPlugin)
+        .add_plugin(ShadersPlugin)
+        .run();
+}</code></pre>
+
+<p>现在游戏不会有任何变化，因为我们的“系统”仍然以普通的方式加入。为了改变这一点，我们将从修改 <code>arrows.rs</code> 中的 <code>ArrowsPlugin</code> 入手：</p>
+
+<pre><code class="language-`rust">// arrows.rs
+pub struct ArrowsPlugin;
+impl Plugin for ArrowsPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;ArrowMaterialResource&gt;()
+            .init_resource::&lt;Events&lt;CorrectArrowEvent&gt;&gt;()
+            .on_state_enter(
+                APP_STATE_STAGE,
+                AppState::Game,
+                setup_target_arrows.system(),
+            )
+            .on_state_update(APP_STATE_STAGE, AppState::Game, spawn_arrows.system())
+            .on_state_update(APP_STATE_STAGE, AppState::Game, move_arrows.system())
+            .on_state_update(APP_STATE_STAGE, AppState::Game, despawn_arrows.system());
+    }
+}</code></pre>
+
+<p>我们必须把 <code>add_startup_system</code>替换为 <code>on_stage_enter</code>，将 <code>add_system</code> 替换为 <code>on_stage_update</code>。对于这些函数，我们必须传入“系统”运行的阶段和状态。因为我们想要所有这些运行在 <code>Game</code> 状态，就是我们使用的那个。</p>
+
+<p>现在我们看看 <code>ui.rs</code>：</p>
+
+<pre><code class="language-`rust">// ui.rs
+use crate::consts::*;
+
+pub struct UIPlugin;
+impl Plugin for UIPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.on_state_enter(APP_STATE_STAGE, AppState::Game, setup_ui.system())
+            .on_state_update(APP_STATE_STAGE, AppState::Game, update_time_text.system())
+            .on_state_update(APP_STATE_STAGE, AppState::Game, update_score_text.system());
+    }
+}</code></pre>
+
+<p><code>audio.rs</code> 中的代码:</p>
+
+<pre><code class="language-`rust">// audio.rs
+use crate::consts::*;
+
+pub struct AudioPlugin;
+impl Plugin for AudioPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.on_state_update(APP_STATE_STAGE, AppState::Game, start_song.system());
+    }
+}</code></pre>
+
+<p>我们已经修改了所有与 <code>Game</code> 状态相关的“系统”，所以如果你现在运行游戏，除了看到动画背景外，什么也不会发生，因为我们要从 <code>Menu</code> 开始，但是我们还没有相关的“系统”。</p>
+
+<h2 id='添加基础菜单'>添加基础菜单</h2>
+
+<p>我们现在将制作一个带有按钮的菜单，它可以让我们选择一首歌曲或进入游戏地图制作模式。我们将它保存在一个新的文件 <code>menu.rs</code> 中。我们新建一个资源来保存对应的素材：</p>
+
+<pre><code class="language-`rust">use crate::consts::*;
+use bevy::prelude::*;
+
+struct ButtonMaterials {
+    none: Handle&lt;ColorMaterial&gt;,
+    normal: Handle&lt;ColorMaterial&gt;,
+    hovered: Handle&lt;ColorMaterial&gt;,
+    pressed: Handle&lt;ColorMaterial&gt;,
+    font: Handle&lt;Font&gt;,
+}
+
+impl FromResources for ButtonMaterials {
+    fn from_resources(resources: &amp;Resources) -&gt; Self {
+        let mut materials = resources.get_mut::&lt;Assets&lt;ColorMaterial&gt;&gt;().unwrap();
+        let asset_server = resources.get_mut::&lt;AssetServer&gt;().unwrap();
+
+        ButtonMaterials {
+            none: materials.add(Color::NONE.into()),
+            normal: materials.add(Color::rgb(0.15, 0.15, 0.15).into()),
+            hovered: materials.add(Color::rgb(0.25, 0.25, 0.25).into()),
+            pressed: materials.add(Color::rgb(0.35, 0.75, 0.35).into()),
+            font: asset_server.load(&quot;fonts/FiraSans-Bold.ttf&quot;),
+        }
+    }
+}</code></pre>
+
+<p>这看起来很标准。接下来，我们将创建一个“系统”来构建菜单元素。</p>
+
+<pre><code class="language-`rust">// menu.rs
+struct MenuUI;
+fn setup_menu(commands: &amp;mut Commands, button_materials: Res&lt;ButtonMaterials&gt;) {
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(100.), Val::Percent(100.)),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::FlexStart,
+                justify_content: JustifyContent::FlexStart,
+                ..Default::default()
+            },
+            material: button_materials.none.clone(),
+            ..Default::default()
+        })
+        .with(MenuUI)
+        .with_children(|parent| {
+            // 生成新按钮
+            parent
+                .spawn(ButtonBundle {
+                    style: Style {
+                        size: Size::new(Val::Px(350.0), Val::Px(65.0)),
+                        margin: Rect::all(Val::Auto),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..Default::default()
+                    },
+                    material: button_materials.normal.clone(),
+                    ..Default::default()
+                })
+                .with_children(|parent| {
+                    parent.spawn(TextBundle {
+                        text: Text {
+                            value: &quot;Play&quot;.to_string(),
+                            font: button_materials.font.clone(),
+                            style: TextStyle {
+                                font_size: 20.0,
+                                color: Color::rgb(0.9, 0.9, 0.9),
+                                ..Default::default()
+                            },
+                        },
+                        ..Default::default()
+                    });
+                });
+        });
+}</code></pre>
+
+<p>这看起来非常类似于 <code>ui.rs</code> 中的 <code>setup_ui</code>。但结构类似于 <code>NodeBundle &gt; ButtonBundle &gt; TextBundle</code>。</p>
+
+<p>我们还要创建一个删除所有按钮的系统，这样我们就可以在离开菜单时运行它。如果不这样做，菜单按钮会一直停留在游戏屏幕上。</p>
+
+<pre><code class="language-`rust">// menu.rs
+fn despawn_menu(commands: &amp;mut Commands, query: Query&lt;(Entity, &amp;MenuUI)&gt;) {
+    for (entity, _) in query.iter() {
+        commands.despawn_recursive(entity);
+    }
+}</code></pre>
+
+<p>给这个系统实现插件：</p>
+
+<pre><code class="language-`rust">// menu.rs
+pub struct MenuPlugin;
+impl Plugin for MenuPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;ButtonMaterials&gt;()
+            .on_state_enter(APP_STATE_STAGE, AppState::Menu, setup_menu.system())
+            .on_state_exit(APP_STATE_STAGE, AppState::Menu, despawn_menu.system());
+    }
+}</code></pre>
+
+<p>把它添加到 <code>main.rs</code> 中，导入它并在 <code>main</code> 函数中增加 <code>.add_plugin(MenuPlugin)</code> 调用：</p>
+
+<pre><code class="language-`rust">// main.rs
+mod menu;
+use menu::MenuPlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_resource(State::new(AppState::Menu))
+        .add_stage_after(
+            stage::UPDATE,
+            APP_STATE_STAGE,
+            StateStage::&lt;AppState&gt;::default(),
+        )
+        .init_resource::&lt;ScoreResource&gt;()
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .add_plugin(AudioPlugin)
+        .add_plugin(ShadersPlugin)
+        .add_plugin(MenuPlugin) // &lt;--- 新代码
+        .run();
+}
+
+
+fn setup(commands: &amp;mut Commands) {
+    commands
+        .spawn(Camera2dBundle::default())
+        .spawn(CameraUiBundle::default());
+}</code></pre>
+
+<p>我们还要更改 <code>setup</code>，不再是 <code>SongConfig</code> 资源，因为我们会在玩家点击按钮选择歌曲时添加它。</p>
+
+<p>现在运行游戏会显示下面这样的按钮：</p>
+
+<p><img src='https://caballerocoll.com/images/rhythm_basic_menu.png' alt='' /></p>
+
+<p>目前，单击按钮并将鼠标悬停在按钮上会发现按钮什么也没有干，所以我们需要让菜单能根据需要有所反应。首先，我们将添加一个系统，根据按钮的交互改变颜色：</p>
+
+<pre><code class="language-`rust">// menu.rs
+fn button_color_system(
+    button_materials: Res&lt;ButtonMaterials&gt;,
+    mut query: Query&lt;
+        (&amp;Interaction, &amp;mut Handle&lt;ColorMaterial&gt;),
+        (Mutated&lt;Interaction&gt;, With&lt;Button&gt;),
+    &gt;,
+) {
+    for (interaction, mut material) in query.iter_mut() {
+        match *interaction {
+            Interaction::Clicked =&gt; {
+                *material = button_materials.pressed.clone();
+            }
+            Interaction::Hovered =&gt; {
+                *material = button_materials.hovered.clone();
+            }
+            Interaction::None =&gt; {
+                *material = button_materials.normal.clone();
+            }
+        }
+    }
+}</code></pre>
+
+<p>这里我们使用的是 <code>Interaction</code> 组件，它和 <code>ButtonBundle</code> 一起。它有三个不同的变体，<code>Clicked</code>，<code>Hovered</code> 和 <code>None</code>。分别表示：单机按钮，悬停在按钮上，不做任何事。我们将匹配按钮的所有可能的值，从而做出不同的反应。将 <code>MenuPlugin</code> 加到游戏中，运行游戏，观察鼠标悬停、点击或移开时按钮的颜色是如何变化的。</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_button_interactions.mp4'>视频资源</a></p>
+
+<h2 id='优化菜单'>优化菜单</h2>
+
+<p>我们还需要两个东西：在文件夹中显示歌曲列表菜单，以及正式开始游戏的按钮。我们从第一点开始，在 <code>menu.rs</code> 中增加一个方法：</p>
+
+<pre><code class="language-`rust">// menu.rs
+use std::fs::read_dir;
+
+pub fn get_songs() -&gt; Vec&lt;String&gt; {
+    let paths = read_dir(&quot;assets/songs&quot;).unwrap();
+
+    let mut vec = vec![];
+    for path in paths {
+        let path = path.unwrap().path();
+
+        if &quot;toml&quot; == path.as_path().extension().unwrap() {
+            vec.push(
+                path.as_path()
+                    .file_stem()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            );
+        }
+    }
+    vec
+}</code></pre>
+
+<p>这个函数使用 <a href='https://doc.rust-lang.org/std/fs/fn.read_dir.html'>`read_dir`</a> 获取 <code>songs</code> 目录中的文件，并将 <code>.toml</code> 后缀文件路径追加到数组中。</p>
+
+<p>现在我们可以从 <code>setup_menu</code> 内部调用这个函数，来为 <code>get_songs</code> 得到的每个文件增加按钮。首先，我们创建一个枚举组件加到按钮中：</p>
+
+<pre><code class="language-`rust">// menu.rs
+enum MenuButton {
+    MakeMap,
+    PlaySong(String),
+}
+impl MenuButton {
+    fn name(&amp;self) -&gt; String {
+        match self {
+            Self::MakeMap =&gt; &quot;Make map&quot;.to_string(),
+            Self::PlaySong(song) =&gt; format!(&quot;Play song: {}&quot;, song),
+        }
+    }
+}</code></pre>
+
+<p>枚举的第一个变体 <code>MakeMap</code> 用于进入地图制作模式（如果实现了）。另一个变体 <code>PlaySong</code> 用于开始特定的歌曲游戏。</p>
+
+<pre><code class="language-`rust">// menu.rs
+fn setup_menu(commands: &amp;mut Commands, button_materials: Res&lt;ButtonMaterials&gt;) {
+    // 制作按钮列表
+    let mut buttons: Vec&lt;MenuButton&gt; = get_songs()
+        .iter()
+        .map(|name| MenuButton::PlaySong(name.clone()))
+        .collect();
+    buttons.push(MenuButton::MakeMap);
+
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(100.), Val::Percent(100.)),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::FlexStart,
+                justify_content: JustifyContent::FlexStart,
+                ..Default::default()
+            },
+            material: button_materials.none.clone(),
+            ..Default::default()
+        })
+        .with(MenuUI)
+        .with_children(|parent| {
+            // 将所有按钮以子按钮的方式加入
+            for button in buttons {
+                // 生成新按钮
+                parent
+                    .spawn(ButtonBundle {
+                        style: Style {
+                            size: Size::new(Val::Px(350.0), Val::Px(65.0)),
+                            margin: Rect::all(Val::Auto),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..Default::default()
+                        },
+                        material: button_materials.normal.clone(),
+                        ..Default::default()
+                    })
+                    .with_children(|parent| {
+                        parent.spawn(TextBundle {
+                            text: Text {
+                                value: button.name(),
+                                font: button_materials.font.clone(),
+                                style: TextStyle {
+                                    font_size: 20.0,
+                                    color: Color::rgb(0.9, 0.9, 0.9),
+                                    ..Default::default()
+                                },
+                            },
+                            ..Default::default()
+                        });
+                    })
+                    .with(button);
+            }
+        });
+}</code></pre>
+
+<p>我们已替换了 <code>with_children</code> 的内容，来循环遍历按钮列表，从而创建按钮。</p>
+
+<p>注意：我们设置按钮的方式有点菜，所以如果你有很多按钮显示的话，它会看起来很奇怪！添加一个滚动条或者其他改善方式就留给读者作为练习了。</p>
+
+<p>效果如下图所示：</p>
+
+<p><img src='https://caballerocoll.com/images/rhythm_menu_with_correct_buttons.png' alt='' /></p>
+
+<p>现在我们要让按钮可用。为此，我们添加另一个“系统”来监听点击事件：</p>
+
+<pre><code class="language-`rust">// menu.rs
+use crate::types::load_config;
+
+fn button_press_system(
+    commands: &amp;mut Commands,
+    asset_server: Res&lt;AssetServer&gt;,
+    query: Query&lt;(&amp;Interaction, &amp;MenuButton), (Mutated&lt;Interaction&gt;, With&lt;Button&gt;)&gt;,
+    mut state: ResMut&lt;State&lt;AppState&gt;&gt;,
+) {
+    for (interaction, button) in query.iter() {
+        // 在这一帧中检测按钮是否被点击
+        if *interaction == Interaction::Clicked {
+            match button {
+                // 如果地图制作按钮被点击，改变模式
+                MenuButton::MakeMap =&gt; state
+                    .set_next(AppState::MakeMap)
+                    .expect(&quot;Couldn&#8217;t switch state to MakeMap&quot;),
+                // 如果它是一个播放歌曲按钮，加载对应配置，插入资源，然后改变态模式
+                MenuButton::PlaySong(song) =&gt; {
+                    let config = load_config(&amp;*format!(&quot;{}.toml&quot;, song), &amp;asset_server);
+                    commands.insert_resource(config);
+                    state
+                        .set_next(AppState::Game)
+                        .expect(&quot;Couldn&#8217;t switch state to Game&quot;)
+                }
+            };
+        }
+    }
+}</code></pre>
+
+<p>在这个系统中，我们循环遍历每个按钮，并检查它们是否处于点击状态。如果是，我们会匹配按钮的类型，执行相应的逻辑。对于 <code>MakeMap</code>，我们只需使用 <code>set_next</code> 改变状态。对于 <code>PlaySong</code>，用我们创建的 <code>SongConfig</code> 函数来加载选定歌曲的 <code>SongConfig</code>，在将状态更改为 <code>Game</code> 之前，我们使用 <code>insert_resource</code> 添加歌曲。</p>
+
+<p>最后，我们应该把这个系统添加到 <code>MenuPlugin</code>，设置成 <code>Menu</code> 状态更新时运行：</p>
+
+<pre><code class="language-`rust">// menu.rs
+pub struct MenuPlugin;
+impl Plugin for MenuPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;ButtonMaterials&gt;()
+            .on_state_enter(APP_STATE_STAGE, AppState::Menu, setup_menu.system())
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::Menu,
+                button_color_system.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::Menu,
+                button_press_system.system(),
+            )
+            .on_state_exit(APP_STATE_STAGE, AppState::Menu, despawn_menu.system());
+    
+}</code></pre>
+
+<p>现在运行游戏，我们会看到按钮正常工作，开始游戏：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_menu_changing_state.mp4'>视频资源</a></p>
+
+<p>但有个大问题！当我们开始游戏时，时间在跑了，箭头却没有显示！因为我们使用 <code>time_since_startup</code> 来检查何时生成箭头，当我们进入 <code>Game</code> 状态时，值已经过了第一个箭头的生成时间，所以不会出现，其它箭头也不会出现。为了解决这个问题，我们将在后面制作一个包装器，这样我们就可以在进入 <code>Game</code> 模式时重置它。</p>
+
+<h2 id='时间系统封装'>时间系统封装</h2>
+
+<p>我们的时间包装器非常类似于 Bevy 的时间资源实现，不同的是它需要在我们进入 <code>Game</code> 和 <code>MakeMap</code> 状态时重置时间系统。复制所有代码只是为了改善一些糟糕的东西，但这会让我们在未来做其他工作时带来方便，比如暂停。这也是一个了解 Bevy 源码的好机会。</p>
+
+<p>此外，通过同时拥有一个正常的时间资源和我们自己包装的版本，可以让我们使用正常的时间资源，以及其他需要控制时间的场景。例如，我们要继续为游戏背景使用正常时间，因为我们希望它在所有状态下都能工作。</p>
+
+<p>打开一个新文件， <code>time.rs</code>：</p>
+
+<pre><code class="language-`rust">use crate::consts::*;
+use bevy::{
+    prelude::*,
+    utils::{Duration, Instant},
+};
+
+pub struct ControlledTime {
+    delta: Duration,
+    last_update: Option&lt;Instant&gt;,
+    delta_seconds_f64: f64,
+    delta_seconds: f32,
+    seconds_since_startup: f64,
+    startup: Instant,
+}
+impl Default for ControlledTime {
+    fn default() -&gt; Self {
+        Self {
+            delta: Duration::from_secs(0),
+            last_update: None,
+            startup: Instant::now(),
+            delta_seconds_f64: 0.0,
+            seconds_since_startup: 0.0,
+            delta_seconds: 0.0,
+        }
+    }
+}</code></pre>
+
+<p>这里我们添加了一个与 Bevy 的 time 相同的结构体，使用相同的 <code>Default</code> 实现，我们将其称为 <code>ControlledTime</code>。</p>
+
+<p>现在，添加我们想要的方法，它来自于<a href='https://github.com/bevyengine/bevy/blob/3b2c6ce49b3b9ea8bc5cb68f8d350a80ff928af6/crates/bevy_core/src/time/time.rs'>这个资源</a>，此外我们还会添加一个 <code>reset_time</code> 函数，它将时间设置为 0：</p>
+
+<pre><code class="language-`rust">// time.rs
+impl ControlledTime {
+    pub fn reset_time(&amp;mut self) {
+        self.startup = Instant::now();
+        self.seconds_since_startup = 0.0;
+    }
+
+    pub fn update(&amp;mut self) {
+        let now = Instant::now();
+        self.update_with_instant(now);
+    }
+
+    pub fn update_with_instant(&amp;mut self, instant: Instant) {
+        if let Some(last_update) = self.last_update {
+            self.delta = instant - last_update;
+            self.delta_seconds_f64 = self.delta.as_secs_f64();
+            self.delta_seconds = self.delta.as_secs_f32();
+        }
+
+        let duration_since_startup = instant - self.startup;
+        self.seconds_since_startup = duration_since_startup.as_secs_f64();
+        self.last_update = Some(instant);
+    }
+
+    /// 当前标记和最后一次标记的时间差是 [`f32`] 秒
+    #[inline]
+    pub fn delta_seconds(&amp;self) -&gt; f32 {
+        self.delta_seconds
+    }
+
+    /// 当前标记和最后一次标记的时间差是 [`f64`] 秒
+    #[inline]
+    pub fn delta_seconds_f64(&amp;self) -&gt; f64 {
+        self.delta_seconds_f64
+    }
+
+    /// 启动后的时间，以秒为单位
+    #[inline]
+    pub fn seconds_since_startup(&amp;self) -&gt; f64 {
+        self.seconds_since_startup
+    }
+}</code></pre>
+
+<p>考虑到这一点，我们需要一个能够更新时间的“系统”：</p>
+
+<pre><code class="language-`rust">// time.rs
+pub fn update_time(mut time: ResMut&lt;ControlledTime&gt;) {
+    time.update();
+}</code></pre>
+
+<p>并且有一个系统对时间进行重置</p>
+
+<pre><code class="language-`rust">// time.rs
+pub fn reset_time_when_entering_game(mut time: ResMut&lt;ControlledTime&gt;) {
+    time.reset_time();
+}</code></pre>
+
+<p>我们还会添加一个插件来把它们放在一起：</p>
+
+<pre><code class="language-`rust">// time.rs
+pub struct TimePlugin;
+impl Plugin for TimePlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;ControlledTime&gt;()
+            .on_state_update(APP_STATE_STAGE, AppState::Game, update_time.system())
+            .on_state_update(APP_STATE_STAGE, AppState::MakeMap, update_time.system())
+            .on_state_enter(
+                APP_STATE_STAGE,
+                AppState::Game,
+                reset_time_when_entering_game.system(),
+            )
+            .on_state_enter(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                reset_time_when_entering_game.system(),
+            );
+    }
+}</code></pre>
+
+<p>我们在 <code>Game</code> 和 <code>MapMaker</code> 执行期间设置了 <code>update_time</code>，并且 <code>reset_time_when_entering_game</code> 在这两种模式下都会执行。</p>
+
+<p>跟其它插件一样，我们在 <code>main.rs</code> 中添加：</p>
+
+<pre><code class="language-`rust">// main.rs
+mod time;
+use time::TimePlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_resource(State::new(AppState::Menu))
+        .add_stage_after(
+            stage::UPDATE,
+            APP_STATE_STAGE,
+            StateStage::&lt;AppState&gt;::default(),
+        )
+        .init_resource::&lt;ScoreResource&gt;()
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .add_plugin(AudioPlugin)
+        .add_plugin(ShadersPlugin)
+        .add_plugin(MenuPlugin)
+        .add_plugin(TimePlugin) // &lt;--- New
+        .run();
+}</code></pre>
+
+<p>我们需要做的最后一件事就是用 <code>ControlledTime</code> 代替 <code>Time</code>。</p>
+
+<p>首先是 <code>ui.rs</code>，我们只需改变 <code>update_time_text</code> 中的 <code>time</code> 参数：</p>
+
+<pre><code class="language-`rust">// ui.rs
+use crate::time::ControlledTime;
+
+fn update_time_text(time: Res&lt;ControlledTime&gt;, mut query: Query&lt;(&amp;mut Text, &amp;TimeText)&gt;) {
+    [...]
+}</code></pre>
+
+<p><code>audio.rs</code> 文件也一样，将 <code>Time</code> 替换为 <code>ControlledTime</code></p>
+
+<pre><code class="language-`rust">// audio.rs
+use crate::time::ControlledTime;
+
+fn start_song(audio: Res&lt;Audio&gt;, time: Res&lt;ControlledTime&gt;, config: Res&lt;SongConfig&gt;) {
+    [...]
+}</code></pre>
+
+<p>最后是 <code>arrows.rs</code> 文件，要修改的地方多一些：</p>
+
+<pre><code class="language-`rust">// main.rs
+use crate::time::ControlledTime;
+
+/// Spawns arrows
+fn spawn_arrows(
+    commands: &amp;mut Commands,
+    mut song_config: ResMut&lt;SongConfig&gt;,
+    materials: Res&lt;ArrowMaterialResource&gt;,
+    time: Res&lt;ControlledTime&gt;,
+) {
+    [...]
+}
+
+/// Moves the arrows forward
+fn move_arrows(time: Res&lt;ControlledTime&gt;, mut query: Query&lt;(&amp;mut Transform, &amp;Arrow)&gt;) {
+    [...]
+}</code></pre>
+
+<p>现在运行游戏，可以看到菜单和游戏正常工作了：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_working_menu_and_game.mp4'>视频资源</a></p>
+
+<p>太棒了！</p>
+
+<h2 id='添加简单的地图制作模式'>添加简单的地图制作模式</h2>
+
+<p>在本节中，我们添加一个场景模式来帮助我们给歌曲创建地图。我们想要的是当歌曲播放时，我们何时按下按键，并将它们保存到一个文件中。</p>
+
+<p>我们打开一个新文件 <code>map_maker.rs</code>，我们从添加资源和“系统”开始：</p>
+
+<pre><code class="language-`rust">use crate::time::ControlledTime;
+use crate::consts::*;
+use crate::types::{
+    ArrowTimeToml,
+    Directions::{self, *},
+    Speed,
+};
+use bevy::{
+    app::AppExit,
+    input::{keyboard::KeyCode, Input},
+    prelude::*,
+};
+use serde_derive::Serialize;
+use std::fs::File;
+use std::io::prelude::*;
+
+#[derive(Serialize, Debug, Default)]
+/// 跟踪按键被按下的时间
+struct Presses {
+    arrows: Vec&lt;ArrowTimeToml&gt;,
+}
+
+/// 保存被按下的键
+fn save_key_presses(
+    time: Res&lt;ControlledTime&gt;,
+    keyboard_input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+    mut presses: ResMut&lt;Presses&gt;,
+) {
+    let directions = [Up, Down, Left, Right];
+    for direction in directions.iter() {
+        if direction.key_just_pressed(&amp;keyboard_input) {
+            presses.arrows.push(ArrowTimeToml {
+                click_time: time.seconds_since_startup(),
+                speed: Speed::Slow,
+                direction: *direction,
+            });
+        }
+    }
+}</code></pre>
+
+<p>我们大量添加需要增加的东西，我们创建 <code>Presses</code> 资源，它保存了一个 <code>ArrowTimeToml</code> 列表，以及一个当方向键被按下时添加到该列表的“系统”，并循环所有方向的按键。</p>
+
+<p>我们还需要一个系统来监听 <code>AppExit</code> 事件，并将 <code>ArrowTimeToml</code> 列表保存到文件中：</p>
+
+<pre><code class="language-`rust">// map_maker.rs
+fn save_to_file_on_exit(
+    mut event_reader: Local&lt;EventReader&lt;AppExit&gt;&gt;,
+    events: Res&lt;Events&lt;AppExit&gt;&gt;,
+    presses: Res&lt;Presses&gt;,
+) {
+    for _event in event_reader.iter(&amp;events) {
+        let text = toml::to_string(&amp;*presses).expect(&quot;Couldn&#8217;t convert to toml text&quot;);
+
+        let mut file = File::create(&quot;map.toml&quot;).expect(&quot;Couldn&#8217;t open map.toml&quot;);
+        file.write_all(text.as_bytes())
+            .expect(&quot;Couldn&#8217;t write to map.toml&quot;);
+    }
+}</code></pre>
+
+<p>我们得做点什么来提高这个模式的易用性。当玩家按下一个按键时，相应的方向会有箭头出现在屏幕上。我们将添加两个系统，一个生成箭头，一个切换箭头的可见性：</p>
+
+<pre><code class="language-`rust">// map_maker.rs
+struct MapMakerArrow(Directions);
+
+/// Creates map maker arrows
+fn setup_map_maker_arrows(
+    commands: &amp;mut Commands,
+    mut materials: ResMut&lt;Assets&lt;ColorMaterial&gt;&gt;,
+    asset_server: ResMut&lt;AssetServer&gt;,
+) {
+    let border_handle = materials.add(asset_server.load(&quot;images/arrow_border.png&quot;).into());
+
+    let directions = [Up, Down, Left, Right];
+    for direction in directions.iter() {
+        let y = match direction {
+            Up =&gt; 150.,
+            Down =&gt; 50.,
+            Left =&gt; -50.,
+            Right =&gt; -150.,
+        };
+
+        let mut transform = Transform::from_translation(Vec3::new(0., y, 1.));
+        transform.rotate(Quat::from_rotation_z(direction.rotation()));
+        commands
+            .spawn(SpriteBundle {
+                material: border_handle.clone(),
+                sprite: Sprite::new(Vec2::new(140., 140.)),
+                transform,
+                ..Default::default()
+            })
+            .with(MapMakerArrow(*direction));
+    }
+}
+
+/// 根据是否按下对应的键来切换可见性
+fn toggle_map_maker_arrows(
+    mut query: Query&lt;(&amp;mut Visible, &amp;MapMakerArrow)&gt;,
+    keyboard_input: Res&lt;Input&lt;KeyCode&gt;&gt;,
+) {
+    for (mut visible, arrow) in query.iter_mut() {
+        visible.is_visible = arrow.0.key_pressed(&amp;keyboard_input);
+    }
+}</code></pre>
+
+<p>第一个“系统”非常类似于 <code>spawn_target_arrows</code>，它只是创建精灵，并添加我们刚刚声明的 <code>MapMakerArrow</code> 组件。第二个系统是 <code>toggle_map_maker_arrows</code>，根据箭头对应的方向键是否被按下来设置箭头的可见性。我们通过设置精灵的 <code>Visible</code> 中的 <code>is_visible</code> 字段来做到这一点。</p>
+
+<p>这里有一个问题，我们目前给 <code>Directions</code> 声明的 <code>key_just_pressed</code> 方法使用了 <code>just_pressed</code>，这只会在按键被按下的第一帧时才会生效。我们希望玩家按下按键，箭头就立即显示，所以我们添加了另一种 <code>pressed</code> 方法，它可以实现我们想要的：</p>
+
+<pre><code class="language-`rust">// types.rs
+impl Directions {
+    [Other methods...]
+
+    /// 检查是否按下与当前方向相同的方向键
+    pub fn key_pressed(&amp;self, input: &amp;Input&lt;KeyCode&gt;) -&gt; bool {
+        let keys = match self {
+            Directions::Up =&gt; [KeyCode::Up, KeyCode::D],
+            Directions::Down =&gt; [KeyCode::Down, KeyCode::F],
+            Directions::Left =&gt; [KeyCode::Left, KeyCode::J],
+            Directions::Right =&gt; [KeyCode::Right, KeyCode::K],
+        };
+
+        keys.iter().any(|code| input.pressed(*code))
+    }
+}</code></pre>
+
+<p>这样，我们的 <code>toggle_map_maker_arrows</code> 系统就可以正常工作了！我们还要给所有的歌曲地图实现一个插件：</p>
+
+<pre><code class="language-`rust">// map_maker.rs
+pub struct MapMakerPlugin;
+impl Plugin for MapMakerPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;Presses&gt;()
+            .on_state_enter(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                setup_map_maker_arrows.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                toggle_map_maker_arrows.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                save_key_presses.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                save_to_file_on_exit.system(),
+            );
+    }
+}</code></pre>
+
+<p>要想让它运行起来，我们还需要在 <code>main.rs</code> 中加上“系统”的调用代码：</p>
+
+<pre><code class="language-`rust">// main.rs
+mod map_maker;
+use map_maker::MapMakerPlugin;
+
+fn main() {
+    App::build()
+        // Set antialiasing to use 4 samples
+        .add_resource(Msaa { samples: 4 })
+        // Set WindowDescriptor Resource to change title and size
+        .add_resource(WindowDescriptor {
+            title: &quot;Rhythm!&quot;.to_string(),
+            width: 800.,
+            height: 600.,
+            ..Default::default()
+        })
+        .add_resource(State::new(AppState::Menu))
+        .add_stage_after(
+            stage::UPDATE,
+            APP_STATE_STAGE,
+            StateStage::&lt;AppState&gt;::default(),
+        )
+        .init_resource::&lt;ScoreResource&gt;()
+        .add_startup_system(setup.system())
+        .add_system(exit_on_esc_system.system())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ArrowsPlugin)
+        .add_plugin(UIPlugin)
+        .add_plugin(AudioPlugin)
+        .add_plugin(ShadersPlugin)
+        .add_plugin(MenuPlugin)
+        .add_plugin(TimePlugin)
+        .add_plugin(MapMakerPlugin) // &lt;--- 新增代码
+        .run();
+}</code></pre>
+
+<p>现在，我们可以运行游戏来看看地图制作模式是否能正常工作：</p>
+
+<p>&gt; &gt; <a href='https://caballerocoll.com/images/rhythm/rhythm_map_maker_mode.mp4'>视频资源</a></p>
+
+<p>请记住，在游戏终端中使用 ESC 键退出，而不是 <code>Ctrl+C</code> 键，这样才能保存文件成功。</p>
+
+<p>这是我们得到的一个文件示例：</p>
+
+<pre><code class="language-`map.toml">[[arrows]]
+click_time = 1.04939044
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 1.658164574
+speed = &quot;Slow&quot;
+direction = &quot;Down&quot;
+
+[[arrows]]
+click_time = 2.191576505
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 2.558483463
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 2.858588189
+speed = &quot;Slow&quot;
+direction = &quot;Left&quot;
+
+[[arrows]]
+click_time = 3.4904190330000002
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 3.9252477949999998
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 4.240984206
+speed = &quot;Slow&quot;
+direction = &quot;Left&quot;
+
+[[arrows]]
+click_time = 4.62353972
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 4.97381796
+speed = &quot;Slow&quot;
+direction = &quot;Up&quot;
+
+[[arrows]]
+click_time = 5.308837329
+speed = &quot;Slow&quot;
+direction = &quot;Left&quot;</code></pre>
+
+<p>现在我们可以将它添加到 <code>assets/songs</code> 目录下，添加 <code>name</code> 和 <code>filename</code> 字段，这样就有了歌曲的工作地图！</p>
+
+<p>我们需要做的最后一件事是在地图制作模式下播放歌曲，否则它就显得有点鸡肋。我们简单实现一下，并且给使用的歌曲路径硬编码，这样可以让教程简短一些（如果还算短的话）。我们将使用路径 <code>assets/map_maker_song.mp3</code> 中的歌曲。玩家必须在地图制作器中修改文件路径来更换歌曲。每个人都可以实现一些自己的“系统”，以更容易地选择地图制作器中使用的歌曲。</p>
+
+<h2 id='在地图制作器中播放歌曲'>在地图制作器中播放歌曲</h2>
+
+<p>为了让音乐进入地图制作器，我们先要添加一个资源来保存 <code>Handle&lt;AudioSource&gt;</code>。我们要为该资源实现 <code>FromResources</code>，这样可以在开始时就加载它，当把它加载到地图制作器中时，它就准备好可以玩了：</p>
+
+<pre><code class="language-`rust">struct MapMakerAudio(Handle&lt;AudioSource&gt;);
+impl FromResources for MapMakerAudio {
+    fn from_resources(resources: &amp;Resources) -&gt; Self {
+        let asset_server = resources.get_mut::&lt;AssetServer&gt;().unwrap();
+        let audio = asset_server.load(&quot;map_maker_song.mp3&quot;);
+        Self(audio)
+    }
+}</code></pre>
+
+<p>这一次我决定使用一个元组结构体来处理资源，因为我们只有一个字段。<code>FromResources</code> 实现了静态资源服务器，它可以加载音频资源。</p>
+
+<p>在那之后，我们要创建一个新“系统”来进行播放音频，我们将把它设置为进入 <code>MakeMap</code> 的状态时执行：</p>
+
+<pre><code class="language-`rust">// map_maker.rs
+fn start_song(audio: Res&lt;Audio&gt;, map_maker_audio: Res&lt;MapMakerAudio&gt;) {
+    audio.play(map_maker_audio.0.clone());
+}</code></pre>
+
+<p>我们要做的最后一件事是将这两个资源加到插件中：</p>
+
+<pre><code class="language-`rust">// map_maker.rs
+pub struct MapMakerPlugin;
+impl Plugin for MapMakerPlugin {
+    fn build(&amp;self, app: &amp;mut AppBuilder) {
+        app.init_resource::&lt;Presses&gt;()
+            .init_resource::&lt;MapMakerAudio&gt;() // &lt;--- 新代码
+            .on_state_enter(APP_STATE_STAGE, AppState::MakeMap, start_song.system()) // &lt;--- 新代码
+            .on_state_enter(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                setup_map_maker_arrows.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                toggle_map_maker_arrows.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                save_key_presses.system(),
+            )
+            .on_state_update(
+                APP_STATE_STAGE,
+                AppState::MakeMap,
+                save_to_file_on_exit.system(),
+            );
+    }
+}</code></pre>
+
+<p>找一个音频文件，并将其放到 <code>assets/map_maker_song.mp3</code> 中，如果你运行游戏，进入地图制作模式时，应该可以听到音频播放了！</p>
+
+<p>至此，我们的游戏教程就结束了。和往常一样，你可以随意尝试，修改一些东西，让它成为你的东西！如果你有任何的改进，请在 <a href='https://twitter.com/guimcaballero'>Twitter</a> 标记我，这样我就能看到了！</p>
+
+<h2 id='下一步'>下一步</h2>
+
+<p>如果你还没想好要做什么样的二次开发，以下提供一些可以尝试的想法：</p>
+
+<ul>
+<li>1.添加必须在特定的时间内保持状态的箭头。</li>
+
+<li>2.改进地图制作器，增加选择歌曲的功能。</li>
+
+<li>3.给游戏增加一个游戏结束画面。</li>
+
+<li>4.增加一种歌曲播放完后，回到菜单的方式</li>
+
+<li>5.创建一个可以改变点击阈值的“系统”，可以让玩家在困难模式时选择简单模式，玩家很轻松则切换到困难模式。</li>
+</ul>
+]]></content:encoded></item><item><title>「译」Arenas in Rust</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/arenas-in-rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」arenas_in_rust'>「译」Arenas in Rust</h1>
+
+<p>译者：<a href='https://github.com/MATRIXKOO'>MATRIXKOO</a> / 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 原文: <a href='https://manishearth.github.io/blog/2021/03/15/arenas-in-rust/'>Arenas in Rust</a></p>
+
+<h2 id=''></h2>
+
+<h1 id='rust_中的_arenas_内存池'>Rust 中的 Arenas 内存池</h1>
+
+<p>最近有一些关于 Rust 中 <code>Arenas</code> 的讨论，我想我应该写一篇关于这个文章。</p>
+
+<p>在 Rust 中，<code>Arenas</code> 并不是那种 &quot;典型的&quot; 问题，所以很少有人了解它们。只会在各种用例的应用程序中有看到它们。一般来说，你只需要调包就行了，没必要为它使用 <code>unsafe</code> 。因此无需专门去学会写它，但这些知识也不是无用的，尤其是对有使用 <code>Arenas</code> 的人来说更是如此 。</p>
+
+<p>此外，我在实现自引用的 <code>Arenas</code> 时会涉及到一系列非常<em>酷</em>的 <code>lifetime</code>操作 ，我以前完全没写过。</p>
+
+<p>我主要是为了写一些<em>很酷</em>的生命周期效应而写的，但是我认为有必要写一篇针对所有 <code>Rustaceans</code> 的介绍。如果你已经知道什么是 <code>Arenas</code>，并且想看到一些很炫酷的 <code>lifetime</code> 技巧，则可以直接跳到<a href='https://manishearth.github.io/blog/2021/03/15/arenas-in-rust/#implementing-a-self-referential-arena'>这里</a>阅读。</p>
+
+<h2 id='什么是_arena_?'>什么是 arena ?</h2>
+
+<p><code>Arenas</code> 本质上是一种将预期生命周期相同的内存进行分组的模式。比如说有时需要在某个生命周期内分配一堆对象，之后这些对象将被全部销毁。每次都调用系统分配器效率低下，更可取的是为对象预分配一堆内存，并在完成处理后立即将其全部清理干净。 \&gt;译者注: 没错就是 cache</p>
+
+<p>从广义上讲，使用 <code>Arenas</code>  有以下两个原因：</p>
+
+<p>首先，如上所述，使用它主要目标可能是减轻内存消耗。例如，在游戏或应用程序中，可能存在大量需要逐帧分配，使用完立即销毁的情况。特别是在游戏开发中，这非常普遍，而内存压力是游戏开发人员比较关心的事情。使用  <code>Arenas</code>，可以轻松地分配一个 <code>Arena</code>，在每个帧中将其填满，并在帧结束后将其清空。缓存局部性还能其他好处：可以确保大多数每帧对象在帧期间（可能比其他对象使用得更多）位于缓存中，因为它们是相邻分配的。</p>
+
+<p>另一个原因可能是用于编写自引用的数据，例如带有环的复杂图，使用此方法数据可以一次全部清除。例如，在编写编译器时，<code>type</code>信息可能将需要引用其他类型或者其他数据，从而导致复杂的，可能是 <code>type</code> 的有环图。一旦推导出类型，就不需要专门销毁它了，因此可以使用一个 <code>Arenas</code> 来存储所有计算出的类型信息，当类型信息无关紧要时，就可以直接将他们一次性清楚。使用这种模式可以让代码不必担心自引用位是否会 “提前” 释放，它可以保证，如果存在一个 <code>Ty</code> ，则它的寿命与其他所有 <code>Ty</code> 一样长，并且可以直接引用它们。</p>
+
+<p>&gt; &gt; 译者注: 不会导致空引用</p>
+
+<p>这两个目标不一定是相互联系的：可以使用一个 <code>Arenas</code>来同时实现两个目标。但是，也可以拥有一个禁止使用自我引用类型的 <code>Arenas</code>（有得有失，你能得到一些好处）。在本文的稍后部分，我将实现一个允许自我引用类型但对减轻内存分配压力影响不大的  <code>Arenas</code>，主要是为了易于实现。<em>通常</em>，如果要为编写用于自引用类型 的 <code>Arenas</code>，则可以使其同时减少分配器压力，但可能会有所取舍。</p>
+
+<h2 id='在_rust_中如何使用_arena_?'>在 Rust 中如何使用 arena ?</h2>
+
+<p>一般来说，要使用 arena ，只需要调包。 我简单的搜索一下现有的 <code>Arenas</code> 实现，在<a href='https://crates.io/search?q=arena'>这里</a>。下面我会介绍两个我已经了解的库，但我只是挂 &quot;二&quot; 漏万。</p>
+
+<p>要指出的是，如果只需要环结构，而不必使用 <code>arenas</code> ，那么出色的 <a href='https://docs.rs/petgraph/'>petgraph</a> 通常就足够了。 <a href='https://docs.rs/slotmap/'>slotmap</a> 也很不错； 它是类似地图的数据结构，可用于基于分代索引的自引用数据。</p>
+
+<h3 id='bumpalo'>Bumpalo</h3>
+
+<p><code>Bumpalo</code> 是一种快速的 <code>bump allocator[1]</code>，它允许异构的内容，并且仅在不关心析构函数运行的情况下才允许循环。</p>
+
+<p>&gt; &gt; 参见: \[1]https://blog.codingnow.com/2013/11/bump<em>pointer</em>allocator.html</p>
+
+<pre><code class="language-`rust">use bumpalo::Bump;
+
+// (example slightly modified from `bumpalo` docs)
+
+// Create a new arena to bump allocate into.
+let bump = Bump::new();
+
+// Allocate values into the arena.
+let scooter = bump.alloc(Doggo {
+    cuteness: u64::max_value(),
+    age: 8,
+    scritches_required: true,
+});
+
+// Happy birthday, Scooter!
+scooter.age += 1;</code></pre>
+
+<p>每次对 <code>Bump::alloc()</code> 的调用都会返回对已分配对象的可变引用。 这可以分配不同的对象，它们甚至可以相互引用 (不用环的话,借用检查就会强制这样做) 。 默认情况下，它不会在其内容上调用析构函数。 但是，可以使用 <code>bumpalo::boxed</code>（或Nightly上的自定义分配器）来实现这个效果。 可以类似地使用 <code>bumpalo::collections</code>来获取 <code>bumpalo</code> 支持的向量和字符串。<code> bumpalo::boxed</code> 将不允许自引用。 x</p>
+
+<h3 id='typed-arena'>typed-arena</h3>
+
+<p>［typed-arena](https://docs.rs/typed-arena/)是一个 <code>areana</code> 分配器，它只能存储单一类型的对象，但是就可以循环引用：</p>
+
+<pre><code class="language-`rust">// Example from typed-arena docs
+
+use std::cell::Cell;
+use typed_arena::Arena;
+
+struct CycleParticipant&lt;&#8217;a&gt; {
+    other: Cell&lt;Option&lt;&amp;&#8217;a CycleParticipant&lt;&#8217;a&gt;&gt;&gt;,
+}
+
+let arena = Arena::new();
+
+let a = arena.alloc(CycleParticipant { other: Cell::new(None) });
+let b = arena.alloc(CycleParticipant { other: Cell::new(None) });
+
+// mutate them after the fact to set up a cycle
+a.other.set(Some(b));
+b.other.set(Some(a));</code></pre>
+
+<p>和 <code>bumpalo</code> 不同的是，<code>typed-arena</code> 当 <code>arena</code> 本身超出范围时，就会使用析构函数 \&gt;你或许想知道，析构函数在引用数据上的安全性–毕竟，无论哪一个变量被第二次销毁，析构函数都会读到悬挂的引用。 我们将在文章的后面对此进行介绍，但这与 <code>drop</code> 检查有关，特别是如果尝试自引用时，则 arena 元素 本身允许的唯一显式析构函数将是带有适当标记类型的析构函数。</p>
+
+<h2 id='实现一个支持自引用的_arena'>实现一个支持自引用的 arena</h2>
+
+<p>写自引用代码是很有趣的，因为 Rust 非常警惕自我参照数据。 但是 <code>areana</code> 可以让你清楚地将“我不在乎此对象”和“可以删除此对象”阶段分开，以允许自引用和循环类型出现。</p>
+
+<p>&gt; &gt; 人们很少需要实现自己的 arena，Bumpalo和Typedarena涵盖了大多数使用场景，实在没办法的话不妨先在 crates.io上 找一下。 但是，如果你的确需要直接实现的话，或者对具体的生命周期细节感兴趣，那么本节适合你。</p>
+
+<p>在以下规则中实现输入条目为Entry的竞技场Arena的关键：</p>
+
+<ul>
+<li><code>Arena</code> 和 <code>Entry</code> 都应具有生命周期参数：<code>Arena &lt;&#8217;arena&gt;</code> 和 <code>Entry &lt;&#8217;arena&gt;</code></li>
+
+<li><code>Arena</code> 方法都应将 <code>Arena &lt;&#8217;arena&gt;</code> 接收为 <code>＆&#8217;arena</code> 自身，即其自身类型为<code>＆&#8217;arena Arena &lt;&#8217;arena&gt;</code></li>
+
+<li><code>Entry</code>几乎应该始终以 <code>＆&#8217;arena Entry &lt;&#8217;arena&gt;</code> 的形式传递（为此创建别名非常有用）</li>
+
+<li>使用内部可变性； <code>Arena</code>上的 <code>＆mut self</code> 将使所有代码停止编译。 如果使用 <code>unsafe</code>的可变性，请确保 <code>RefCell &lt;Entry &lt;&#8217;arena &gt;&gt;</code>  具有 <a href='https://doc.rust-lang.org/std/marker/struct.PhantomData.html'>PhantomData</a> 。</li>
+</ul>
+
+<p>从生命周期的角度来看基本上就是这样，剩下的全部就是确定所需的 API 。 掌握了以上规则，只要确保定义区域与所需的保证一起使用，就不必了解底层生命周期的状况。</p>
+
+<p>让我们看一个 实现，然后剖析其工作原理。</p>
+
+<p>\###　实现 我的库 <a href='https://docs.rs/elsa'>elsa</a> 在其中一个示例中使用 100％ <code>safe</code> 的代码实现了一个 <code>arena</code> 。由于 <code>elsa :: FrozenVec</code> 要求其内容位于间接引用之后，因此该 <code>arena</code> 无法节省分配，并且它不是通用的，但这是一种合理的方式来说明生命周期的工作方式，而无需陷入 使用 <code>unsafe</code> 带来的麻烦之中。</p>
+
+<p>该示例实现了 <code>Person &lt;&#8217;arena&gt;</code> 类型的 <code>Arena</code> ，<code>Arena &lt;&#8217;arena&gt;</code> 。目标是实现某种可能有环的有向社交图。</p>
+
+<pre><code class="language-`rust">use elsa::FrozenVec;
+
+struct Arena&lt;&#8217;arena&gt; {
+    people: FrozenVec&lt;Box&lt;Person&lt;&#8217;arena&gt;&gt;&gt;,
+}</code></pre>
+
+<p><a href='https://docs.rs/elsa/1.4.0/elsa/vec/struct.FrozenVec.html'>elsa::FrozenVec</a>是类似于 <code>Vec</code> 的仅支持追加内容的抽象，可让你调用<code>push</code> 而不需要传入可变的引用，这是只使用 <code>safe</code> 的一个实现。</p>
+
+<p>每个 <code>Person &lt;&#8217;arena&gt;</code> 都有一个他们关注的人的列表，但也跟踪他们关注的人：</p>
+
+<pre><code class="language-`rust">struct Person&lt;&#8217;arena&gt; {
+    pub follows: FrozenVec&lt;PersonRef&lt;&#8217;arena&gt;&gt;,
+    pub reverse_follows: FrozenVec&lt;PersonRef&lt;&#8217;arena&gt;&gt;,
+    pub name: &amp;&#8217;static str,
+}
+
+// following the rule above about references to entry types
+type PersonRef&lt;&#8217;arena&gt; = &amp;&#8217;arena Person&lt;&#8217;arena&gt;;</code></pre>
+
+<p>这个生命周期 <code>arena</code>  其实是 “arena本身的生命周期”。 从这开始事情就变得奇怪起来了：通常，如果一个有生命周期参数，则调用者可以选择其中的内容。 不必只是说“这是对象本身的生命周期”，调用者通常可以根据需要实例化 <code>arena &lt;&#8217;static&gt;</code> 或为某个 <code>&#8217;a</code> 实例化 <code>Arena &lt;&#8217;a&gt;</code> 。 但是在这里，我们声明 “<code> &#8217;arena</code> 是 <code>arena</code> 自身的生命周期&quot; ； 很明显，一定有东西不太对。</p>
+
+<p>这是我们实际实现的地方：</p>
+
+<pre><code class="language-`rust">impl&lt;&#8217;arena&gt; Arena&lt;&#8217;arena&gt; {
+    fn new() -&gt; Arena&lt;&#8217;arena&gt; {
+        Arena {
+            people: FrozenVec::new(),
+        }
+    }
+    
+    fn add_person(&amp;&#8217;arena self, name: &amp;&#8217;static str,
+                  follows: Vec&lt;PersonRef&lt;&#8217;arena&gt;&gt;) -&gt; PersonRef&lt;&#8217;arena&gt; {
+        let idx = self.people.len();
+        self.people.push(Box::new(Person {
+            name,
+            follows: follows.into(),
+            reverse_follows: Default::default(),
+        }));
+        let me = &amp;self.people[idx];
+        for friend in &amp;me.follows {
+            // We&#8217;re mutating existing arena entries to add references,
+            // potentially creating cycles!
+            // 把每一个元素都加上了 引用 , 很有可能导致循环引用
+            friend.reverse_follows.push(me)
+        }
+        me
+    }
+
+    fn dump(&amp;&#8217;arena self) {
+        // code to print out every Person, their followers, and the people who follow them
+        // 打印出 `Person` ,他们的关注者 ,和关注的人
+    }
+}</code></pre>
+
+<p>注意 <code>add_person中的&amp;&#8217;arena self</code>。</p>
+
+<p>此处的很好的实现了,“如果A 关注了 B，然后B又关注A” 这种通常需要分开处理的情况，但这仅是示例。</p>
+
+<p>最后，我们可以像这样使用 <code>arena</code> ：</p>
+
+<pre><code class="language-`rust">fn main() {
+    let arena = Arena::new();
+    let lonely = arena.add_person(&quot;lonely&quot;, vec![]);
+    let best_friend = arena.add_person(&quot;best friend&quot;, vec![lonely]);
+    let threes_a_crowd = arena.add_person(&quot;threes a crowd&quot;, vec![lonely, best_friend]);
+    let rando = arena.add_person(&quot;rando&quot;, vec![]);
+    let _everyone = arena.add_person(&quot;follows everyone&quot;, vec![rando, threes_a_crowd, lonely, best_friend]);
+    arena.dump();
+}</code></pre>
+
+<p>在这种情况下，所有 “可变性” 都发生在 <code>arena</code> 本身的实现中，但是此代码可能会将元素直接添加到 <code>follows/reverse_follows</code> 列表中，或者 <code>Person</code> 可能具有用于其他类型链接的 <code>RefCells</code> 。</p>
+
+<h3 id='生命周期是如何工作的'>生命周期是如何工作的</h3>
+
+<p>那么这是如何工作的呢？ 如前所述，在 Rust 中使用这样的抽象，调用者通常可以自由地根据其处理方式来设置生存期。 例如，如果 <code>HashMap&lt;K，&amp;&#8217;a str&gt;</code>，则 <code>&#8217;a</code> 将根据你尝试插入的内容的生存期进行调整。</p>
+
+<p>当构造 <code>Arena</code> 时，其生命周期确实仍然不受限制，我们可以通过检查以下强制约束生命周期的代码来进行测试。 (依然是能过编译的)</p>
+
+<pre><code class="language-`rust">let arena: Arena&lt;&#8217;static&gt; = Arena::new();</code></pre>
+
+<p>当你想做点什么的时候,就会停止工作:</p>
+
+<pre><code class="language-`rust">let arena: Arena&lt;&#8217;static&gt; = Arena::new();
+let lonely = arena.add_person(&quot;lonely&quot;, vec![]);</code></pre>
+
+<pre><code class="language-`shell">error[E0597]: `arena` does not live long enough
+  --&gt; examples/mutable_arena.rs:5:18
+   |
+4  |     let arena: Arena&lt;&#8217;static&gt; = Arena::new();
+   |                -------------- type annotation requires that `arena` is borrowed for `&#8217;static`
+5  |     let lonely = arena.add_person(&quot;lonely&quot;, vec![]);
+   |                  ^^^^^ borrowed value does not live long enough
+...
+11 | }
+   | - `arena` dropped here while still borrowed</code></pre>
+
+<p><code>add_person</code> 方法以某种方式强制将 <code>Arena</code> 的 <code>arena</code> 参数设置为自己的生命周期，从而对其进行约束（并且无法用类型注释将其强制约束为其他任何值）。 这是与 <code>add_person</code> 的<code>＆&#8217;arena</code> 自签名（即 self 是 <code>＆&#8217;arena Arena &lt;&#8217;self&gt;</code> ）的巧妙互动，以及<code>&#8217;Arena in Arena &lt;&#8217;arena&gt;</code> 是<a href='https://doc.rust-lang.org/nomicon/subtyping.html#variance'>不变的生命周期</a>。</p>
+
+<p>通常，在 Rust 程序中，生命周期具有&quot;伸缩性&quot;。 以下代码可以通过编译：</p>
+
+<pre><code class="language-`rust">// ask for two strings *with the same lifetime*
+// 要求具有相同 生命周期的 string 
+fn take_strings&lt;&#8217;a&gt;(x: &amp;&#8217;a str, y: &amp;&#8217;a str) {}
+
+// string literal with lifetime &#8217;static
+// 要求具有 `&#8217;static&#8217; 生命周期的 ` string literal`  
+let lives_forever = &quot;foo&quot;;
+// owned string with shorter, local lifetime
+// 要求具有 `local` 生命周期
+let short_lived = String::from(&quot;bar&quot;);
+
+// still works!
+// 能跑通
+take_strings(lives_forever, &amp;*short_lived);</code></pre>
+
+<p>在这段代码中，Rust 很高兴地注意到，虽然 <code>live_forever</code> 和 <code>&amp;* short_lived</code> 具有不同的生命周期，但假装 <code>life_forever</code> 在 <code>take_strings</code> 函数的有效期内具有较短的生命周期是完全可以接受的。这只是引用，使用生命周期长的引用也适用于生命周期短的情况。</p>
+
+<p>事实是，这种伸缩性并非对所用的生命周期都一样！<a href='https://doc.rust-lang.org/nomicon/subtyping.html'>nomicon chapter on subtyping and variance</a> 一章详细说明了为什么会这样，但一般的经验法则是，大多数生命周期都是“紧缩的” (更专业的说法是 <code>协变的</code> )，就像上面的<code>&amp;a str</code> 中的一样，但是如果涉及某种形式的可变性，它们是不可变的，也称为“不变式”。如果使用的是函数类型，则具有 <code>弹性的</code> 生命周期 (即抗变的)，但是这种情况很少见。</p>
+
+<p>我们的 <code>Arena &lt;&#8217;arena&gt;</code> 使用内部可变性（通过 <code>FrozenVec</code>）使&#8217; <code>arena</code>不变。 让我们再次看一下两行代码。当编译器看到下面代码的第一行时，便会构建 <code>arena</code>，我们将其生命周期称为“ a”。此时 Arena 类型是 <code>Arena &lt;&#8217;？&gt;</code> ，其中的&#8217;？由表示形式表示，但生命周期不受限制。</p>
+
+<pre><code class="language-`rust">let arena = Arena::new(); 
+let lonely = arena.add_person(&quot;lonely&quot;, vec![]);</code></pre>
+
+<p>让我们把生命周期写清楚一点</p>
+
+<pre><code class="language-`rust">let arena = Arena::new(); // type Arena&lt;&#8217;?&gt;, lives for &#8217;a
+
+// explicitly write the `self` that gets constructed when you call add_person
+// 显式写出 在调用 add_person 时的构建函数
+let ref_to_arena = &amp;arena; // type &amp;&#8217;a Arena&lt;&#8217;?&gt;
+let lonely = Arena::add_person(ref_to_arena, &quot;lonely&quot;, vec![]);</code></pre>
+
+<p>还记得我之前列出的第二条规则吗？</p>
+
+<ul>
+<li>Arena方法都应将Arena \&lt;&#8217;arena&gt;接收为＆&#8217;arena自身，即其自身类型为＆&#8217;arena Arena \&lt;&#8217;arena&gt; 我们遵循这条规则；</li>
+</ul>
+
+<p><code>add_person</code> 的签名是 <code>fn add_person(&amp;&#8217;arena self)</code>。这意味着 <code>ref_to_arena</code> 的生存期必须与 <code>&amp;&#8217;arena Arena &lt;&#8217;arena&gt;</code> 模式匹配。目前，它的生命周期是<code>&amp;&#8217;a Arena &lt;&#8217;?&gt;</code>，表示<code> &#8217;？</code>强制与&#8217;a相同，即 <code>arena</code> 变量本身的生存期。如果生命周期是可变的，则编译器可以压缩其他生存期来适配它，但它是不变的，并且不受限制的生存期被强制转变成一个确切的生命周期。</p>
+
+<p>通过这个巧妙的技巧，我们可以强制编译器将 <code>Arena &lt;&#8217;arena&gt;</code> 的生存期参数设置为其实例的生存期。</p>
+
+<p>在此之后，其余的工作就非常简单了。 <code>Arena &lt;&#8217;arena&gt;</code> 拥有类型为 <code>Person &lt;&#8217;arena&gt;</code>的元素，也就是说：“<code>Person</code> 被允许引用具有 <code>&#8217;arena</code> 生命周期的元素, 例如 <code>Arena</code> &quot;。</p>
+
+<p><code>type PersonRef &lt;&#8217;arena&gt; =&amp;&#8217;arena Person &lt;&#8217;arena&gt;</code>是“引用在 <code>Arena</code> 中并允许从其中引用对象 <code>Person</code> 的引用的便捷缩写。</p>
+
+<h3 id='析构器如何工作'>析构器如何工作</h3>
+
+<p>到目前为止，我还没有讨论存在析构函数的情况下如何保证安全。 如果 <code>Arena</code> 具 有循环引用，并且编写了一个析构函数读取去这些循环引用，那么在销毁的过程中就会导致悬垂引用。</p>
+
+<p>这是 rust 十分模糊的地方。 除了“明确析构器巧妙地改变借用检查行为”，你没有什么需要必须去了解的。 但是了解这里的机制对建立一个更好的心智模型更有帮助。</p>
+
+<p>如果将以下代码添加到 <code>arena</code> 示例中：</p>
+
+<pre><code class="language-`rust">impl&lt;&#8217;arena&gt; Drop for Person&lt;&#8217;arena&gt; {
+    fn drop(&amp;mut self) {
+        println!(&quot;goodbye {:?}&quot;, self.name);
+        for friend in &amp;self.reverse_follows {
+            // potentially dangling!
+            println!(&quot;\t\t{}&quot;, friend.name);
+        }
+    }
+}</code></pre>
+
+<p>报错:</p>
+
+<pre><code class="language-`shell">error[E0597]: `arena` does not live long enough
+  --&gt; examples/mutable_arena.rs:5:18
+   |
+5  |     let lonely = arena.add_person(&quot;lonely&quot;, vec![]);
+   |                  ^^^^^ borrowed value does not live long enough
+...
+11 | }
+   | -
+   | |
+   | `arena` dropped here while still borrowed
+   | borrow might be used here, when `arena` is dropped and runs the destructor for type `Arena&lt;&#8217;_&gt;`</code></pre>
+
+<p>析构函数的存在在自引用数据的生命周期内巧妙地更改了借用检查器的行为。准确的规则是十分 <code>tricky</code>的，并在 <a href='https://doc.rust-lang.org/nomicon/dropck.html'>nomicon</a>中进行了解释，但实际上发生的是，在Person \&lt;&#8217;arena&gt;上存在自定义析构函数后，<code>&#8217;person arena</code>（因为是Arena）的 &#8217;<code>&#8217;arena</code>变成了一个“在销毁时观测到的的生命周期&quot;。然后在借用检查期间将其考虑在内---知道作用域末尾隐式调用<code>drop()</code>能够读取<code>&#8217;arena</code>的数据，Rust 做出了适当的结论，由于销毁本身是可变的操作，在销毁之后，调用<code>drop()</code> 读取内容是可行的 。</p>
+
+<p>当然，需要问的一个合理问题是，如果析构函数不允许用 <code>&#8217;arena</code> &#8217;“包装”数据，应该如何在 <code>arena</code> 中存储例如 <code>Box</code> 或者 <code>FrozenVec</code>之类的东西呢?</p>
+
+<p>原因是 Rust 知道 <code>Box::Drop </code>由于不清楚 <code>Person</code> 是什么,也不会去试图知道,而无法检查 <code>Person.follows</code>的内容。</p>
+
+<p>当然凡事都有例外,由于析构器可以调用指定的 <code>trait</code> 方法(或者特化的方法)来告诉如何读取<code>Person</code>的内容,如果有一个随机的泛型类型提供了这种方法,就可以再次巧妙地更改借用检查器的行为。<code> stdlib</code> 类型和其他自定义数据结构通过转义填充<code>＃[may_dangle]</code>（也称为“ eyepatch” 毕竟析构器 &quot;看不到&quot; 生命周期）来实现这种目的，声明不会从生命周期或通用参数中读取自定义析构函数。</p>
+
+<p>这也适用于诸如  <a href='https://docs.rs/typed-arena/'>typed-arena </a>之类的库；如果需要创建循环引用，则将无法在为放置在 <code>arena</code>  上的类型上编写自定义析构函数。但是只要避免创建循环引用就可以使用 <code>typed-arena</code> 编写自定义析构函数了；因此将无法使用内部可变性来使一个 <code>arena</code> 指向另一个 <code>arena</code>。</p>
+
+<p>感谢 <a href='https://mpc.sh/'>Mark Cohen</a> 和 <a href='https://twitter.com/kneecaw/'>Nika Layzell</a> 审阅了这篇文章的草稿。</p>
+]]></content:encoded></item><item><title>「译」用 Rust 编写 LLVM 的玩具编译器</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/toy-front-end-for-llvm-write-in-rust.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='「译」用rust编写llvm的玩具编译器'>「译」用Rust编写LLVM的玩具编译器</h1>
+
+<p>译者：<a href='https://github.com/iamazy'>iamazy</a> / 后期编辑：张汉东</p>
+
+<p>&gt; &gt; 原文：<a href='https://blog.ulysse.io/post/a-toy-front-end-for-llvm-written-in-rust/'>A Toy Front-End for LLVM, written in Rust</a></p>
+
+<h2 id=''></h2>
+
+<h2 id='正文'>正文</h2>
+
+<p>&gt; &gt; 我目前的副业是用 Rust 编写一个可以将代码转换成 LLVM IR 的编译器。LLVM 的 API 对于新手来说有点令人生畏，而且没有很多有关的教程（有限的教程大多数还是基于 C++ 的，如何使用 Rust 做同样的事并不总是那么明确）。我希望当我准备做一件事情时，有人可以手把手的教我，这也是我要写这篇文章的原因。</p>
+
+<p>对于 Rust，与 LLVM 的接口交互的最佳选择是使用 <code>llvm-sys</code>。互联网上的一些热心朋友在<a href='http://rustdoc.taricorp.net/llvm-sys/llvm_sys/'>这里</a>托管了一些关于 <code>llvm-sys</code> 的文档。当然，你还应该去查看 LLVM 的<a href='http://llvm.org/docs/tutorial/LangImpl01.html'>官方指南</a>，因为它可以帮助你理解 LLVM 是如何“思考”的。这篇文章基本上是 LLVM 官方指南的 Rust 翻译。</p>
+
+<p>你可以从这里获取最终的<a href='https://github.com/ucarion/llvm-rust-getting-started'>代码</a>。</p>
+
+<h2 id='搭建开发环境'>搭建开发环境</h2>
+
+<p>对于新手，使用 LLVM 开发有一个可以复用的方式：</p>
+
+<pre><code class="language-`shell"># `curl` is just so we can next install Rust
+sudo apt-get -y install clang curl llvm-3.8-dev
+curl https://sh.rustup.rs -sSf | sh
+
+# The `llvm-sys` crate expects something called `llvm-config` on your PATH.
+sudo ln -s /usr/bin/llvm-config-3.8 /usr/bin/llvm-config</code></pre>
+
+<p>如果你是在 Ubuntu 上执行上面的语句（你可能需要执行 <code>apt-get update</code> ），则没有任何问题。如果不是，你需要使用下面的 <code>Vagrantfile</code> 文件在 Vagrant Box 中运行上述语句。</p>
+
+<pre><code class="language-`shell">Vagrant.configure(&quot;2&quot;) do |config|
+  config.vm.box = &quot;bento/ubuntu-16.04&quot;
+end</code></pre>
+
+<p>你可以从执行 <code>cargo init llvm-example --bin</code> 开始，并将下面（从 llvm-sys 中拷贝）的代码写入 <code>src/main.rs</code> 中：</p>
+
+<pre><code class="language-`rust">//! Construct a function that does nothing in LLVM IR.
+
+extern crate llvm_sys as llvm;
+
+use std::ptr;
+
+fn main() {
+    unsafe {
+        // Set up a context, module and builder in that context.
+        let context = llvm::core::LLVMContextCreate();
+        let module = llvm::core::LLVMModuleCreateWithName(b&quot;nop\0&quot;.as_ptr() as *const _);
+        let builder = llvm::core::LLVMCreateBuilderInContext(context);
+
+        // Get the type signature for void nop(void);
+        // Then create it in our module.
+        let void = llvm::core::LLVMVoidTypeInContext(context);
+        let function_type = llvm::core::LLVMFunctionType(void, ptr::null_mut(), 0, 0);
+        let function = llvm::core::LLVMAddFunction(module, b&quot;nop\0&quot;.as_ptr() as *const _, function_type);
+
+        // Create a basic block in the function and set our builder to generate
+        // code in it.
+        let bb = llvm::core::LLVMAppendBasicBlockInContext(context, function,b&quot;entry\0&quot;.as_ptr() as *const _);
+        llvm::core::LLVMPositionBuilderAtEnd(builder, bb);
+
+        // Emit a `ret void` into the function
+        llvm::core::LLVMBuildRetVoid(builder);
+
+        // Dump the module as IR to stdout.
+        llvm::core::LLVMDumpModule(module);
+
+        // Clean up. Values created in the context mostly get cleaned up there.
+        llvm::core::LLVMDisposeBuilder(builder);
+        llvm::core::LLVMDisposeModule(module);
+        llvm::core::LLVMContextDispose(context);
+    }
+}</code></pre>
+
+<p>并在你的 <code>Cargo.toml</code> 文件中：</p>
+
+<pre><code class="language-`toml">[package]
+name = &quot;llvm-example&quot;
+version = &quot;0.1.0&quot;
+authors = [&quot;Ulysse Carion &lt;ulysse@ulysse.io&gt;&quot;]
+
+[[bin]]
+name = &quot;main&quot;
+
+[dependencies]
+llvm-sys = &quot;0.2&quot;</code></pre>
+
+<p>你可以获得：</p>
+
+<pre><code class="language-`shell">vagrant@vagrant:/vagrant$ cargo run
+   Compiling llvm-example v0.1.0 (file:///vagrant)
+     Running `target/debug/main`
+; ModuleID = &#8217;nop&#8217;
+
+define void @nop() {
+entry:
+  ret void
+}</code></pre>
+
+<p>完美！现在我们可以开始编写自己的东西了。</p>
+
+<h2 id='一段不太平凡的程序'>一段不太平凡的程序</h2>
+
+<p>首先，让我们编译一个程序，该程序通过从 main 函数中返回一个整数来简单的设置一个返回码。</p>
+
+<p>下面是我使用的方式（我们有时候需要使用一个解析器，所以我先添加了 <code>peg</code> 库）：</p>
+
+<pre><code class="language-`rust">#![feature(plugin)]
+#![plugin(peg_syntax_ext)]
+
+extern crate llvm_sys as llvm;
+
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::ptr;
+
+fn main() {
+    let mut input = String::new();
+    let mut f = File::open(&quot;in.ex&quot;).unwrap();
+    f.read_to_string(&amp;mut input).unwrap();
+
+    let parsed_input = parser::program(&amp;input).unwrap();
+
+    unsafe {
+        codegen(parsed_input);
+    }
+}
+
+peg! parser(r#&quot;
+    #[pub]
+    program -&gt; String
+        = i:int_literal &quot;\n&quot; { i }
+
+    int_literal -&gt; String
+        = [0-9]+ { match_str.to_owned() }
+&quot;#);
+
+unsafe fn codegen(input: String) {
+    let context = llvm::core::LLVMContextCreate();
+    let module = llvm::core::LLVMModuleCreateWithName(b&quot;example_module\0&quot;.as_ptr() as *const _);
+    let builder = llvm::core::LLVMCreateBuilderInContext(context);
+
+    // In LLVM, you get your types from functions.
+    let int_type = llvm::core::LLVMInt64TypeInContext(context);
+    let function_type = llvm::core::LLVMFunctionType(int_type, ptr::null_mut(), 0, 0);
+    let function = llvm::core::LLVMAddFunction(module, b&quot;main\0&quot;.as_ptr() as *const _, function_type);
+
+    let entry_name = CString::new(&quot;entry&quot;).unwrap();
+    let bb = llvm::core::LLVMAppendBasicBlockInContext(context, function, entry_name.as_ptr());
+    llvm::core::LLVMPositionBuilderAtEnd(builder, bb);
+
+    // The juicy part: construct a `LLVMValue` from a Rust value:
+    let int_value: u64 = input.parse().unwrap();
+    let int_value = llvm::core::LLVMConstInt(int_type, int_value, 0);
+
+    llvm::core::LLVMBuildRet(builder, int_value);
+
+    // Instead of dumping to stdout, let&#8217;s write out the IR to `out.ll`
+    let out_file = CString::new(&quot;out.ll&quot;).unwrap();
+    llvm::core::LLVMPrintModuleToFile(module, out_file.as_ptr(), ptr::null_mut());
+
+    llvm::core::LLVMDisposeBuilder(builder);
+    llvm::core::LLVMDisposeModule(module);
+    llvm::core::LLVMContextDispose(context);
+}</code></pre>
+
+<p>它起作用了！测试一下：</p>
+
+<pre><code class="language-`shell">vagrant@vagrant:/vagrant$ cat in.ex
+42
+vagrant@vagrant:/vagrant$ cargo run
+     Running `target/debug/main`
+vagrant@vagrant:/vagrant$ lli-3.8 out.ll ; echo $?
+42</code></pre>
+
+<p>有点酷哦！顺便提一下，下面是 <code>out.ll</code> 文件的内容：</p>
+
+<pre><code class="language-`s">; ModuleID = &#8217;example_module&#8217;
+
+define i64 @main() {
+entry:
+  ret i64 42
+}</code></pre>
+
+<h2 id='算术'>算术</h2>
+
+<p>让我们添加对数字的加减乘除操作的支持。为了实现这个，我们需要扩展我们的语法。我们引入一个枚举来代表 AST（抽象语法树）。</p>
+
+<pre><code class="language-`rust">pub enum Expr {
+    Add(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Sub(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Mul(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Div(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Literal(String),
+}</code></pre>
+
+<p>并扩展语法：</p>
+
+<pre><code class="language-`rust">// `product` and `sum` are that way to get operator precedence
+peg! parser(r#&quot;
+    use super::Expr;
+
+    #[pub]
+    program -&gt; Expr
+        = e:expression &quot;\n&quot; { e }
+
+    expression -&gt; Expr
+        = sum
+
+    sum -&gt; Expr
+        = a:product _ &quot;+&quot; _ b:sum { Expr::Add(Box::new(a), Box::new(b)) }
+        / a:product _ &quot;-&quot; _ b:sum { Expr::Sub(Box::new(a), Box::new(b)) }
+        / product
+
+    product -&gt; Expr
+        = a:int_literal _ &quot;*&quot; _ b:product { Expr::Mul(Box::new(a), Box::new(b)) }
+        / a:int_literal _ &quot;/&quot; _ b:product { Expr::Div(Box::new(a), Box::new(b)) }
+        / int_literal
+
+    int_literal -&gt; Expr
+        = [0-9]+ { Expr::Literal(match_str.to_owned()) }
+
+    _ = &quot; &quot;*
+&quot;#);</code></pre>
+
+<p>接下来，可以提交代码。你可以指定诸如 “addtmp” 的字符串，这些字符串将被用作 IR 中对应“寄存器”名称的一部分。</p>
+
+<pre><code class="language-`rust">// When you write out instructions in LLVM, you get back `LLVMValueRef`s. You
+// can then use these references in other instructions.
+unsafe fn codegen_expr(context: LLVMContextRef, builder: LLVMBuilderRef, expr: Expr) -&gt; LLVMValueRef {
+    match expr {
+        Expr::Literal(int_literal) =&gt; {
+            let int_type = llvm::core::LLVMInt64TypeInContext(context);
+            llvm::core::LLVMConstInt(int_type, int_literal.parse().unwrap(), 0)
+        },
+
+        Expr::Add(lhs, rhs) =&gt; {
+            let lhs = codegen_expr(context, builder, *lhs);
+            let rhs = codegen_expr(context, builder, *rhs);
+
+            let name = CString::new(&quot;addtmp&quot;).unwrap();
+            llvm::core::LLVMBuildAdd(builder, lhs, rhs, name.as_ptr())
+        },
+
+        Expr::Sub(lhs, rhs) =&gt; {
+            let lhs = codegen_expr(context, builder, *lhs);
+            let rhs = codegen_expr(context, builder, *rhs);
+
+            let name = CString::new(&quot;subtmp&quot;).unwrap();
+            llvm::core::LLVMBuildSub(builder, lhs, rhs, name.as_ptr())
+        },
+
+        Expr::Mul(lhs, rhs) =&gt; {
+            let lhs = codegen_expr(context, builder, *lhs);
+            let rhs = codegen_expr(context, builder, *rhs);
+
+            let name = CString::new(&quot;multmp&quot;).unwrap();
+            llvm::core::LLVMBuildMul(builder, lhs, rhs, name.as_ptr())
+        },
+
+        Expr::Div(lhs, rhs) =&gt; {
+            let lhs = codegen_expr(context, builder, *lhs);
+            let rhs = codegen_expr(context, builder, *rhs);
+
+            let name = CString::new(&quot;divtmp&quot;).unwrap();
+            llvm::core::LLVMBuildUDiv(builder, lhs, rhs, name.as_ptr())
+        },
+    }
+}</code></pre>
+
+<p>现在，你可以执行 <code>10 * 4 + 20/2 - 8</code> 之类的程序！如果你问我，那可真是太酷了。</p>
+
+<h2 id='变量'>变量</h2>
+
+<p>我们将采用简单的方式并假设程序不会执行任何烦人的操作，如引用未定义的变量等。我们只将变量存储在寄存器中，并将它们存在 <code>HashMap&lt;String, LLVMValueRef&gt;</code> 中，之所以有用是因为运行该程序只有这一种方式。</p>
+
+<p>我们扩展语言和解析器：</p>
+
+<pre><code class="language-`rust">pub enum Expr {
+    Literal(String),
+    Ref(String),
+    Assign(String, Box&lt;Expr&gt;),
+    Add(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Sub(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Mul(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Div(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+}
+
+peg! parser(r#&quot;
+    use super::Expr;
+
+    #[pub]
+    program -&gt; Vec&lt;Expr&gt;
+        = e:(expression ** &quot;\n&quot;) &quot;\n&quot; { e }
+
+    expression -&gt; Expr
+        = i:identifier _ &quot;=&quot; _ s:sum { Expr::Assign(i, Box::new(s)) }
+        / sum
+
+    sum -&gt; Expr
+        = a:product _ &quot;+&quot; _ b:sum { Expr::Add(Box::new(a), Box::new(b)) }
+        / a:product _ &quot;-&quot; _ b:sum { Expr::Sub(Box::new(a), Box::new(b)) }
+        / product
+
+    product -&gt; Expr
+        = a:ref_or_literal _ &quot;*&quot; _ b:product { Expr::Mul(Box::new(a), Box::new(b)) }
+        / a:ref_or_literal _ &quot;/&quot; _ b:product { Expr::Div(Box::new(a), Box::new(b)) }
+        / ref_or_literal
+
+    ref_or_literal -&gt; Expr
+        = i:identifier { Expr::Ref(i) }
+        / int_literal
+
+    identifier -&gt; String
+        = [a-zA-Z]+ { match_str.to_owned() }
+
+    int_literal -&gt; Expr
+        = [0-9]+ { Expr::Literal(match_str.to_owned()) }
+
+    _ = &quot; &quot;*
+&quot;#);</code></pre>
+
+<p>然后为这两个新的表达式添加支持：</p>
+
+<pre><code class="language-`rust">unsafe fn codegen_expr(context: LLVMContextRef, builder: LLVMBuilderRef, names: &amp;mut HashMap&lt;String, LLVMValueRef&gt;, expr: Expr) -&gt; LLVMValueRef {
+    match expr {
+        // ...
+
+        Expr::Ref(name) =&gt; {
+            *names.get(&amp;name).unwrap()
+        },
+
+        Expr::Assign(name, expr) =&gt; {
+            let new_value = codegen_expr(context, builder, names, *expr);
+            names.insert(name, new_value);
+            new_value
+        },
+    }
+}</code></pre>
+
+<p>并迅速的在 <code>codegen</code> 函数中更新：</p>
+
+<pre><code class="language-`rust">let zero = llvm::core::LLVMConstInt(int_type, 0, 0);
+
+let mut names = HashMap::new();
+let mut return_value = zero; // return value on empty program
+for expr in input {
+    return_value = codegen_expr(context, builder, &amp;mut names, expr);
+}
+llvm::core::LLVMBuildRet(builder, return_value);</code></pre>
+
+<p>现在让我们来一探究竟：</p>
+
+<pre><code class="language-`rust">vagrant@vagrant:/vagrant$ cat in.ex
+a = 3
+b = 76
+a + b
+vagrant@vagrant:/vagrant$ cargo run
+     Running `target/debug/main`
+vagrant@vagrant:/vagrant$ cat out.ll
+; ModuleID = &#8217;example_module&#8217;
+
+define i64 @main() {
+entry:
+  ret i64 79
+}</code></pre>
+
+<h2 id='if'>If</h2>
+
+<p>在使用 <code>if</code> 关键字的时候遇到一些麻烦。让 <code>if</code> 起作用的最简单的方式就是将所有的变量存储在堆栈上。并让 LLVM 做一些优化。在 LLVM 中，你可以通过 <code>alloca</code> 指令创建一个栈变量，并使用 <code>load/store</code> 进行读写。</p>
+
+<p>为了实现这个，我们通过添加新的解析规则再一次扩展了语言和语法。</p>
+
+<pre><code class="language-`rust">expression -&gt; Expr
+    = if_expression
+    / i:identifier _ &quot;=&quot; _ s:expression { Expr::Assign(i, Box::new(s)) }
+    / sum
+
+if_expression -&gt; Expr
+    = &quot;if&quot; _ e:expression _ &quot;{\n&quot; _ then_body:statements _ &quot;}&quot; _ &quot;else&quot; _ &quot;{\n&quot; _ else_body:statements _ &quot;}&quot; {
+        Expr::If(Box::new(e), then_body, else_body)
+    }</code></pre>
+
+<p>并在 AST 节点上添加了一个新的类型：</p>
+
+<pre><code class="language-`rust">pub enum Expr {
+    Literal(String),
+    Ref(String),
+    Assign(String, Box&lt;Expr&gt;),
+    Add(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Sub(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Mul(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    Div(Box&lt;Expr&gt;, Box&lt;Expr&gt;),
+    If(Box&lt;Expr&gt;, Vec&lt;Expr&gt;, Vec&lt;Expr&gt;),
+}</code></pre>
+
+<p>最后，完成关于 <code>if</code> 表达式的代码：</p>
+
+<pre><code class="language-`rust">unsafe fn codegen_expr(context: LLVMContextRef, builder: LLVMBuilderRef, func: LLVMValueRef, names: &amp;mut HashMap&lt;String, LLVMValueRef&gt;, expr: Expr) -&gt; LLVMValueRef {
+    match expr {
+        // ...
+
+        Expr::If(condition, then_body, else_body) =&gt; {
+            let condition_value = codegen_expr(context, builder, func, names, *condition);
+            let int_type = llvm::core::LLVMInt64TypeInContext(context);
+            let zero = llvm::core::LLVMConstInt(int_type, 0, 0);
+
+            // `is_nonzero` is a 1-bit integer
+            let name = CString::new(&quot;is_nonzero&quot;).unwrap();
+            let is_nonzero = llvm::core::LLVMBuildICmp(builder, llvm::LLVMIntPredicate::LLVMIntNE, condition_value, zero, name.as_ptr());
+
+            // It&#8217;s fine to create blocks first, and then fill them in later.
+            let entry_name = CString::new(&quot;entry&quot;).unwrap();
+            let then_block = llvm::core::LLVMAppendBasicBlockInContext(context, func, entry_name.as_ptr());
+            let else_block = llvm::core::LLVMAppendBasicBlockInContext(context, func, entry_name.as_ptr());
+            let merge_block = llvm::core::LLVMAppendBasicBlockInContext(context, func, entry_name.as_ptr());
+
+            llvm::core::LLVMBuildCondBr(builder, is_nonzero, then_block, else_block);
+
+            llvm::core::LLVMPositionBuilderAtEnd(builder, then_block);
+            let mut then_return = zero;
+            for expr in then_body {
+                then_return = codegen_expr(context, builder, func, names, expr);
+            }
+            llvm::core::LLVMBuildBr(builder, merge_block);
+
+            llvm::core::LLVMPositionBuilderAtEnd(builder, else_block);
+            let mut else_return = zero;
+            for expr in else_body {
+                else_return = codegen_expr(context, builder, func, names, expr);
+            }
+            llvm::core::LLVMBuildBr(builder, merge_block);
+
+            // Position the builder so that it&#8217;s ready to work on the next
+            // expression.
+            llvm::core::LLVMPositionBuilderAtEnd(builder, merge_block);
+            zero
+        }
+    }
+}</code></pre>
+
+<p>代码有点多，但是完成了你所期待的事情。现在，你可以像这样来运行程序：</p>
+
+<pre><code class="language-`groovy">a = 1
+if a {
+    a = 42
+} else {
+    a = 13
+}
+a</code></pre>
+
+<p>上述代码对应的 IR 如下所示：</p>
+
+<pre><code class="language-`s">; ModuleID = &#8217;example_module&#8217;
+
+define i64 @main() {
+entry:
+  %a = alloca i64
+  store i64 1, i64* %a
+  %a1 = load i64, i64* %a
+  %is_nonzero = icmp ne i64 %a1, 0
+  br i1 %is_nonzero, label %entry2, label %entry3
+
+entry2:                                           ; preds = %entry
+  store i64 42, i64* %a
+  br label %entry4
+
+entry3:                                           ; preds = %entry
+  store i64 13, i64* %a
+  br label %entry4
+
+entry4:                                           ; preds = %entry3, %entry2
+  %a5 = load i64, i64* %a
+  ret i64 %a5
+}</code></pre>
+
+<p>然而，我们还没有结束。目前，我们的 “if” 表达式的返回结果始终为 zero（见上述 <code>codegen_expr</code> 函数中 If 分支的返回值）。而我们想要的正好与其相反，如果我们执行了 “then” 路径，则 if 的求值结果应该为 then<em>return，否则返回 else</em>return。</p>
+
+<p>你如何使用 LLVM 跟踪它执行了哪个分支？通过使用 “phi” 节点。你给 phi 指令一个 (block, value) 对，该 phi 节点将会返回与先前执行的块相对应的值。</p>
+
+<p>我们可以这样结束 if。注意，我们必须更新 then<em>block 和 else</em>block，因为这是我们在 “then/else” 分支中需要的最后一个块，并且前面的 then_block 是 “then/else” 的第一个块。</p>
+
+<pre><code class="language-`rust">// This is mostly the same code as before, just note the new calls to
+// `LLVMGetInsertBlock`.
+
+llvm::core::LLVMPositionBuilderAtEnd(builder, then_block);
+let mut then_return = zero;
+for expr in then_body {
+    then_return = codegen_expr(context, builder, func, names, expr);
+}
+llvm::core::LLVMBuildBr(builder, merge_block);
+let then_block = llvm::core::LLVMGetInsertBlock(builder);
+
+llvm::core::LLVMPositionBuilderAtEnd(builder, else_block);
+let mut else_return = zero;
+for expr in else_body {
+    else_return = codegen_expr(context, builder, func, names, expr);
+}
+llvm::core::LLVMBuildBr(builder, merge_block);
+let else_block = llvm::core::LLVMGetInsertBlock(builder);
+
+// Insert the phi node
+llvm::core::LLVMPositionBuilderAtEnd(builder, merge_block);
+let phi_name = CString::new(&quot;iftmp&quot;).unwrap();
+let phi = llvm::core::LLVMBuildPhi(builder, int_type, phi_name.as_ptr());
+
+let mut values = vec![then_return, else_return];
+let mut blocks = vec![then_block, else_block];
+
+llvm::core::LLVMAddIncoming(phi, values.as_mut_ptr(), blocks.as_mut_ptr(), 2);
+phi</code></pre>
+
+<p>然后，你就得到了一个令人惊叹的编译器：</p>
+
+<pre><code class="language-`shell">vagrant@vagrant:/vagrant$ cat in.ex
+a = 1
+b = 0
+c = if a {
+    if b {
+        11
+    } else {
+        40
+    }
+} else {
+    if b {
+        10
+    } else {
+        20
+    }
+}
+c + 2
+vagrant@vagrant:/vagrant$ cargo run
+     Running `target/debug/main`
+vagrant@vagrant:/vagrant$ lli-3.8 out.ll ; echo $?
+42</code></pre>
+
+<p>太酷了！下面是我们提供的示例输入程序的 IR：</p>
+
+<pre><code class="language-`s">; ModuleID = &#8217;example_module&#8217;
+
+define i64 @main() {
+entry:
+  %a = alloca i64
+  %b = alloca i64
+  %c = alloca i64
+  store i64 1, i64* %a
+  store i64 0, i64* %b
+  %a1 = load i64, i64* %a
+  %is_nonzero = icmp ne i64 %a1, 0
+  br i1 %is_nonzero, label %entry2, label %entry3
+
+entry2:                                           ; preds = %entry
+  %b5 = load i64, i64* %b
+  %is_nonzero6 = icmp ne i64 %b5, 0
+  br i1 %is_nonzero6, label %entry7, label %entry8
+
+entry3:                                           ; preds = %entry
+  %b10 = load i64, i64* %b
+  %is_nonzero11 = icmp ne i64 %b10, 0
+  br i1 %is_nonzero11, label %entry12, label %entry13
+
+entry4:                                           ; preds = %entry14, %entry9
+  %iftmp16 = phi i64 [ %iftmp, %entry9 ], [ %iftmp15, %entry14 ]
+  store i64 %iftmp16, i64* %c
+  %c17 = load i64, i64* %c
+  %addtmp = add i64 %c17, 2
+  ret i64 %addtmp
+
+entry7:                                           ; preds = %entry2
+  br label %entry9
+
+entry8:                                           ; preds = %entry2
+  br label %entry9
+
+entry9:                                           ; preds = %entry8, %entry7
+  %iftmp = phi i64 [ 11, %entry7 ], [ 40, %entry8 ]
+  br label %entry4
+
+entry12:                                          ; preds = %entry3
+  br label %entry14
+
+entry13:                                          ; preds = %entry3
+  br label %entry14
+
+entry14:                                          ; preds = %entry13, %entry12
+  %iftmp15 = phi i64 [ 10, %entry12 ], [ 20, %entry13 ]
+  br label %entry4
+}</code></pre>
+
+<p>请注意：这些块具有以下的模式：不包含第一个条目，它们三个为一组，第一个是 “then” 分支，然后是 “else” 分支，最后是 “merge” 块（带有可识别的 phi 指令）。每一次我们遇到 “if” 表达式时都会在 main 后面附加三个新块。因为要在 AST 中递归查询三元组，所以块的三元组是有序的。</p>
+
+<p>这就是我想要分享的全部内容！希望在这一点上你可以有足够的实力来决定你的命运。</p>
+]]></content:encoded></item><item><title>透过 Rust 探索系统的本原：并发篇</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust-to-system-essence-concurrent.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h2 id='透过_rust_探索系统的本原：并发篇'>透过 Rust 探索系统的本原：并发篇</h2>
+
+<p>作者：陈天 / 后期编辑：<a href='https://github.com/NiZerin'>NiZerin</a></p>
+
+<p>&gt; &gt; 原文链接：<a href='https://mp.weixin.qq.com/s/9g0wVT-5PpmXRoKJZo-skA'>https://mp.weixin.qq.com/s/9g0wVT-5PpmXRoKJZo-skA</a></p>
+
+<h2 id=''></h2>
+
+<p>rust 是一门非常优秀的语言，我虽然没有特别正式介绍过 rust 本身，但其实已经写了好多篇跟 rust 相关的文章：</p>
+
+<ul>
+<li><a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828208&amp;idx=1&amp;sn=1599b7cbc3bcc2c050c2689b9e46acbd&amp;chksm=8704a96cb073207a890c0056332ede6ac01eda5f5bcc02ec016b466b0fb6b6c91c3637fee1c1&amp;scene=21#wechat_redirect'>沅有芷兮：类型系统的数学之美</a></li>
+
+<li><a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828386&amp;idx=1&amp;sn=555e16a024e027f6cde350a0a09d3af4&amp;chksm=8704ae3eb0732728040c309dbd4200c93483f6f40b1ac86dc7d8810f53290d870657b89ea5ce&amp;scene=21#wechat_redirect'>Noise 协议的应用</a></li>
+
+<li><a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828413&amp;idx=1&amp;sn=2eadc24e7fe82581c70f78c186d0e678&amp;chksm=8704ae21b0732737f456bc372e8317edd532edeb63ee60a3a92efd748e2c5a9b5a9ec6e3caf8&amp;scene=21#wechat_redirect'>用 noise 协议的思路来点对点加密文件？</a></li>
+
+<li><a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828397&amp;idx=1&amp;sn=37978455a88361c65663bc7e73fa63f3&amp;chksm=8704ae31b0732727ea88c86b95b551307b2a2d55834d3ee2a9d731165bce96289fe4a12cec0e&amp;scene=21#wechat_redirect'>如何安全地保存密码？</a></li>
+
+<li><a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828863&amp;idx=1&amp;sn=5ff0ccb8b286e9ba86e2c944f244ce6d&amp;chksm=8704afe3b07326f50e903b975d655248b0136dff262a776291cf662d7c7a0f30889648570b9f&amp;scene=21#wechat_redirect'>从微秒到纳秒：关于性能的奇妙旅程</a></li>
+</ul>
+
+<p>我打算写一个系列，讲讲如果透过 rust 来更好地探索系统的本原。我不知道我能写多少，也许就这一篇，也许很多篇，不管怎样，每篇都会介绍独立的概念。这个系列并不会介绍大量的 rust 代码，因此其内容对非 rust 程序员也有好处。</p>
+
+<p>这一篇我们讲并发。几年前我曾经写过一篇介绍并发概念的文章：<a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=401691172&amp;idx=1&amp;sn=b4b3a8fe51eb4250ff82e9153580f1dd&amp;chksm=0d04d0383a73592ea5f61767d2c6ee7f1ee364153fc6a3ff4d4d8253a6a17afe71c693e941e8&amp;scene=21#wechat_redirect'>concurrency</a>，大家感兴趣可以看看。这篇我们从更加务实的角度，以一个简单的字典服务器程序的迭代为引子，把并发中涉及的概念和解决方法串起来。</p>
+
+<h2 id='v1：循环处理'>v1：循环处理</h2>
+
+<p>我们的字典服务器监听 8888 端口，在服务器端维护一个 KV db（使用 hash map）。客户端可以插入（更新）一个 key 和相关的 value，也可以查询一个 key，获得对应的 value。嗯，就像 redis 服务器一样，只不过比 redis 简单十万八千倍。</p>
+
+<p>这个需求很简单，我们马上可以想到：</p>
+
+<ol type="1">
+<li>监听 8888 端口</li>
+
+<li>写一个死循环，不断 <code>accept</code> socket，然后对 socket 里收到的数据进行处理。</li>
+</ol>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/1.webp' alt='' /></p>
+
+<p>但这样是串行服务，我们只有处理完上一个 socket 的数据，才有机会处理下一个 socket，吞吐量非常有限。显然，我们需要改进。</p>
+
+<h2 id='v2：多线程处理'>v2：多线程处理</h2>
+
+<p>接下来我们需要解决串行服务的瓶颈。一个方法是 <code>accept</code> 之后，将新的 socket 放入一个线程里执行，于是主线程不会被阻塞住，可以继续 <code>accept</code> 后续的 socket。这样，每个 client 过来的请求都可以独立地处理。</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/2.png' alt='' /></p>
+
+<p>可是，这带来了一个显而易见的问题：我们的 KV db 成为了一个共享状态，它在多个线程之间共享数据。这是并发处理的第一种范式：共享状态的并发（Shared-State Concurrency）。</p>
+
+<p>既然引入了共享状态，那么我们需要在访问它的时候做妥善的保护 —— 这个访问和操作共享状态的代码区域叫临界区（Critical Section）。如果你还记得操作系统课程的内容，你会知道，最基本的操作是使用互斥量（Mutex）来保护临界区。</p>
+
+<p>互斥量本质是一种二元锁。当线程获得锁之后，便拥有了对共享状态的独占访问；反之，如果无法获得锁，那么将会在访问锁的位置阻塞，直到能够获得锁。在完成对共享状态的访问后（临界区的出口），我们需要释放锁，这样，其它访问者才有机会退出阻塞状态。一旦忘记释放锁，或者使用多把锁的过程中造成了死锁，那么程序就无法响应或者崩溃。rust 的内存安全模型能够避免忘记释放锁，这让开发变得非常轻松，并且最大程度上解决了（不同函数间）死锁问题。</p>
+
+<p>但任何语言的任何保护都无法避免逻辑上的死锁，比如下面这个显而易见的例子：</p>
+
+<pre><code class="language-`rust">use std::sync::Mutex;
+
+fn main() {
+   let data = Mutex::new(0);
+   let _d1 = data.lock();
+   let _d2 = data.lock(); // deadlock now
+}</code></pre>
+
+<p>互斥锁往往锁的粒度太大，在很多场景下效率太低。于是我们在此基础上分离了读写的操作，产生了读写锁（RwLock），它同一时刻允许任意数量的共享读者或者一个写者。读写锁的一个优化是顺序锁（SeqLock），它提高了读锁和写锁的独立性 —— 写锁不会被读锁阻塞，读锁也不会被写锁阻塞。，但写锁会被写锁阻塞。</p>
+
+<p>读写锁适用于读者数量远大于写者，或者读多写少的场景。在我们这个场景下，读写的比例差别可能并不是特别明显，从 Mutex 换到 RwLock 的收益需要在生产环境中具体测试一下才能有结论。</p>
+
+<h2 id='v3：锁的优化'>v3：锁的优化</h2>
+
+<p>但即使我们无法通过使用不同实现的锁来优化对共享状态访问的效率，我们还是有很多方法来优化锁。无论何种方法，其核心思想是：<strong>尽可能减少锁的粒度</strong>。比如，对数据库而言，我们可以对整个数据库管理系统加锁，也可以对单个数据库的访问加锁，还可以对数据表的访问加锁，甚至对数据表中的一行或者一列加锁。对于我们的 KV db 而言，我们可以创建 N 个 hashmap（模拟多个数据库），然后把 Key 分散到这 N 个 hashmap 中，这样，不管使用什么锁，其粒度都变成之前的 1/N 了。</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/3.webp' alt='' /></p>
+
+<p>新的 KV db 的定义，以及添加 / 访问数据的代码：</p>
+
+<pre><code class="language-`rust">use std::collections::{hash_map::DefaultHasher, HashMap};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
+
+struct KvDb(Arc&lt;Vec&lt;RwLock&lt;HashMap&lt;String, Vec&lt;u8&gt;&gt;&gt;&gt;&gt;);
+
+impl KvDb {
+    pub fn new(len: usize) -&gt; Self {
+        let mut dbs: Vec&lt;RwLock&lt;HashMap&lt;String, Vec&lt;u8&gt;&gt;&gt;&gt; = Vec::with_capacity(len);
+        for _i in 0..len {
+            dbs.push(RwLock::new(HashMap::new()))
+        }
+        Self(Arc::new(dbs))
+    }
+
+    pub fn insert(&amp;self, k: &amp;str, v: Vec&lt;u8&gt;) {
+        let dbs = self.0.clone();
+        let mut writer = dbs[(self.hash(k) % dbs.len()) as usize].write().unwrap();
+        writer.insert(k.into(), v);
+    }
+
+    pub fn get(&amp;self, k: &amp;str) -&gt; Vec&lt;u8&gt; {
+        let dbs = self.0.clone();
+        let reader = dbs[(self.hash(k) % dbs.len()) as usize].read().unwrap();
+        reader.get(k).unwrap().to_owned()
+    }
+
+    fn hash(&amp;self, k: &amp;str) -&gt; usize {
+        let mut hasher = DefaultHasher::new();
+        k.to_owned().hash(&amp;mut hasher);
+        hasher.finish() as usize
+    }
+}</code></pre>
+
+<p>rust 里面的 dashmap 提供了一个类似思路的高并发访问的 hashmap。</p>
+
+<h2 id='v4：share_memory_by_communicating'>v4：share memory by communicating</h2>
+
+<p>前面的迭代不管怎么优化都跳脱不出同一种思路：Shared-state concurrency，或者说：communicate by share memory。这种方法限制很少，非常灵活，适用于任何并发场景，因而它是所有并发方案的基石。然而，灵活度带来的问题就是容易出错，需要额外的约定和限制来避免一些问题的产生。</p>
+
+<p>那么，有没有办法把并发的需求抽象出来，设计一些更高级的数据结构和使用方法，把锁的使用隐藏起来？</p>
+
+<p>当然有。</p>
+
+<p>其中最有效最优雅的方法是消息传递（message passing）。我们把问题的两端分别定义成生产者和消费者。KvDb 的客户端是生产者，它们提交请求（update / get），而 KvDb 的服务器是消费者，它接受请求，返回处理的结果。连接两端的是一个消息通道（channel）。我们可以根据消息通道的两端的使用情况，将其进一步细分成几种访问模型：</p>
+
+<ul>
+<li>
+<p>spsc：单生产者单消费者（Single producer single consumer）。这是最简单的访问模型，它可以用锁（RwLock）来实现并发，也可以通过一个 ring buffer 实现无锁（lock-free）并发。rust 的标准库没有 spsc 的实现，但第三方库，如 tokio，提供了 <code>oneshot</code> channel。当然我们也可以封装 <code>VecDeque</code> 来模拟 spsc。</p>
+</li>
+
+<li>
+<p>mpsc：多生产者单消费者（ Multiple producer single consumer）。这是最典型的并发使用模型，大部分的客户端/服务器实现都能用 mpsc 模型来处理。rust 标准库里有 <code>std::mpsc::channel</code> 来处理 mpsc 模型。</p>
+</li>
+
+<li>
+<p>spmc：单生产者多消费者（Single producer multiple consumer）。这可能是使用最少的消息模型。rust 标准库里没有对应的实现，也鲜有第三方库单独实现它。Jonhoo 做了一个 crate <code>bus</code> ，是 spmc broadcast channel，它是单个生产者对所有消费者的广播。</p>
+</li>
+
+<li>
+<p>mpmc：多生产者多消费者（ Multiple producer Multiple consumer）。mpmc 是最复杂的情况，可以用来实现之前的几种模式。但因为 spsc / mpsc 有很多使用场景，所以一般我们不会用 mpmc 来模拟。rust 标准库里没有 mpmc 的实现，但 <code>crossbeam</code> 实现了高效的 mpmc channel。</p>
+</li>
+</ul>
+
+<p>使用消息通道的思路，我们可以进一步迭代我们的 KvDb —— 在处理 socket 的线程和处理 state 的线程之间建立一个 mpsc channel：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/4.png' alt='' /></p>
+
+<p>这种方式是否更高效？不见得。但从并发处理的角度来看，它结构上更清晰，不容易出错。</p>
+
+<p>使用消息传递来处理并发的思路是如此重要，以至于两门非常有影响力的语言将其内置在语言的运行时里，成为语言的一部分：</p>
+
+<p>golang 内建了 channel，使用 goroutine 和 channel 来处理并发。其语言的核心思想是：</p>
+
+<p>&gt; &gt; Do not communicate by sharing memory; instead, share memory by communicating.</p>
+
+<p>而 erlang 内建了 actor model，让 <code>send</code>，<code>receive</code> 成为其最基本的六个函数之一。两个 actor（process）之间唯一的交流方式就是找到对方的 pid，然后发送消息。</p>
+
+<h2 id='v5：协程（async/await_or_异步处理）'>v5：协程（async/await or 异步处理）</h2>
+
+<p>我们在使用多线程做并发处理时，使用的是操作系统的调度能力。这样的好处是，我们无需自己再做一个调度器，进行复杂的调度处理；坏处是，操作系统处理线程的调度需要复杂的上下文切换，其中包括用户态和内核态的切换，所以它的效率不够高，尤其是如果我们需要大量的随用随抛的「线程」时。</p>
+
+<p>然而，「现代」的应用程序因为复杂程度越来越高，所以其并发程度也越来越高，大量的操作都涉及随用随抛的「线程」。如果我们用操作系统线程来实现这些「线程」，会大大拖累系统的整体效率，甚至会触及操作系统的限制（<code>/proc/sys/kernel/threads-max</code>）。</p>
+
+<p>因而，「现代」的编程语言都有协程的支持 —— 在 golang 里是 goroutine，在 erlang 里是 process，在 python 里是 coroutine，在 rust 里是 future。它们可以以一个更小的粒度在用户态进行并发处理，代价是用户态需要一个调度器。golang / erlang 在语言层面的运行时提供了这个调度器，而 rust 需要引入相关的库。这些语言的用户态调度器的实现都大同小异：</p>
+
+<ul>
+<li>
+<p>使用 N 个操作系统线程（一般来说 N= 硬件线程的数量）</p>
+</li>
+
+<li>
+<p>每个线程上维护若干个队列，保存不同状态下的异步任务。当 ready 队列有任务时，执行该任务，直到其再度挂起或者执行完毕。所以每个异步任务本身要避免没有 IO 或系统调用的大量纯计算工作（computation intensive），如果有这样的工作，那么要主动 yield。</p>
+</li>
+
+<li>
+<p>如果某个线程上没有待执行的任务，它可以去其它线程上「偷」任务（work stealing scheduler）。</p>
+</li>
+
+<li>
+<p>如果某个线程上正在运行的任务被阻塞（比如执行 syscall），那么一般而言调度器会把队列里的其它任务交给没有阻塞的线程（golang），或者把阻塞操作交给其它专门的线程处理。</p>
+</li>
+</ul>
+
+<p>无论从 v3 还是 v4 版本，我们都很容易把一个多线程的实现变成多协程的实现。对于 rust 而言，就是引入 async / await：</p>
+
+<ul>
+<li>
+<p>把相应的函数变成 async 函数，这样函数的返回值会变成一个 <code>Future</code>。</p>
+</li>
+
+<li>
+<p>在调用 async 函数的地方，添加 <code>.await</code> 来处理 async 的状态机。</p>
+</li>
+
+<li>
+<p>在使用 <code>spawn</code> 的地方，使用 <code>tokio</code> 或者 <code>async_std</code> 对应的 <code>spawn</code>，来创建一个协程。</p>
+</li>
+
+<li>
+<p>在入口函数，引入 <code>executor</code>，比如使用宏 <code>#[tokio::main]</code>。</p>
+</li>
+</ul>
+
+<p>对于我们的 kv server，因为协程处理的流程图和线程处理类似（内部机制大不一样），所以这里我就不附图了。</p>
+
+<h2 id='one_more_thing：线程和协程间的同步'>One more thing：线程和协程间的同步</h2>
+
+<p>在一个复杂的系统里，线程和协程可能会同时出现。我们用线程做计算密集的事情，而用协程做 IO 密集的事情，这样系统可以达到最好的吞吐能力。遗憾的是，很多以协程为卖点的语言，如 erlang 和 golang，你所面临的环境是受控的（某种意义上说，这也是优势 - don&#8217;t make me think），只能创建协程，而不能创建线程。所以无法做这样的优化。而另一些语言，如 Python，Scala，虽然同时支持线程和协程，两者混合使用要么效率不高，要么没有很好的库，用起来很别扭（我并没有 scala 经验，关于 akka 和 thread 混用的别扭只是道听途说）。</p>
+
+<p>而 Rust 处理得很优雅 — <code>tokio::sync</code> 提供了在同步和异步线程之间使用 channel 同步的工具。你甚至感觉不到你的数据在不同的 runtime 间穿梭。其实站在操作系统的角度想想也能释然：管它是线程和协程，在操作系统层面都是线程，只不过协程是运行在某些线程上的受那些线程独立调度的数据结构而已。所以，线程和协程间的同步，归根结底，还是线程之间的同步问题。而线程间同步的手段，我们都可以使用，只不过在这种场景下，channel 是最好（最舒服）的选择。</p>
+
+<p>所以，我们可以在系统启动时（或者服务器启动时），在普通的线程和 tokio 管理的线程（Runtime）间创建好一个 channel，然后在各自的上下文中处理流入流出 channel 的数据，如下图所示：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/5.webp' alt='' /></p>
+
+<p>本文中我们提到的这个 KV store 的例子太简单，并不涉及同步线程和异步线程之间的同步，我举个其它例子。上篇文章《<a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828863&amp;idx=1&amp;sn=5ff0ccb8b286e9ba86e2c944f244ce6d&amp;chksm=8704afe3b07326f50e903b975d655248b0136dff262a776291cf662d7c7a0f30889648570b9f&amp;scene=21#wechat_redirect'>从微秒到纳秒</a>》讲了如何使用多线程来处理不同 repo 下的事件的写入。下图是之前文章里的主流程：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/6.webp' alt='' /></p>
+
+<p>在这个流程的基础上，我们需要添加一个新的功能：当日志文件 rotate 时，我们发一个消息出去，由一组 uploader 线程负责把刚刚关闭封存的日志文件传输到 S3。</p>
+
+<p>Rust 下和 S3 打交道的库是 Rusoto，Rusoto 是全异步的处理，因而我们需要一个 Tokio runtime 来处理异步的任务。我们可以在 <code>Server.start</code> 接口来处理 Runtime 的创建，然后创建 channel，把 rx 交给 Tokio runtime 下运行的一个死循环的异步任务，这个任务从 rx 里取数据，然后 spawn 新的异步任务将 file 上传到 S3 对应 bucket 的 key 下。而 channel 的 tx 端则传给每个 repo 的 <code>LoggerWriter</code>，这样，<code>LoggerWriter</code> 在做 rotation 的时候，就可以通过 tx 发送要上传给 S3 的本地文件名 file，以及上传到 S3 的对象的 key。如下图所示：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-concurrent/7.webp' alt='' /></p>
+
+<p>整个流程同样看上去不容易实现，但最终添加的也就是二十行代码而已（不计入 S3 具体上传的代码）。</p>
+]]></content:encoded></item><item><title>透过 Rust 探索系统的本原：安全篇</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/rust-to-system-essence-safety.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h2 id='透过_rust_探索系统的本原：安全篇'>透过 Rust 探索系统的本原：安全篇</h2>
+
+<p>作者：陈天 / 后期编辑：<a href='https://github.com/NiZerin'>NiZerin</a></p>
+
+<p>&gt; &gt; 原文链接：<a href='https://mp.weixin.qq.com/s/HCHYr5sWnEG_qOGE3hfNnQ'>https://mp.weixin.qq.com/s/HCHYr5sWnEG_qOGE3hfNnQ</a></p>
+
+<h2 id=''></h2>
+
+<p>安全是我的老本行，隔一段时间不拉出来谈一谈就不舒服。我个人觉得：做应用不谈安全都是在耍流氓。</p>
+
+<p>按照 CISSP\[1] 的定义，安全有八大领域：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/1.webp' alt='' /></p>
+
+<p>本文只关注 Communication and Network Security 中 TCP/IP 范畴下的 Session Layer Security，也就是 TCP/UDP 层之上的安全方案：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/2.webp' alt='' /></p>
+
+<p>目前业界首选的方案是 TLS\[2]。在所有流行的应用层解决方案中，都离不开 TLS。</p>
+
+<p>在 p2p 领域，TLS 并不那么受待见，大家似乎更喜欢和 TLS 提供了同等安全水平，但更加去中心化（不需要 CA\<a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828386&amp;idx=1&amp;sn=555e16a024e027f6cde350a0a09d3af4&amp;chksm=8704ae3eb0732728040c309dbd4200c93483f6f40b1ac86dc7d8810f53290d870657b89ea5ce&amp;scene=21#wechat_redirect'>3]）的 noise protocol\[4]。我去年写过一篇关于 Noise protocol 的文章：[Noise 框架：构建安全协议的蓝图</a>。</p>
+
+<p>本文围绕 TLS 和 Noise protocol，以及它们在 Rust 下的使用场景，谈谈我们如何做安全的系统和应用。</p>
+
+<h2 id='安全的本质'>安全的本质</h2>
+
+<p>很多人谈到安全，首先想到的是加密解密。加解密只解决了安全范畴的机密性（confidentialilty）的问题，但它没有触及另外两个重要的范畴：完整性（integrity）和可用性（availability）。我们简单讲一下这三个概念：</p>
+
+<ul>
+<li>
+<p>机密性：信息在使用和传输的过程中以密文保存，只有授权的用户才可以获取到明文。</p>
+</li>
+
+<li>
+<p>完整性：信息在使用和传输的过程中，不会被非法授权和破坏。</p>
+</li>
+
+<li>
+<p>可用性：合法用户对信息的访问不会被拒绝。</p>
+</li>
+</ul>
+
+<p>为了保证可用性，我们会提供服务的高可用性（防止 DoS 以及服务故障），做数据冗余和灾备处理（防止数据丢失），监控，故障转移等等。</p>
+
+<p>为了保证完整性，我们会使用哈希算法，数字签名来保证数据的一致性。</p>
+
+<p>为了保证机密性，我们会使用对称和非对称加密来保证在传输途中，以及在数据载体上的机密性。机密性往往需要完整性作为先决条件；而完整性不一定需要机密性作为先决条件。</p>
+
+<p>下图阐述了安全领域涉及机密性和完整性的主要算法：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/3.webp' alt='' /></p>
+
+<p>注意，这里的一些算法是泛称，而非具体某种算法。比如：sha3 算法族下面除了 keccak 以外，还有 blake2，blake3 等其他算法；而 ECC 算法下面，属于签名算法的有 Ed25519，Ed448 等，属于非对称加密的有 x25519，x448 等。</p>
+
+<p>如果你看了我前几周的文章，大概对我介绍的《<a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828843&amp;idx=1&amp;sn=f60193eba1debfdbab4d9ea48ddf8203&amp;chksm=8704aff7b07326e1c265b21c1617c436e2ab4b4f8911c9b7b64cc8b9f5d34e993aa875090e87&amp;scene=21#wechat_redirect'>胖客户端，廋服务器</a>》有些印象。文章中我提到了服务端把用户端的事件写入到事件日志中，客户端可以 clone / pull 这些事件日志，在本地生成相应的状态。那么问题来了，客户端怎么知道 clone 下来的事件日志是未经第三方篡改的事件日志呢？很简单，我们只需对日志文件做个 hash，然后用服务器的私钥对这个 hash 做一个签名，把签名附带在文件头上。这样客户端收到文件后，用服务器的公钥验证这个签名即可。这样，只要服务器的私钥不泄露，这个签名就可以验证文件的完整性。在比特币的世界里，每个区块的完整性都由打包该区块的矿工的签名来保证，而整个链的完整性则由哈希链和中本聪共识（最长链）保证。</p>
+
+<p>进一步的，如果我们用户的私有 repo 下的所有事件日志都只有用户自己才能访问，其他人（包括服务端应用）都无法访问，那么我们可以用用户的公钥来加密 repo 的所有事件日志。</p>
+
+<h2 id='dh_算法：互联网安全的基石'>DH 算法：互联网安全的基石</h2>
+
+<p>当我们需要保证存储在媒介上的信息的安全性时，一切都简单而直观；但当我们需要保证在网络传输中的实时信息的安全性时，我们就面临着巨大的挑战。</p>
+
+<p>这其中第一个挑战就是：每个连接使用什么密钥来加密数据？</p>
+
+<p>我们知道，在网络传输中，非对称加密的效率不高，不适合大量数据的加密，而对称加密则需要双方共享密钥，才能正常通讯。因此，我们需要一种手段，在不安全的网络信道中，只传输部分信息，通过这部分信息 + 本地的私有信息，协商出来双方一致的共享密钥。第三方即便获得明文传输的信息，也无法推导出密钥。如果这样的手段行得通，那么，我们就可以在网络通讯的握手过程，生成每个 session 独立的共享密钥（session key），后续的通讯都通过这个（这对）密钥来加密完成。这个协商的过程就是 DH 算法（Diffie-Hellman Key Exchange Algorithm）\[5]（对算法细节感兴趣的可以去看 wikipedia）：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/4.webp' alt='' /></p>
+
+<p>DH 算法是 TLS 以及 Noise protocol 的基石。如果没有它，我们就不会有目前这样一个繁荣且安全的互联网世界。</p>
+
+<p>在 Rust 下，如果你需要直接使用 DH 算法，可以使用 dalek 出品的 <code>x25519-dalek</code>\[6]。它是使用 curve25519 \[7] 的 ECDH（Elliptic Curve Diffie-Hellman） 的实现。代码如下：</p>
+
+<pre><code class="language-`rust">use rand_core::OsRng;
+use x25519_dalek::{EphemeralSecret, PublicKey};
+let alice_secret = EphemeralSecret::new(OsRng);
+let alice_public = PublicKey::from(&amp;alice_secret);
+let bob_secret = EphemeralSecret::new(OsRng);
+let bob_public = PublicKey::from(&amp;bob_secret);
+let alice_shared_secret = alice_secret.diffie_hellman(&amp;bob_public);
+let bob_shared_secret = bob_secret.diffie_hellman(&amp;alice_public);
+assert_eq!(alice_shared_secret.as_bytes(), bob_shared_secret.as_bytes());</code></pre>
+
+<p>你也许会问：我又不去实现 TLS 或者类似的加密协议，而我自己的网络传输都靠 TLS 保护着呢，DH 对我来说有什么用呢？</p>
+
+<p>我能想到的一个场景是文件加密。在本文开头，我说：</p>
+
+<p>&gt; &gt; 进一步的，如果我们用户的私有 repo 下的所有事件日志都只有用户自己才能访问，其他人（包括服务端应用）都无法访问，那么我们可以用用户的公钥来加密 repo 的所有事件日志。</p>
+
+<p>这个方案的缺点是效率太低 — 如果需要加密的文件有几个 G，非对称加密显然不好。但我们又没法用对称加密：毕竟我们不能跟每个人都预先共享一组密钥（共享密钥本身又存在安全风险）。这时，我们可以用 DH 算法生成一个只对这个文件有效的密钥，加密文件，然后在文件头提供必要的信息即可：</p>
+
+<ol type="1">
+<li>
+<p>生成一个临时公钥对</p>
+</li>
+
+<li>
+<p>用私钥和用户的公钥算 DH key</p>
+</li>
+
+<li>
+<p>用 DH key 作为 AES\[8] 或者 ChachaPoly\[9] 的密钥，加密文件</p>
+</li>
+
+<li>
+<p>在文件头添加临时生成的公钥</p>
+</li>
+</ol>
+
+<p>这样，在解密端，用户可以用自己的私钥和文件中携带的公钥算出 DH key，然后解密之。</p>
+
+<p>如果大家对这个思路感兴趣，可以参考我用 Noise protocol 做的类似的解决方案：tyrchen/conceal\[10]。</p>
+
+<p>除了 x25519-dalek 外，ristretto255-dh\[11] 也值得一试，它是 zcash 实现的 Ristretto255\[12] DH 算法。</p>
+
+<h2 id='tls：不仅仅是_http_的安全防线'>TLS：不仅仅是 HTTP 的安全防线</h2>
+
+<p>作为 HTTPS 的安全协议的唯一选择，相信大家对 TLS（以及它的前身 SSL）有一定的了解 — 起码知道：</p>
+
+<ul>
+<li>
+<p>服务端需要安装经过合法 CA 签署的证书（certificate）。如果你配过 nginx，你还会知道，证书和证书的私钥一般都是 PEM \[13] 格式存储在文件系统的。一般来说，除了配置自己的证书外，还需要配置整个服务器证书链以便客户端验证。</p>
+</li>
+
+<li>
+<p>客户端在连接服务器时，会获取服务器证书，然后通过操作系统受信的根证书来验证服务器的证书以及签署该证书的 CA，以及签署该 CA 的上一级 CA 等形成的整个证书链可以由某个根证书验证。</p>
+</li>
+
+<li>
+<p>客户端验证了服务器的证书后，会跟服务器交互建立一个安全信道，保证之后的传输的安全。这个过程是 TLS 握手。</p>
+</li>
+
+<li>
+<p>之后整个 HTTP 协议交互的过程，都被这个安全信道保护起来（说人话就是加密了），第三方无法嗅探到内部的交互，也无法破坏其完整性。</p>
+</li>
+</ul>
+
+<p>如果你经常调试（或者逆向工程）HTTPS，你大概还知道：</p>
+
+<ul>
+<li>
+<p>通过 Charles Proxy 这样的工具，可以做 Man-In-The-Middle\[14]，来截获加密的数据。使用 Charles Proxy 时，需要在操作系统级「信任」其根证书，这是证书验证的流程所决定的。一旦某个根证书被系统信任，那么它可以签署任何域名的证书，这样第三方就可以伪装成目标服务器，terminate 客户端到服务器的任何 TLS 流量，然后再伪装成客户端，向实际服务器发送数据。所以，不要轻易信任来路不明的根证书。</p>
+</li>
+
+<li>
+<p>如果要避免 Charles Proxy 等工具做 Man-In-The-Middle，你可以使用 certificate pinning。</p>
+</li>
+</ul>
+
+<p>你大概率不知道：</p>
+
+<ul>
+<li>
+<p>TLS 支持 client certificate - 也就是说不光客户端可以验证服务器是否是我要连的服务器；服务器也可以验证客户端是否是我（的 CA）签署的客户端。</p>
+</li>
+
+<li>
+<p>客户端验证服务器时，除了可以通过系统的根证书验证，也可以预置一个 CA 证书来验证服务器的证书是否由该 CA 签署。</p>
+</li>
+</ul>
+
+<h3 id='证书是个什么鬼？'>证书是个什么鬼？</h3>
+
+<p>我们这里所说的证书，是 PKI 体系下的 X.509 证书\[16]。X.509 证书用于证明一个公钥的身份。我说我是 domain.com 的合法服务器，何以见得？我生成一对私钥和公钥，通过其签署一个 CSR（Certificate Signing Request \[17]），里面通过 CN（Common Name）声索我对 <code>*.domain.com</code> 的占有。一般一个 CSR 包含这些信息：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/5.webp' alt='' /></p>
+
+<p>随后我把 CSR 提交给一个由某个根证书签署的 CA，由其签名并发回给我。这样，任何应用通过 HTTPS 连接 domain.com 时就可以正常通讯。</p>
+
+<p>在 letsencrypt\[18] 成为主流之前，证书是个几乎相当于特许经营的好生意。像 godaddy 这样的家伙，一个证书可以卖上百美金一年，简直如同抢钱。证书作为一门生意，极大地破坏了互联网的安全性，很多小的玩家不想支付每年的证书费用，干脆就避免使用 HTTPS。letsencrypt 的出现，几乎摧毁了各大吃相难看的 CA 的生意。Letsencrypt 自动化了证书的申请流程，只要你能把某个域名指向你的服务器，让 letsencrypt 验证到你请求的域名就是你拥有的域名，可以立即签署一个有效期是 3 个月的免费证书。至于证书的有效期为啥不能更长，这个，根本不是技术原因，我猜是来自做垂死挣扎的既得利益者们的压力。</p>
+
+<h3 id='能不能自己做_ca？'>能不能自己做 CA？</h3>
+
+<p>CA 机构是 internet 的不可或缺，却相对脆弱的一环。Letsencrypt 只是解决了证书收费的问题，不过没有解决 CA 机构本身的脆弱性 — 任何一个中心化的，可以签署证书，被数亿设备信任的机构都是有安全风险的，因为黑客随时盯着这些机构的漏洞。一旦一个CA 被攻陷，黑客们可以伪造出成千上万的域名的服务器证书。</p>
+
+<p>有没有可能一个应用的客户端和服务器使用自己的 CA，绕过任何 CA 机构？</p>
+
+<p>当然可以。你可以生成自己的 CA cert（自签名），然后用 CA key 签名 Server cert。你的客户端在启动 TLS 连接时，信任你自己的 CA cert 即可。你甚至还可以通过你的 CA 给每个客户端签名，让服务器也同时验证客户端是你信任的客户端。如下图所示：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/6.webp' alt='' /></p>
+
+<p>一个新的客户端在注册新用户/登录时，服务器会从 CA 获取证书，连同用户登录获得的 token 一同返回给客户端。之后，客户端访问任何服务端的 API（除 auth 之外），都需要提供 client cert 供服务器验证，这样，额外增加安全性，并且，可以杜绝 Charles Proxy 这样的中间人。</p>
+
+<p>当然这样的手段只适合客户端代码由你自己控制（比如 iOS/android/OSX/Linux/Windows app）。你无法让你的服务器证书通过浏览器的安全验证（因为证书不在系统根证书的信任列表中），因而，任何使用浏览器访问你的服务器的用户将无法使用你的服务。</p>
+
+<p>如果你对这样的方案感兴趣，可以看看我的 crate: tyrchen/cellar\[19]。它借鉴比特币分层钱包\[20]的设计，可以从一个 passphrase 衍生出确定的分层密码/密钥/证书。生成的证书可以被应用在 TLS 应用中，比如：tyrchen/mobc-tonic\[21]（我做的一个 grpc client connection pool）。</p>
+
+<p>下面是我通过 celllar 生成的 CA 证书（注意 <code>CA: TRUE</code>）：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/7.webp' alt='' /></p>
+
+<p>以及该 CA 签署的服务器证书（注意 <code>CA: FALSE</code> 和 <code>TLS Web Server Authentication</code>）：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/8.webp' alt='' /></p>
+
+<p>以及该 CA 签署的客户端证书（注意 <code>CA: FALSE</code> 以及 <code>TLS Web Client Authentication</code>）：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/9.webp' alt='' /></p>
+
+<p>将 TLS 应用在 HTTP 之外</p>
+
+<p>TLS 可以保护我们的 HTTP 应用，其中包括 REST/GraphQL/Websocket API，以及 gRPC API。虽然目前 HTTP 是几乎绝大多数互联网应用使用的协议，但还有大量的其它基于 TCP 层的协议。如果你要保证这些协议的安全性，使用 TLS 是一个简单直接的选择。</p>
+
+<p>然而，理解和使用好 OpenSSL 库不是一件容易的事情。十多年前，我曾经用 C 语言和老旧的 OpenSSL （0.9.x）打过交道，那体验<strong>相当</strong>不好。Python / Erlang 有不错的 OpenSSL 的封装，在应用中使用 TLS 比较舒服自然。如果你熟悉的语言没有很好的库去包装 OpenSSL，那么，在应用中使用 TLS 就不那么容易。</p>
+
+<p>在 Rust 里，除了 OpenSSL 的封装，我们还有 Rustls\[22]。它是一个经过了 security auditing\[23] 的 TLS 安全裤，性能比 OpenSSL 更好，且理论上更加安全（没有遗留的历史问题，没有 TLS1.1 及以下的不安全代码，没有遗留的不安全的加密算法，比如 RC4，3DES）。</p>
+
+<p>Rustls 虽然比 OpenSSL 容易使用，但成功建立起 TLS 连接，还需要更多对 TLS 细节的理解。为此，我做了一个 crate：tokio-tls-helper\[24]，可以让你通过简单的配置，创建 TLS connector (client) 和 acceptor (server)。</p>
+
+<p>比如客户端使用自定义的 CA cert 以及通过自定义 CA 签署的 client cert：</p>
+
+<pre><code class="language-`rust">domain = &quot;localhost&quot;
+
+[cert]
+pem = &quot;&quot;&quot;-----BEGIN CERTIFICATE-----
+MIIBeTCCASugAwIBAgIBKjAFBgMrZXAwNzELMAkGA1UEBgwCVVMxFDASBgNVBAoM
+C0RvbWFpbiBJbmMuMRIwEAYDVQQDDAlEb21haW4gQ0EwHhcNMjEwMzE0MTg0NTU2
+WhcNMzEwMzEyMTg0NTU2WjA3MQswCQYDVQQGDAJVUzEUMBIGA1UECgwLRG9tYWlu
+IEluYy4xEjAQBgNVBAMMCURvbWFpbiBDQTAqMAUGAytlcAMhAAzhorM9IPsXjBTx
+ZxykGl5xZrsj3X2XqKjaAVutnf7po1wwWjAUBgNVHREEDTALgglsb2NhbGhvc3Qw
+HQYDVR0OBBYEFD+NqChBZDOs5FMgefHJSIWiRTHXMBIGA1UdEwEB/wQIMAYBAf8C
+ARAwDwYDVR0PAQH/BAUDAwcGADAFBgMrZXADQQA9sligQcYGaBqTxR1+JadSelMK
+Wp35+yhVVuu4PTL18kWdU819w3cVlRe/GHt+jjlbk1i22TvfO5AaNmdxySkO
+-----END CERTIFICATE-----&quot;&quot;&quot;
+
+[identity]
+key = &quot;&quot;&quot;-----BEGIN PRIVATE KEY-----
+MFMCAQEwBQYDK2VwBCIEIArjJtHm3xb4aX3fsGHpuB8dD3yzcLxWcPCqy7AGtTG5
+oSMDIQD/38MZBnYuyitIGU3ltOGwwDwtB6KYag4rL1zsSGTzYg==
+-----END PRIVATE KEY-----&quot;&quot;&quot;
+
+[identity.cert]
+pem = &quot;&quot;&quot;-----BEGIN CERTIFICATE-----
+MIIBZDCCARagAwIBAgIBKjAFBgMrZXAwNzELMAkGA1UEBgwCVVMxFDASBgNVBAoM
+C0RvbWFpbiBJbmMuMRIwEAYDVQQDDAlEb21haW4gQ0EwHhcNMjEwMzE0MTg0NTU2
+WhcNMjEwOTEwMTg0NTU2WjAyMQswCQYDVQQGDAJVUzEQMA4GA1UECgwHYW5kcm9p
+ZDERMA8GA1UEAwwIYWJjZDEyMzQwKjAFBgMrZXADIQD/38MZBnYuyitIGU3ltOGw
+wDwtB6KYag4rL1zsSGTzYqNMMEowFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1Ud
+JQQMMAoGCCsGAQUFBwMCMAwGA1UdEwQFMAMBAQAwDwYDVR0PAQH/BAUDAwfgADAF
+BgMrZXADQQCKhph1Z3g6E+EULUi5yIROSXmMxWjzi+L1OmqNh9ANJlrQwlcfwq0G
+8JbfGVwq1sotEI83mv42mWkSSX98uysO
+-----END CERTIFICATE-----&quot;&quot;&quot;</code></pre>
+
+<p>有了这个配置，客户端可以生成 <code>ClientTlsConfig</code>，然后生成 <code>connector</code>，在建立好 TCP stream 后，直接调用 <code>connector.connect(stream)</code> 就可以将 TCP 连接升级为 TLS 连接，之后可以在其之上进行应用层的协议：</p>
+
+<pre><code class="language-`rust">let msg = b&quot;Hello world\n&quot;;
+let mut buf = [0; 12];
+
+let config: ClientTlsConfig = toml::from_str(config_file).unwrap();
+let connector = config.tls_connector(Uri::from_static(&quot;localhost&quot;)).unwrap();
+
+let stream = TcpStream::connect(addr).await.unwrap();
+let mut stream = connector.connect(stream).await.unwrap();
+info!(&quot;client: TLS conn established&quot;);
+
+stream.write_all(msg).await.unwrap();
+
+info!(&quot;client: send data&quot;);
+
+let (mut reader, _writer) = split(stream);
+
+reader.read_exact(buf).await.unwrap();
+
+info!(&quot;client: read echoed data&quot;);</code></pre>
+
+<p>服务端的使用也很简单：配置相同的 CA cert，以及服务器的 server/key：</p>
+
+<pre><code class="language-`rust">[identity]
+key = &quot;&quot;&quot;-----BEGIN PRIVATE KEY-----
+MFMCAQEwBQYDK2VwBCIEII0kozd0PJsbNfNUS/oqI/Q/enDiLwmdw+JUnTLpR9xs
+oSMDIQAtkhJiFdF9SYBIMcLikWPRIgca/Rz9ngIgd6HuG6HI3g==
+-----END PRIVATE KEY-----&quot;&quot;&quot;
+
+[identity.cert]
+pem = &quot;&quot;&quot;-----BEGIN CERTIFICATE-----
+MIIBazCCAR2gAwIBAgIBKjAFBgMrZXAwNzELMAkGA1UEBgwCVVMxFDASBgNVBAoM
+C0RvbWFpbiBJbmMuMRIwEAYDVQQDDAlEb21haW4gQ0EwHhcNMjEwMzE0MTg0NTU2
+WhcNMjIwMzE0MTg0NTU2WjA5MQswCQYDVQQGDAJVUzEUMBIGA1UECgwLRG9tYWlu
+IEluYy4xFDASBgNVBAMMC0dSUEMgU2VydmVyMCowBQYDK2VwAyEALZISYhXRfUmA
+SDHC4pFj0SIHGv0c/Z4CIHeh7huhyN6jTDBKMBQGA1UdEQQNMAuCCWxvY2FsaG9z
+dDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMEBTADAQEAMA8GA1UdDwEB/wQF
+AwMH4AAwBQYDK2VwA0EAy7EOIZp73XtcqaSopqDGWU7Umi4DVvIgjmY6qbJZP0sj
+ExGdaVq/7MOlZl1I+vY7G0NSZWZIUilX0CoOkrn0DA==
+-----END CERTIFICATE-----&quot;&quot;&quot;
+
+
+[client_ca_root]
+pem = &quot;&quot;&quot;-----BEGIN CERTIFICATE-----
+MIIBeTCCASugAwIBAgIBKjAFBgMrZXAwNzELMAkGA1UEBgwCVVMxFDASBgNVBAoM
+C0RvbWFpbiBJbmMuMRIwEAYDVQQDDAlEb21haW4gQ0EwHhcNMjEwMzE0MTg0NTU2
+WhcNMzEwMzEyMTg0NTU2WjA3MQswCQYDVQQGDAJVUzEUMBIGA1UECgwLRG9tYWlu
+IEluYy4xEjAQBgNVBAMMCURvbWFpbiBDQTAqMAUGAytlcAMhAAzhorM9IPsXjBTx
+ZxykGl5xZrsj3X2XqKjaAVutnf7po1wwWjAUBgNVHREEDTALgglsb2NhbGhvc3Qw
+HQYDVR0OBBYEFD+NqChBZDOs5FMgefHJSIWiRTHXMBIGA1UdEwEB/wQIMAYBAf8C
+ARAwDwYDVR0PAQH/BAUDAwcGADAFBgMrZXADQQA9sligQcYGaBqTxR1+JadSelMK
+Wp35+yhVVuu4PTL18kWdU819w3cVlRe/GHt+jjlbk1i22TvfO5AaNmdxySkO
+-----END CERTIFICATE-----&quot;&quot;&quot;</code></pre>
+
+<p>服务端同样可以通过配置生成 <code>ServerTlsConfig</code>，然后生成 <code>acceptor</code>，之后正常使用 TCP listener accept 一个 TCP stream 后，就可以通过 <code>acceptor.accept(stream)</code> 把 TCP 连接升级为 TLS。这个过程配合客户端的 <code>connector.connect(stream)</code>，共同完成前面所说的 DH 过程，协商出来 session key，然后开始加密/解密应用层的数据：</p>
+
+<pre><code class="language-`rust">let config: ServerTlsConfig = toml::from_str(config_file).unwrap();
+let acceptor = config.tls_acceptor().unwrap();
+let listener = TcpListener::bind(addr).await.unwrap();
+tokio::spawn(async move {
+    loop {
+        let (stream, peer_addr) = listener.accept().await.unwrap();
+        let stream = acceptor.accept(stream).await.unwrap();
+        info!(&quot;server: Accepted client conn with TLS&quot;);
+
+        let fut = async move {
+            let (mut reader, mut writer) = split(stream);
+            let n = copy(&amp;mut reader, &amp;mut writer).await?;
+            writer.flush().await?;
+            debug!(&quot;Echo: {} - {}&quot;, peer_addr, n);
+        }
+
+        tokio::spawn(async move {
+            if let Err(err) = fut.await {
+                error!(&quot;{:?}&quot;, err);
+            }
+        });
+    }
+});</code></pre>
+
+<h2 id='noise_protocol：狂野西部的守护者'>Noise Protocol：狂野西部的守护者</h2>
+
+<p>如果你没看过我之前的文章，大概率 Noise Protocol 对你来说是个陌生的名字。如果你搭过各种各样的梯子，你也许使用过 Wireguard\<a href='http://mp.weixin.qq.com/s?__biz=MzA3NDM0ODQwMw==&amp;mid=2649828356&amp;idx=1&amp;sn=0cfcf0de0a6a3c1fe9d1fc8d9e7df5f1&amp;chksm=8704ae18b073270e2e7ced09f29846ebc38affed8cb023410f995ee829ceedaddaa7b80cadbe&amp;scene=21#wechat_redirect'>25]，那么恭喜你，你已经在不知不觉中使用 Noise Protocol 了 — 因为 Wireguard 在安全层使用了 Noise Protocol。我曾经写过一篇文章：[Wireguard：简约之美</a>，介绍了 Wireguard 这个非常牛逼的 VPN 工具。</p>
+
+<p>因为之前的关于 Wireguard 和 Noise protocol 的文章对 Noise Protocol 本身已经有足够丰富的介绍，这里我就不再赘述 Noise Protocol 的细节。</p>
+
+<p>如果说 TLS 是出身高贵的正规军，那么 Noise Protocol 就是出身草根的土八路。但二者其实互相借鉴，互相学习。TLS 1.3 和 Noise Protocol 的主要区别有两个：</p>
+
+<ol type="1">
+<li>
+<p>在身份验证方面二者走上了不同的道路（TLS 1.3 使用证书，而 Noise Protocol 完全不使用）</p>
+</li>
+
+<li>
+<p>通讯过程中使用的算法一个走协商（TLS）一个走预配置（Noise）</p>
+</li>
+</ol>
+
+<p>走协商还是走配置这跟协议的使用场景有关。TLS 关注的是大量不同版本的标准客户端（比如 Firefox）和服务器之间的交互，两端支持的算法族可能有不小的出入，协商出双方都能接受的算法是最优的选择，这样可以支持尽可能广的应用场景；而 Noise Protocol 关注的是定制的客户端和服务器之间的交互，因而两端可以通过预配置来确定使用的算法。比如 WireGuard 使用 <code>Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s</code>，那么客户端和服务端都需要：</p>
+
+<ul>
+<li>
+<p>Curve 25519 做 ECDH</p>
+</li>
+
+<li>
+<p>CharChaPoly 做加密</p>
+</li>
+
+<li>
+<p>Blake2s 做哈希</p>
+</li>
+
+<li>
+<p>两端使用 pre-shared key 进一步保证安全性</p>
+</li>
+</ul>
+
+<p>因为避免使用证书这样天然具有中心化的东西，Noise Protocol 在 p2p 领域走出了新的天地。从最简单的 NN（双方都没有固定公钥）KK（双方都知道对方的固定公钥），到最复杂的 XX（双方都有固定公钥，通过网络加密传输给对方），Noise Protocol 定义了 12 种协商模式，再辅以不同的哈希和加密算法，可以组合出上百种安全方案，总有一种适合你：</p>
+
+<p><img src='https://oss.iacblog.com/rust/rust-to-system-essence-safety/10.webp' alt='' /></p>
+
+<p>在 Rust 下，snow\[26] 是 Noise Protocol 的非常成熟的实现，而 libp2p 则使用了 snow 来实现 libp2p 协议的安全层。</p>
+
+<p>下面是使用 snow 在 TCP 协议之上建立加密信道的实例。我们可以看到，仅需额外的几行代码就可以将你的网络应用打造得非常安全：</p>
+
+<ul>
+<li>
+<p>创建 snow Builder</p>
+</li>
+
+<li>
+<p>在建立连接后发送和接收不超过 3 个 Noise protocol 协议报文</p>
+</li>
+
+<li>
+<p>协议握手完成后，使用 <code>noise.into_transport_mode()</code> 将 snow 状态机切换到传输模式</p>
+</li>
+
+<li>
+<p>之后收到报文后调用 <code>noise.read_message()</code> 解密，发送报文前调用 <code>noise.write_message()</code> 加密即可。</p>
+</li>
+</ul>
+
+<p>服务器：</p>
+
+<pre><code class="language-`rust">let params: NoiseParams = &quot;Noise_XX_25519_ChaChaPoly_BLAKE2s&quot;.parse().unwrap();
+let builder: Builder&lt;&#8217;_&gt; = Builder::new(params.clone());
+let static_key = builder.generate_keypair().unwrap().private;
+let mut noise = builder
+    .local_private_key(&amp;static_key)
+    .build_responder()
+    .unwrap();
+
+// wait on client&#8217;s arrival
+println!(&quot;Listening on 0.0.0.0:9999&quot;);
+let (mut stream, _) = TcpListener::bind(&quot;0.0.0.0:9999&quot;).unwrap().accept().unwrap();
+
+// &lt;- e
+noise
+    .read_message(&amp;recv(&amp;mut stream).unwrap(), &amp;mut buf)
+    .unwrap();
+
+// -&gt; e, ee, s, es
+let len = noise.write_message(&amp;[0u8; 0], &amp;mut buf).unwrap();
+send(&amp;mut stream, &amp;buf[..len]);
+
+// &lt;- s, se
+noise
+    .read_message(&amp;recv(&amp;mut stream).unwrap(), &amp;mut buf)
+    .unwrap();
+
+// transition the state machine to transport mode sinc handshake is complete.
+let mut noise = noise.into_transport_mode().unwrap();
+while let Ok(msg) = recv(&amp;mut stream) {
+    let len = noise.read_message(&amp;msg, &amp;mut buf).unwrap();
+    println!(&quot;client said: {}&quot;, String::from_utf8_lossy(&amp;buf[..len]));
+}
+
+println!(&quot;connection closed&quot;);</code></pre>
+
+<p>客户端：</p>
+
+<pre><code class="language-`rust">let params: NoiseParams = &quot;Noise_XX_25519_ChaChaPoly_BLAKE2s&quot;.parse().unwrap();
+let builder: Builder&lt;&#8217;_&gt; = Builder::new(params.clone());
+let static_key = builder.generate_keypair().unwrap().private;
+let mut noise = builder
+    .local_private_key(&amp;static_key)
+    .build_initiator()
+    .unwrap();
+
+// connect to server
+let mut stream = TcpStream::connect(&quot;127.0.0.1:9999&quot;).unwrap();
+println!(&quot;connected!&quot;);
+
+// -&gt; e
+let len = noise.write_message(&amp;[], &amp;mut buf).unwrap();
+send(&amp;mut stream, &amp;buf[..len]);
+
+// &lt;- e, ee, s, es
+noise
+    .read_message(&amp;recv(&amp;mut stream).unwrap(), &amp;mut buf)
+    .unwrap();
+
+// -&gt; s, se
+let len = noise.write_message(&amp;[], &amp;mut buf).unwrap();
+send(&amp;mut stream, &amp;buf[..len]);
+
+let mut noise = noise.into_transport_mode().unwrap();
+println!(&quot;Session established...&quot;);
+
+// send secure data
+for _ in 0..10 {
+    let len = noise.write_message(b&quot;HACK THE PLANET&quot;, &amp;mut buf).unwrap();
+    send(&amp;mut stream, &amp;buf[..len]);
+}</code></pre>
+
+<p>因为 snow 的所有操作都直接操作内存的 buffer，所有的 IO 都是由你创建的 TCP stream 完成，所以 snow 可以很好地在同步或者异步模式下工作。</p>
+
+<h2 id='贤者时刻'>贤者时刻</h2>
+
+<p>&gt; &gt; 连接千万条，安全第一条。网络不加密，亲人两行泪。- 鲁迅：不是我说的</p>
+]]></content:encoded></item><item><title>如何为 Rust 语言做贡献 | Part 2</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/contribute_to_the_rust_part2.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='如何为_rust_语言做贡献_|_part_2'>如何为 Rust 语言做贡献 | Part 2</h1>
+
+<p>作者：CrLF0710（野喵）/ 后期编辑：张汉东</p>
+
+<h2 id=''></h2>
+
+<p>大家好，上次讲了如何利用空闲时间参与Rust Project，做一些技术上的参与。这一次呢，我要讲的是如何更加系统的参与Rust Project，相应的，这里讲的内容也需要参与者相应的投入更多的时间、以及更高的门槛。</p>
+
+<p>在开始正式参与之前，我们有必要了解一下Rust Project的组织架构，也就是Rust Team。</p>
+
+<h1 id='rust_官方团队'>Rust 官方团队</h1>
+
+<p>Rust Team 由十个Team 构成。每个Team习惯上称为T-XYZ，比如权限最高的Team是核心团队，习惯上写成T-Core。</p>
+
+<p>十个Team(除T-Core外排名不分先后)分别是T-Core, T-Lang, T-Libs, T-Compiler, T-Devtools, T-Crates&lt;span&gt;.io&lt;/span&gt;, T-Infra, T-Release, T-Community 和 T-Moderation。所有团队的成员是常驻人员，其实也都是志愿者，成员的选拔主要来自于同一团队其他已有成员的认同。接下来让我们来逐一对各个团队做个介绍。</p>
+
+<p>首先是核心团队T-Core，它的职责是管理Rust Project的总体方向，管理各个Team的领导职责，管理跨团队事务。它是一个没有团队负责人的团队，而且讨论频道是不对外部公众公开的。它出现最多的地方就是，大家会看到那些刊发重大决策的博文都是以核心团队的名义发表的。它的成员往往是其他团队的团队负责人等。</p>
+
+<p>接下来我想首先介绍的是语言设计团队T-Lang，它的职责是设计Rust这门语言。在<a href='https://github.com/rust-lang/rfcs'>Rust RFCs</a>被接受的RFC中，语言设计类的RFC到目前为止是占绝对多数的。他们的职责就是讨论语言的未来更改，并且帮忙参与一部分语言特性的实现（参见稍后提到的“项目组”）。平时大家笑谈的“语言律师”就是这些人——对于你的一个设计想法，他们可以飞快地在脑中与语言其他已有特性进行交叉验证，指出你的设计不足……在我的经验里，多多围观他们的讨论对你更深地理解Rust是非常有好处的。</p>
+
+<p>然后是库设计团队T-Libs，它的职责是设计维护Rust的内置库。要注意内置库不止是标准库std，还有core, alloc, test等等。库设计团队的成员们往往都是一些知名rust库的作者，他们在设计API上都是非常有经验的，关注的是接口的易用性等等。实际上Rust的内置库其实从整体上是已经趋于“收敛”了，很难看到较大块的增加，一般都是在一些已有的类型上增加一些小的接口和辅助函数等等。这些接口的稳定化就是由T-Libs来把关的。</p>
+
+<p>接下来是编译器维护团队T-Compiler，它的职责是维护编译器的主体代码。T-Compiler是所有团队中人员最多的团队，以T-Compiler的名义提交的代码占的比重也是最大的。所有已经实现的语言特性相关的代码都是移交给他们来维护的，而对编译器的各种bug的修复、各种诊断帮助信息的用户体验逻辑维护、对编译器的性能优化等等，都是由T-Compiler来进行。这里的任务从简单的“调整一个内部判断条件”，到困难的“实现一个下一代的借用检查器和特质查询系统”，能做的事情有很多很多。</p>
+
+<p>接下来是开发工具团队T-Devtools，它其实是由一堆小团队组成，职责是负责维护cargo、rustdoc、rustfmt、rustup等各种小的程序。每个程序的维护团队其实是相互独立的。这里其实有非常多的贡献机会。</p>
+
+<p>然后是Crates.io团队T-Crates&lt;span&gt;.io&lt;/span&gt;，它负责开发维护crates.io网站的前后端，大家上传的开源Rust包都可以集中放到这个网站里。</p>
+
+<p>接下来是运维团队T-Infra，它负责维护Rust的各个网站、crater、CI、域名解析、CDN连接等等的正常运转。</p>
+
+<p>然后是版本发布团队T-Release。与任务导向的T-Compiler不同，T-Release负责按照Rust的发布周期对各个发布版本执行回归测试，定位回归测试中发现的问题、联系T-Compiler进行评估修复。</p>
+
+<p>然后是社区团队T-Community。负责组织Rust相关的活动和会议、管理网站内容、进行社区投票等等。它基本上就可以看作是最近新成立的 Rust 基金会的前身，区别在于新成立的Rust基金会在原来的基础上增加了财务和法务等等的新的责任。</p>
+
+<p>最后是风纪管理T-Moderation。主要负责维持各种交流频道的秩序，维护《行为准则》，管理必要的账号封禁事项等等。</p>
+
+<h1 id='rust_官方团队里的非正式成员'>Rust 官方团队里的非正式成员</h1>
+
+<p>虽然听起来团队成员数量还不少，但是实际上要推动rust的健康发展，人员力量很容易捉襟见肘。Rust的策略是吸纳更多的非正式成员进来完成工作。其中活跃的人在某种意义上也可以看作是正式成员的候补。</p>
+
+<p>对非正式成员的组织有三种形式：项目组，工作组和社区组。这个划分是之前讨论的，还在试行阶段没有变成正式决策。</p>
+
+<p>项目组(project group)是临时的。例如某个团队想要完成一个新功能的设计与实现，那么就会由该团队的一个成员发起一个项目组，由这个正式成员来带队。这个正式成员负责组织人手和会议，对相关的功能进行推进。</p>
+
+<p>工作组(working group)是较长期的。例如某个团队决定需要一群人来固定推进一些事情，那么同样也会由该团队的一个成员发起一个工作组。这个正式成员负责组织人手和会议，完成既定的任务。</p>
+
+<p>社区组(community group)之前叫做领域工作组，曾经也是工作组概念里的一部分。领域工作组是2017~2018年左右官方推进的一个概念，希望针对一些比较有前景的领域，各自集合一些人来定期讨论，做一些事情，比如写一些代码之类的。第一批成立了四个：网络、嵌入式、WebAssembly、命令行界面。后来又成立了第五个：游戏开发。实践证明，社区工作组这个想法执行起来并不太好，甚至导致了官方和社区的一些矛盾和摩擦。网络领域工作组解散后，官方的态度倾向于将这些领域工作组改编为社区组，不再属于官方团队的一部分。目前是在向这个方向行动，还没有完成。</p>
+
+<p>在这里我们主要关注项目组和工作组。一般来说门槛都是相当低的，一般只需要你在相应小组的频道里简单自我介绍一下，然后按时去参加会议就可以了。但是由于时区的缘故，例会时间往往在北京时间午夜之后，会议语言也一般都是英语。如果你是比较技术导向的，比如希望推进rust的某个特性工作的进展，不妨找到感兴趣的项目组报名参与一下。</p>
+
+<h1 id='rust_官方工作交流平台'>Rust 官方工作交流平台</h1>
+
+<p>Rust官方交流平台是用一个叫Zulip的软件，网址是<a href='rust-lang.zulipchat.com'>rust-lang.zulipchat.com</a>。可以用github登录。这东西有点介于IM与论坛之间，登录之后它有一些频道（称为Stream）。各个团队一般都至少有一个。很多团队也根据需要会为下面的工作组、领域建多个频道。在每个频道里面，任何人都可以建主题，有点像论坛发帖的感觉，然后大家在感兴趣的主题下讨论。它也有手机端app，但是目前还不是很好用；推荐使用网页版或者桌面App。Stream需要订阅才会显示，刚登录的时候显示不全，记得去所有频道面板中订阅自己想关注的频道。</p>
+
+<p>有的团队喜欢开视频会议，它们一般会选Zoom。如果需要协同编辑，往往用Dropbox Papers或者HackMD。大部分都是可以公开访问的，个别的需要申请权限。</p>
+
+<p>在交流时要稍微注意一点的是，关于称呼。欧美有很多人对性别平权、少数群体之类的比较在意。稍微注意下He/She两个词的使用千万不要用错，如果不确定，就用They就好了。</p>
+
+<p>话说，官方 Zulip 里有一个中文频道 <code>t-community/l10n/zh</code>，不过蛮冷清的。大家感兴趣的话可以来聊关于翻译的话题啊。</p>
+]]></content:encoded></item><item><title>三月刊（March）</title><link>https://rustmagazine.github.io/rust_magazine_2021/chapter_3/toc.html</link><description><![CDATA[]]></description><author>blackanger</author><pubDate></pubDate><content:encoded><![CDATA[<h1 id='三月刊'>三月刊</h1>
+
+<p><img src='../image/rust_magazine3.png' alt='logo' /></p>
+
+<h3 id='发刊通告'>发刊通告</h3>
+
+<ul>
+<li><a href='./announce.md'>发刊通告</a></li>
+</ul>
+
+<h3 id='本月社区动态简报'>本月社区动态简报</h3>
+
+<p>精选自《Rust日报》</p>
+
+<ul>
+<li><a href='./lang.md'>Rust官方动态</a></li>
+
+<li><a href='./hots.md'>社区热点</a></li>
+
+<li><a href='./projects.md'>推荐项目</a></li>
+
+<li><a href='./learns.md'>学习资源</a></li>
+
+<li><a href='./rust_laoke.md'>Rust 唠嗑室本月汇总</a></li>
+</ul>
+
+<h3 id='rust_in_production'>Rust in Production</h3>
+
+<ul>
+<li><a href='./hw_rust_stratovirt.md'>华为 | 基于Rust的下一代虚拟化平台-StratoVirt</a></li>
+
+<li><a href='./hw_ndarray.md'>华为 | Rust 科学计算多维数组运算库的分析与实践</a></li>
+
+<li><a href='./hw_rust_rvm_wasm_ai.md'>华为 | 基于 TVM Rust Runtime 和 WASM 沙箱运行 AI 模型</a></li>
+
+<li><a href='./rust_cpu_affinity.md'>蚂蚁集团 CeresDB 团队 | Rust CPU 亲和性(Affinity) 初探</a></li>
+
+<li><a href='./rust_rdma.md'>DatenLord | Rust实现RDMA</a></li>
+</ul>
+
+<h3 id='学习园地'>学习园地</h3>
+
+<ul>
+<li><a href='./no_std_binary.md'>`no_std` 环境下的可执行文件</a></li>
+
+<li><a href='./ink.md'>用 Rust 写智能合约 | Hello, Ink! </a></li>
+
+<li><a href='./reservoir.md'>「算法」蓄水池算法改进 - 面向抽奖场景保证等概率性</a></li>
+
+<li><a href='./rust-mysql.md'>Rust 中使用 MySQL</a></li>
+
+<li><a href='./rust-design-pattern-factory.md'>「系列」Rust 设计模式 ｜ 工厂模式</a></li>
+
+<li><a href='./rust_vs_pandas.md'>「译」数据操作：Rust vs Pandas</a></li>
+
+<li><a href='./Unsafe_Rust_How_and_when_not_to_use_it.md'>「译」Unsafe Rust 的取舍</a></li>
+
+<li><a href='./Rhythm-game-in-Rust-using-bevy.md'>「译」基于 Rust 用 Bevy 实现节奏大师游戏</a></li>
+
+<li><a href='./arenas-in-rust.md'>「译」Arenas in Rust</a></li>
+
+<li><a href='./toy-front-end-for-llvm-write-in-rust.md'>「译」用 Rust 编写 LLVM 的玩具编译器</a></li>
+</ul>
+
+<h3 id='【系列】透过_rust_探索系统的本原'>【系列】透过 Rust 探索系统的本原</h3>
+
+<ul>
+<li><a href='./rust-to-system-essence-concurrent.md'>透过 rust 探索系统的本原：并发篇</a></li>
+
+<li><a href='./rust-to-system-essence-safety.md'>透过 rust 探索系统的本原：安全篇</a></li>
+</ul>
+
+<h3 id='rust_编译器专题'>Rust 编译器专题</h3>
+
+<ul>
+<li><a href='./contribute_to_the_rust_part2.md'>如何为 Rust 语言做贡献 | Part 2</a></li>
+</ul>
+]]></content:encoded></item></channel></rss>


### PR DESCRIPTION
按照 mdbook-rss 的指引，给文章添加了头部注释，但是 mdbook-rss 中使用的 gray_matter 不能准确的把注释中的数据解析出来，导致 mdbook-rss 内部逻辑抛出错误，无法将文章作为一个 rss 的内容节点。

目前我将 mdbook-rss 通过 cargo install --path /path/to/mdbook-rss 的方式安装到本地，修改了部分逻辑，能正常生成 rss 了，之后会给 mdbook-rss 提 PR。