### PR TITLE
feat: add smart-anchor.js

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -14,7 +14,7 @@ theme = "mytheme"
 default-theme = "rust"
 google-analytics = "UA-188947685-1"
 git-repository-url = "https://github.com/RustMagazine/rust_magazine_2021"
-additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "smart-anchor.js"]
 mathjax-support = true
 
 [output.html.playground]

--- a/smart-anchor.js
+++ b/smart-anchor.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/*
+For anchor elements, as known as <a> tags.
+ */
+
+document.querySelectorAll('a').forEach(aElement => {
+    // Open new tab for links to other site.
+    if (aElement.origin !== window.origin) {
+        aElement.target = '_blank';
+    }
+});


### PR DESCRIPTION
Open new tab for links to other site.

文章外链点击会在当前标签页进行跳转，感觉不是很友好，建议本地链接在当前标签页跳转，外链直接打开新标签页。
稍微看了看mdBook的文档，没有找到对应配置方法，看pulldown-cmark也没有提供相应的功能，毕竟Markdown本身就是不提供这种特性的。
然后看可以通过配置additional-js来添加JS，于是我就写了一个JS用于判断链接的origin并决定是否修改a标签的target属性。

不知道是否可以通过mdBook的Preprocessor机制来实现，有时间可以再深入了解一下。

请编辑团队评估是否采纳，觉得方案不好拒绝也没关系哈。

emmm，中文杂志，就写中文PR吧（虽然代码还是习惯性写了英文注释）……