### PR TITLE
修复评论样式

### DIFF
--- a/mytheme/css/general.css
+++ b/mytheme/css/general.css
@@ -101,6 +101,9 @@ h6:target::before {
 .content .header:visited:hover {
     text-decoration: none;
 }
+.content .utterances {
+    max-width: var(--content-max-width);
+}
 
 table {
     margin: 0 auto;

--- a/mytheme/index.hbs
+++ b/mytheme/index.hbs
@@ -178,6 +178,13 @@
                         {{{ content }}}
                     </main>
 
+                    <script src="https://utteranc.es/client.js"
+                    repo="RustMagazine/rust_magazine_2021"
+                    issue-term="title"
+                    theme="github-light"
+                    crossorigin="anonymous"
+                    async></script>
+
                     <nav class="nav-wrapper" aria-label="Page navigation">
                         <!-- Mobile navigation buttons -->
                         {{#previous}}
@@ -301,13 +308,5 @@
         </script>
         {{/if}}
         {{/if}}
-
-        <script src="https://utteranc.es/client.js"
-        repo="RustMagazine/rust_magazine_2021"
-        issue-term="title"
-        theme="github-light"
-        crossorigin="anonymous"
-        async></script>
-
     </body>
 </html>


### PR DESCRIPTION
1. 调整评论脚本在模块的位置，修复评论在侧边栏拉开时定位不变的问题
2. 调整评论块样式，与文本宽度对齐