### PR TITLE
The lack of CR between subheading and table

### DIFF
--- a/src/chapter_7/rusts-standard-library-traits.md
+++ b/src/chapter_7/rusts-standard-library-traits.md
@@ -1682,6 +1682,7 @@ fn example_dbg() {
 ## 操作符 Trait（Operator Traits）
 
 Rust 中所有的操作符都和 trait 关联，如果我们想要为我们的类型实现一些操作符，我们就必须实现与之关联的 trait。
+
 | Trait(s) | 分类（Category） | 操作符（Operator(s)） | 描述（Description） |
 |----------|----------|-------------|-------------|
 | `Eq`, `PartialEq` | 比较 | `==` | 相等 |


### PR DESCRIPTION
The lack of CR between the subheading and the table.

[It can be seen.](https://rustmagazine.github.io/rust_magazine_2021/chapter_7/rusts-standard-library-traits.html#%E6%93%8D%E4%BD%9C%E7%AC%A6-traitoperator-traits) as the the following.

![image](https://user-images.githubusercontent.com/48505670/204010636-a71ec656-9b99-46da-8720-2d96be69b4a7.png)
